### PR TITLE
fix(scripts): port test_console_trigger.py to current MotionInterface API

### DIFF
--- a/scripts/test_console_trigger.py
+++ b/scripts/test_console_trigger.py
@@ -1,98 +1,115 @@
-import asyncio
 import time
-from omotion.Interface import MOTIONInterface
+
+from omotion import MotionInterface
 
 # Run this script with:
 # set PYTHONPATH=%cd%;%PYTHONPATH%
 # python scripts\test_console_trigger.py
 
-def main():
 
+def main():
     print("Starting MOTION Console Module Test Script...")
 
-    # Acquire interface + connection state
-    interface, console_connected, left_sensor, right_sensor = MOTIONInterface.acquire_motion_interface()
+    interface = MotionInterface()
+    interface.start()
 
-    if console_connected and left_sensor and right_sensor:
+    # start() only waits ~2s for devices already mid-CONNECTING. Block
+    # explicitly until the console reaches CONNECTED (or give up).
+    interface.wait_for_ready(console=True, sensors=0, timeout=10.0)
+
+    console_connected, left_connected, right_connected = (
+        interface.is_device_connected()
+    )
+
+    if console_connected and left_connected and right_connected:
         print("MOTION System fully connected.")
     else:
-        print(f'MOTION System NOT Fully Connected. CONSOLE: {console_connected}, SENSOR (LEFT,RIGHT): {left_sensor}, {right_sensor}')
-        
+        print(
+            f"MOTION System NOT Fully Connected. "
+            f"CONSOLE: {console_connected}, "
+            f"SENSOR (LEFT,RIGHT): {left_connected}, {right_connected}"
+        )
+
     if not console_connected:
         print("Console Module not connected.")
+        interface.stop()
         exit(1)
-        
-    # Ping Test
-    print("\n[1] Ping Sensor Module...")
-    response = interface.console_module.ping()
-    print("Ping successful." if response else "Ping failed.")
 
-    print("\n[0] Set trigger...")
-    json_trigger_data = {
-        "TriggerFrequencyHz": 40,
-        "TriggerPulseWidthUsec": 500,
-        "LaserPulseDelayUsec": 100,
-        "LaserPulseWidthUsec": 500,
-        "LaserPulseSkipInterval": 0,
-        "EnableSyncOut": True,
-        "EnableTaTrigger": True
-    }
+    try:
+        # Ping Test
+        print("\n[1] Ping Console Module...")
+        response = interface.console.ping()
+        print("Ping successful." if response else "Ping failed.")
 
-    new_setting = interface.console_module.set_trigger_json(data=json_trigger_data)
-    if new_setting:
-        print(f"Trigger Setting: {new_setting}")
-    else:
-        print("Failed to get trigger setting.")
+        print("\n[0] Set trigger...")
+        json_trigger_data = {
+            "TriggerFrequencyHz": 40,
+            "TriggerPulseWidthUsec": 500,
+            "LaserPulseDelayUsec": 100,
+            "LaserPulseWidthUsec": 500,
+            "LaserPulseSkipInterval": 0,
+            "EnableSyncOut": True,
+            "EnableTaTrigger": True,
+        }
 
-    print("\n[1] Get trigger...")
-    trigger_setting = interface.console_module.get_trigger_json()
-    if trigger_setting:
-        print(f"Trigger Setting: {trigger_setting}")
-    else:
-        print("Failed to get trigger setting.")
+        new_setting = interface.console.set_trigger_json(data=json_trigger_data)
+        if new_setting:
+            print(f"Trigger Setting: {new_setting}")
+        else:
+            print("Failed to get trigger setting.")
 
