### PR TITLE
fix: increase enable_camera timeout to 1.5s to accommodate stream-arm…

### DIFF
--- a/omotion/Sensor.py
+++ b/omotion/Sensor.py
@@ -766,12 +766,16 @@ class MOTIONSensor:
         self._check_camera_mask(camera_position)
         if self.uart.demo_mode:
             return True
+        # 1.5 s accommodates stream-armed IF0 contention: when streaming on
+        # IF1 has just been armed, the MCU can take ~1 s to service the
+        # enable request. A tighter timeout causes the SDK to discard the
+        # eventual (stale) response and poison the next packet ID.
         r = self._send(
             packetType=OW_CAMERA,
             command=OW_CAMERA_STREAM,
             reserved=1,
             addr=camera_position,
-            timeout=0.3,
+            timeout=1.5,
         )
         return r.packet_type not in _ERROR_TYPES
 


### PR DESCRIPTION
…ed contention

Observed worst-case response latency was ~1.08 s when streaming on IF1 has just been armed — the MCU's IF0 command handler takes noticeably longer to service the request under that contention. The previous 0.3 s timeout caused ``_send`` to return as "no response", and the eventual stale response then poisoned the next packet ID, breaking subsequent commands.