-    print("\n[2] Start trigger...")
-    if not interface.console_module.start_trigger():
-        print("Failed to start trigger.")
-    else:
-        print("Press [ENTER] to stop trigger...")
-        input()
-        interface.console_module.stop_trigger()
-
-    print("\n[3] Set trigger...")
-    json_trigger_data = {
-        "TriggerFrequencyHz": 25,
-        "TriggerPulseWidthUsec": 500,
-        "LaserPulseDelayUsec": 100,
-        "LaserPulseWidthUsec": 500,
-        "LaserPulseSkipInterval": 5,
-        "EnableSyncOut": True,
-        "EnableTaTrigger": True
-    }
-
-    new_setting = interface.console_module.set_trigger_json(data=json_trigger_data)
-    if new_setting:
-        print(f"Trigger Setting: {new_setting}")
-    else:
-        print("Failed to get trigger setting.")
-
-    print("\n[4] Start trigger...")
-    if not interface.console_module.start_trigger():
-        print("Failed to start trigger.")
-    else:    
-        trigger_setting = interface.console_module.get_trigger_json()
+        print("\n[1] Get trigger...")
+        trigger_setting = interface.console.get_trigger_json()
         if trigger_setting:
             print(f"Trigger Setting: {trigger_setting}")
         else:
             print("Failed to get trigger setting.")
 
-        time.sleep(1)
-        fsync_pulsecount = interface.console_module.get_fsync_pulsecount()
-        print(f"FSYNC PulseCount: {fsync_pulsecount}")
+        print("\n[2] Start trigger...")
+        if not interface.console.start_trigger():
+            print("Failed to start trigger.")
+        else:
+            print("Press [ENTER] to stop trigger...")
+            input()
+            interface.console.stop_trigger()
 
-        print("Press [ENTER] to stop trigger...")
-        input()
-        interface.console_module.stop_trigger()
-        
+        print("\n[3] Set trigger...")
+        json_trigger_data = {
+            "TriggerFrequencyHz": 25,
+            "TriggerPulseWidthUsec": 500,
+            "LaserPulseDelayUsec": 100,
+            "LaserPulseWidthUsec": 500,
+            "LaserPulseSkipInterval": 5,
+            "EnableSyncOut": True,
+            "EnableTaTrigger": True,
+        }
+
+        new_setting = interface.console.set_trigger_json(data=json_trigger_data)
+        if new_setting:
+            print(f"Trigger Setting: {new_setting}")
+        else:
+            print("Failed to get trigger setting.")
+
+        print("\n[4] Start trigger...")
+        if not interface.console.start_trigger():
+            print("Failed to start trigger.")
+        else:
+            trigger_setting = interface.console.get_trigger_json()
+            if trigger_setting:
+                print(f"Trigger Setting: {trigger_setting}")
+            else:
+                print("Failed to get trigger setting.")
+
+            time.sleep(1)
+            fsync_pulsecount = interface.console.get_fsync_pulsecount()
+            print(f"FSYNC PulseCount: {fsync_pulsecount}")
+
+            print("Press [ENTER] to stop trigger...")
+            input()
+            interface.console.stop_trigger()
+    finally:
+        interface.stop()
+
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary

Ports `scripts/test_console_trigger.py` to the post-redesign SDK API so the script imports and runs again. Verified against `openmotion-console-fw 1.5.8-rc.2` on real hardware — trigger config round-trips correctly (sent `LaserPulseDelayUsec: 100`, got `100` back; previously got `1900` due to the firmware bug fixed in that release).

## What changed

- `from omotion.Interface import MOTIONInterface` → `from omotion import MotionInterface` (the old facade module was removed)
- `MOTIONInterface.acquire_motion_interface()` → `MotionInterface()` + `start()` + `wait_for_ready(console=True, ...)`
- `interface.console_module.<method>` → `interface.console.<method>` (handle was renamed)
- Added `try/finally` so `interface.stop()` always joins the connection-monitor thread on exit
- Dropped unused `asyncio` import

## Heads-up: this is one of 34

Every other script in `scripts/` (33 files) still imports `from omotion.Interface import MOTIONInterface` and will fail at import. This PR only fixes `test_console_trigger.py` — the one we needed for trigger-bug validation. Worth a follow-up sweep through the rest before any new user tries to run them.

## Test plan

- [x] Script imports cleanly
- [x] `MotionInterface().start()` + `wait_for_ready()` connects to a real console
- [x] `set_trigger_json` / `get_trigger_json` round-trip values correctly against `1.5.8-rc.2` firmware
- [x] `start_trigger` / `stop_trigger` work; `get_fsync_pulsecount` returns a plausible count for the configured rate
- [x] `try/finally` cleanly stops the connection monitor on exit (no teardown errors with stdin-redirected runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)