### PR TITLE
Promote next to main: calibration dark-frame work + script API fix

### DIFF
--- a/omotion/CalibrationWorkflow.py
+++ b/omotion/CalibrationWorkflow.py
@@ -421,8 +421,8 @@ def evaluate_passed(rows: list[CalibrationResultRow]) -> bool:
 
 _CSV_FIELDS = [
     "camera_index", "side", "cam",
-    "mean", "avg_contrast", "bfi", "bvi",
-    "mean_test", "contrast_test", "bfi_test", "bvi_test",
+    "mean", "avg_contrast", "bfi", "bvi", "dark",
+    "mean_test", "contrast_test", "bfi_test", "bvi_test", "dark_test",
     "security_id", "hwid",
 ]
 
@@ -451,10 +451,12 @@ def write_result_csv(path: str, rows: list[CalibrationResultRow]) -> None:
                 "avg_contrast": f"{r.avg_contrast:.6f}",
                 "bfi": f"{r.bfi:.4f}",
                 "bvi": f"{r.bvi:.4f}",
+                "dark": f"{r.dark:.4f}",
                 "mean_test": r.mean_test,
                 "contrast_test": r.contrast_test,
                 "bfi_test": r.bfi_test,
                 "bvi_test": r.bvi_test,
+                "dark_test": r.dark_test,
                 "security_id": r.security_id,
                 "hwid": r.hwid,
             })
@@ -568,6 +570,9 @@ def _row_with_thresholds(
         "min_bvi": _get(thresholds.min_bvi_per_camera, r.cam_id),
         "max_bvi": _get(thresholds.max_bvi_per_camera, r.cam_id),
         "bvi_test": r.bvi_test,
+        "dark": r.dark,
+        "max_dark": _get(thresholds.max_dark_per_camera, r.cam_id),
+        "dark_test": r.dark_test,
     }
 
 
@@ -643,6 +648,10 @@ def write_result_json(
             "max_bvi_per_camera": (
                 list(request.thresholds.max_bvi_per_camera)
                 if request.thresholds.max_bvi_per_camera is not None else None
+            ),
+            "max_dark_per_camera": (
+                list(request.thresholds.max_dark_per_camera)
+                if request.thresholds.max_dark_per_camera is not None else None
             ),
         },
         "calibration": _calibration_to_dict(calibration),

--- a/omotion/CalibrationWorkflow.py
+++ b/omotion/CalibrationWorkflow.py
@@ -753,12 +753,16 @@ def _run_subscan_capture(
     twice on the same data.
 
     Returns ``(left_path, right_path, captured_samples, dark_samples)``.
-    ``captured_samples`` is the in-window averaging set (laser-on, the
-    historical return). ``dark_samples`` is the leading + trailing
-    out-of-window samples (laser-off; per-camera mean is ambient light,
-    used by the FT calibration's #122 ambient-light gate). Raises
-    ``RuntimeError`` on scan failure. Honors ``stop_evt`` by calling
-    ``cancel_scan`` and returning empty paths + empty lists.
+    ``captured_samples`` is the in-window averaging set (laser-on
+    corrected Samples, the historical return). ``dark_samples`` is
+    the laser-off frames the science pipeline emits via
+    ``on_dark_frame_fn``: each sample has ``is_dark=True,
+    is_corrected=False`` and ``mean = u1 - PEDESTAL_HEIGHT`` —
+    pedestal-subtracted ambient DN, same convention the CQ ambient
+    gate uses (see motion_connector.py's _on_dark_frame). Used by the
+    FT calibration's #122 ambient-light gate. Raises ``RuntimeError``
+    on scan failure. Honors ``stop_evt`` by calling ``cancel_scan``
+    and returning empty paths + empty lists.
     """
     scan_req = ScanRequest(
         subject_id=subject_id,
@@ -780,11 +784,17 @@ def _run_subscan_capture(
     def _on_corrected_batch(batch: CorrectedBatch) -> None:
         for s in batch.samples:
             if s.absolute_frame_id < skip_leading_frames:
-                dark.append(s)
-            elif s.absolute_frame_id >= upper_bound:
-                dark.append(s)
-            else:
-                captured.append(s)
+                continue
+            if s.absolute_frame_id >= upper_bound:
+                continue
+            captured.append(s)
+
+    def _on_dark_frame(s: Sample) -> None:
+        # Dark frames don't reach on_corrected_batch — the science
+        # pipeline routes them here with mean already pedestal-
+        # subtracted. Every dark frame in the schedule is a valid
+        # ambient reading; no frame-id windowing applies.
+        dark.append(s)
 
     evt = threading.Event()
     holder: dict[str, ScanResult] = {}
@@ -796,6 +806,7 @@ def _run_subscan_capture(
     started = interface.scan_workflow.start_scan(
         scan_req,
         on_corrected_batch_fn=_on_corrected_batch,
+        on_dark_frame_fn=_on_dark_frame,
         on_complete_fn=_on_complete,
         log_dark_endpoints=True,
     )

--- a/omotion/CalibrationWorkflow.py
+++ b/omotion/CalibrationWorkflow.py
@@ -110,10 +110,12 @@ class CalibrationResultRow:
     avg_contrast: float
     bfi: float
     bvi: float
+    dark: float
     mean_test: str
     contrast_test: str
     bfi_test: str
     bvi_test: str
+    dark_test: str
     security_id: str
     hwid: str
 
@@ -379,6 +381,7 @@ def evaluate_passed(rows: list[CalibrationResultRow]) -> bool:
         and r.contrast_test == "PASS"
         and r.bfi_test == "PASS"
         and r.bvi_test == "PASS"
+        and r.dark_test != "FAIL"
         for r in rows
     )
 

--- a/omotion/CalibrationWorkflow.py
+++ b/omotion/CalibrationWorkflow.py
@@ -301,6 +301,7 @@ def _combined_test(*results: str) -> str:
 def _build_result_rows_from_samples(
     samples: list[Sample],
     *,
+    dark_samples: Optional[list[Sample]] = None,
     left_camera_mask: int,
     right_camera_mask: int,
     thresholds: CalibrationThresholds,
@@ -309,10 +310,19 @@ def _build_result_rows_from_samples(
 ) -> list[CalibrationResultRow]:
     """Core row aggregation: per-camera mean/contrast/BFI/BVI averages
     and threshold pass/fail. Pure function — caller pre-filters.
+
+    ``dark_samples`` is the leading + trailing out-of-window samples
+    from the validation scan (laser off; per-camera mean is the
+    ambient-light reading). When supplied alongside
+    ``thresholds.max_dark_per_camera`` the row builder also evaluates
+    the dark gate (#122). When either is absent each row's
+    ``dark_test`` is ``"NA"`` and ``dark`` is the measured mean (NaN
+    if no dark samples were captured for that camera).
     """
     rows: list[CalibrationResultRow] = []
     masks = (left_camera_mask, right_camera_mask)
     sensors = (sensor_left, sensor_right)
+    dark_samples = dark_samples or []
 
     for module_idx, side in enumerate(("left", "right")):
         mask = masks[module_idx]
@@ -331,6 +341,27 @@ def _build_result_rows_from_samples(
             contrast_val = float(np.mean([s.contrast for s in cam_samples]))
             bfi_val = float(np.mean([s.bfi for s in cam_samples]))
             bvi_val = float(np.mean([s.bvi for s in cam_samples]))
+
+            cam_dark_samples = [
+                s for s in dark_samples
+                if s.side == side and s.cam_id == cam_id
+            ]
+            if cam_dark_samples:
+                dark_val = float(np.mean([s.mean for s in cam_dark_samples]))
+            else:
+                dark_val = float("nan")
+
+            if thresholds.max_dark_per_camera is None:
+                dark_test = "NA"
+            elif cam_id >= len(thresholds.max_dark_per_camera):
+                dark_test = "NA"
+            elif not cam_dark_samples:
+                # Active camera but zero dark frames captured — surface
+                # as FAIL rather than silently passing.
+                dark_test = "FAIL"
+            else:
+                cap = thresholds.max_dark_per_camera[cam_id]
+                dark_test = "PASS" if dark_val <= float(cap) else "FAIL"
 
             security_id = ""
             hwid = ""
@@ -362,12 +393,12 @@ def _build_result_rows_from_samples(
                 avg_contrast=contrast_val,
                 bfi=bfi_val,
                 bvi=bvi_val,
-                dark=0.0,          # placeholder, real value lands in #122 task 4
+                dark=dark_val,
                 mean_test=_threshold_test(mean_val, thresholds.min_mean_per_camera, cam_id),
                 contrast_test=_threshold_test(contrast_val, thresholds.min_contrast_per_camera, cam_id),
                 bfi_test=bfi_test,
                 bvi_test=bvi_test,
-                dark_test="NA",    # placeholder, real value lands in #122 task 4
+                dark_test=dark_test,
                 security_id=security_id,
                 hwid=hwid,
             ))
@@ -1073,6 +1104,7 @@ class CalibrationWorkflow:
                 logger.info("Calibration phase 5: aggregating per-camera rows + thresholds.")
                 rows = _build_result_rows_from_samples(
                     val_samples,
+                    dark_samples=val_dark_samples,
                     left_camera_mask=request.left_camera_mask,
                     right_camera_mask=request.right_camera_mask,
                     thresholds=request.thresholds,

--- a/omotion/CalibrationWorkflow.py
+++ b/omotion/CalibrationWorkflow.py
@@ -668,7 +668,7 @@ def _format_result_rows_table(
     thresholds: CalibrationThresholds,
 ) -> str:
     """Multi-line per-camera table for the log: actual measurement,
-    threshold(s), and PASS/FAIL for mean / contrast / BFI / BVI."""
+    threshold(s), and PASS/FAIL for mean / contrast / BFI / BVI / dark."""
     def _t(arr: Optional[list[float]], i: int, fmt: str = "{:>7.3f}") -> str:
         if arr is None or i >= len(arr):
             return "   —   "
@@ -677,13 +677,21 @@ def _format_result_rows_table(
             return "   —   "
         return fmt.format(float(v))
 
-    pf = lambda s: "P" if s == "PASS" else "F"
+    # Map PASS/FAIL/NA to a single character so the per-camera row stays
+    # narrow. NA renders as a dash so masked-out cameras (or runs where
+    # the threshold wasn't configured) don't look like failures.
+    def pf(s: str) -> str:
+        if s == "PASS":
+            return "P"
+        if s == "NA":
+            return "-"
+        return "F"
 
     header = (
-        "| cam | side  |   mean   |   min    | M |   contrast |    min   | C |    bfi   |    min   |    max   | B |    bvi   |    min   |    max   | V |"
+        "| cam | side  |   mean   |   min    | M |   contrast |    min   | C |    bfi   |    min   |    max   | B |    bvi   |    min   |    max   | V |   dark   |    max   | D |"
     )
     sep = (
-        "|-----|-------|----------|----------|---|------------|----------|---|----------|----------|----------|---|----------|----------|----------|---|"
+        "|-----|-------|----------|----------|---|------------|----------|---|----------|----------|----------|---|----------|----------|----------|---|----------|----------|---|"
     )
     lines = [header, sep]
     for r in rows:
@@ -692,7 +700,8 @@ def _format_result_rows_table(
             "| {cam:>3d} | {side:<5} | {mean:>8.3f} | {mean_min} | {mean_pf} "
             "| {contrast:>10.5f} | {contrast_min} | {contrast_pf} "
             "| {bfi:>+8.3f} | {bfi_min} | {bfi_max} | {bfi_pf} "
-            "| {bvi:>+8.3f} | {bvi_min} | {bvi_max} | {bvi_pf} |"
+            "| {bvi:>+8.3f} | {bvi_min} | {bvi_max} | {bvi_pf} "
+            "| {dark:>8.3f} | {dark_max} | {dark_pf} |"
             .format(
                 cam=cam_id + 1, side=r.side,
                 mean=r.mean,
@@ -709,6 +718,9 @@ def _format_result_rows_table(
                 bvi_min=_t(thresholds.min_bvi_per_camera, cam_id, "{:>+8.3f}"),
                 bvi_max=_t(thresholds.max_bvi_per_camera, cam_id, "{:>+8.3f}"),
                 bvi_pf=pf(r.bvi_test),
+                dark=r.dark,
+                dark_max=_t(thresholds.max_dark_per_camera, cam_id, "{:>8.3f}"),
+                dark_pf=pf(r.dark_test),
             )
         )
     return "\n".join(lines)

--- a/omotion/CalibrationWorkflow.py
+++ b/omotion/CalibrationWorkflow.py
@@ -63,6 +63,7 @@ class CalibrationThresholds:
     min_bvi_per_camera: list[float]
     max_bfi_per_camera: Optional[list[float]] = None
     max_bvi_per_camera: Optional[list[float]] = None
+    max_dark_per_camera: Optional[list[float]] = None
 
 
 @dataclass

--- a/omotion/CalibrationWorkflow.py
+++ b/omotion/CalibrationWorkflow.py
@@ -362,10 +362,12 @@ def _build_result_rows_from_samples(
                 avg_contrast=contrast_val,
                 bfi=bfi_val,
                 bvi=bvi_val,
+                dark=0.0,          # placeholder, real value lands in #122 task 4
                 mean_test=_threshold_test(mean_val, thresholds.min_mean_per_camera, cam_id),
                 contrast_test=_threshold_test(contrast_val, thresholds.min_contrast_per_camera, cam_id),
                 bfi_test=bfi_test,
                 bvi_test=bvi_test,
+                dark_test="NA",    # placeholder, real value lands in #122 task 4
                 security_id=security_id,
                 hwid=hwid,
             ))
@@ -688,7 +690,7 @@ def _run_subscan_capture(
     skip_leading_frames: int,
     frame_window_count: int,
     stop_evt: threading.Event,
-) -> tuple[str, str, list[Sample]]:
+) -> tuple[str, str, list[Sample], list[Sample]]:
     """Submit a ScanRequest and capture corrected samples in-memory as
     the science pipeline emits them.
 
@@ -698,9 +700,13 @@ def _run_subscan_capture(
     ``on_corrected_batch_fn``. This avoids running the science pipeline
     twice on the same data.
 
-    Returns ``(left_path, right_path, captured_samples)``. Raises
+    Returns ``(left_path, right_path, captured_samples, dark_samples)``.
+    ``captured_samples`` is the in-window averaging set (laser-on, the
+    historical return). ``dark_samples`` is the leading + trailing
+    out-of-window samples (laser-off; per-camera mean is ambient light,
+    used by the FT calibration's #122 ambient-light gate). Raises
     ``RuntimeError`` on scan failure. Honors ``stop_evt`` by calling
-    ``cancel_scan`` and returning empty paths + empty list.
+    ``cancel_scan`` and returning empty paths + empty lists.
     """
     scan_req = ScanRequest(
         subject_id=subject_id,
@@ -717,14 +723,16 @@ def _run_subscan_capture(
 
     upper_bound = skip_leading_frames + int(frame_window_count)
     captured: list[Sample] = []
+    dark: list[Sample] = []
 
     def _on_corrected_batch(batch: CorrectedBatch) -> None:
         for s in batch.samples:
             if s.absolute_frame_id < skip_leading_frames:
-                continue
-            if s.absolute_frame_id >= upper_bound:
-                continue
-            captured.append(s)
+                dark.append(s)
+            elif s.absolute_frame_id >= upper_bound:
+                dark.append(s)
+            else:
+                captured.append(s)
 
     evt = threading.Event()
     holder: dict[str, ScanResult] = {}
@@ -749,14 +757,14 @@ def _run_subscan_capture(
             except Exception:
                 pass
             evt.wait(timeout=5.0)
-            return "", "", []
+            return "", "", [], []
     res = holder.get("r")
     if res is None or not res.ok:
         raise RuntimeError(
             f"sub-scan failed: {(res.error if res else 'no result')}"
         )
     if res.canceled:
-        return "", "", []
+        return "", "", [], []
     # Loud failure: if the science pipeline detected dark-frame
     # schedule/measurement disagreement, abort the calibration. The
     # interpolated dark baseline would be polluted and the resulting
@@ -770,7 +778,8 @@ def _run_subscan_capture(
             f"warnings): {details}"
         )
     captured.sort(key=lambda s: (s.side, s.cam_id, s.absolute_frame_id))
-    return res.left_path or "", res.right_path or "", captured
+    dark.sort(key=lambda s: (s.side, s.cam_id, s.absolute_frame_id))
+    return res.left_path or "", res.right_path or "", captured, dark
 
 
 class CalibrationWorkflow:
@@ -965,7 +974,12 @@ class CalibrationWorkflow:
                     request.duration_sec, request.scan_delay_sec,
                 )
                 _reset_firmware_trigger("phase 1 (pre-scan)")
-                cal_left, cal_right, cal_samples = _run_subscan_capture(
+                # _cal_dark_samples deliberately discarded — the ambient
+                # check (#122) gates on validation-scan dark frames so it
+                # measures the same scan as the row-level mean/contrast/
+                # BFI/BVI tests. If we ever want to also gate on the
+                # calibration scan's dark frames, capture this here.
+                cal_left, cal_right, cal_samples, _cal_dark_samples = _run_subscan_capture(
                     self._interface, request,
                     subject_id=f"calib1_{request.operator_id}",
                     duration_sec=request.duration_sec + request.scan_delay_sec,
@@ -1035,7 +1049,7 @@ class CalibrationWorkflow:
                     request.duration_sec, request.scan_delay_sec,
                 )
                 _reset_firmware_trigger("phase 4 (pre-scan)")
-                val_left, val_right, val_samples = _run_subscan_capture(
+                val_left, val_right, val_samples, val_dark_samples = _run_subscan_capture(
                     self._interface, request,
                     subject_id=f"calib2_{request.operator_id}",
                     duration_sec=request.duration_sec + request.scan_delay_sec,

--- a/scripts/test_console_trigger.py
+++ b/scripts/test_console_trigger.py
@@ -1,98 +1,115 @@
-import asyncio
 import time
-from omotion.Interface import MOTIONInterface
+
+from omotion import MotionInterface
 
 # Run this script with:
 # set PYTHONPATH=%cd%;%PYTHONPATH%
 # python scripts\test_console_trigger.py
 
-def main():
 
+def main():
     print("Starting MOTION Console Module Test Script...")
 
-    # Acquire interface + connection state
-    interface, console_connected, left_sensor, right_sensor = MOTIONInterface.acquire_motion_interface()
+    interface = MotionInterface()
+    interface.start()
 
-    if console_connected and left_sensor and right_sensor:
+    # start() only waits ~2s for devices already mid-CONNECTING. Block
+    # explicitly until the console reaches CONNECTED (or give up).
+    interface.wait_for_ready(console=True, sensors=0, timeout=10.0)
+
+    console_connected, left_connected, right_connected = (
+        interface.is_device_connected()
+    )
+
+    if console_connected and left_connected and right_connected:
         print("MOTION System fully connected.")
     else:
-        print(f'MOTION System NOT Fully Connected. CONSOLE: {console_connected}, SENSOR (LEFT,RIGHT): {left_sensor}, {right_sensor}')
-        
+        print(
+            f"MOTION System NOT Fully Connected. "
+            f"CONSOLE: {console_connected}, "
+            f"SENSOR (LEFT,RIGHT): {left_connected}, {right_connected}"
+        )
+
     if not console_connected:
         print("Console Module not connected.")
+        interface.stop()
         exit(1)
-        
-    # Ping Test
-    print("\n[1] Ping Sensor Module...")
-    response = interface.console_module.ping()
-    print("Ping successful." if response else "Ping failed.")
 
-    print("\n[0] Set trigger...")
-    json_trigger_data = {
-        "TriggerFrequencyHz": 40,
-        "TriggerPulseWidthUsec": 500,
-        "LaserPulseDelayUsec": 100,
-        "LaserPulseWidthUsec": 500,
-        "LaserPulseSkipInterval": 0,
-        "EnableSyncOut": True,
-        "EnableTaTrigger": True
-    }
+    try:
+        # Ping Test
+        print("\n[1] Ping Console Module...")
+        response = interface.console.ping()
+        print("Ping successful." if response else "Ping failed.")
 
-    new_setting = interface.console_module.set_trigger_json(data=json_trigger_data)
-    if new_setting:
-        print(f"Trigger Setting: {new_setting}")
-    else:
-        print("Failed to get trigger setting.")
+        print("\n[0] Set trigger...")
+        json_trigger_data = {
+            "TriggerFrequencyHz": 40,
+            "TriggerPulseWidthUsec": 500,
+            "LaserPulseDelayUsec": 100,
+            "LaserPulseWidthUsec": 500,
+            "LaserPulseSkipInterval": 0,
+            "EnableSyncOut": True,
+            "EnableTaTrigger": True,
+        }
 
-    print("\n[1] Get trigger...")
-    trigger_setting = interface.console_module.get_trigger_json()
-    if trigger_setting:
-        print(f"Trigger Setting: {trigger_setting}")
-    else:
-        print("Failed to get trigger setting.")
+        new_setting = interface.console.set_trigger_json(data=json_trigger_data)
+        if new_setting:
+            print(f"Trigger Setting: {new_setting}")
+        else:
+            print("Failed to get trigger setting.")
 
-    print("\n[2] Start trigger...")
-    if not interface.console_module.start_trigger():
-        print("Failed to start trigger.")
-    else:
-        print("Press [ENTER] to stop trigger...")
-        input()
-        interface.console_module.stop_trigger()
-
-    print("\n[3] Set trigger...")
-    json_trigger_data = {
-        "TriggerFrequencyHz": 25,
-        "TriggerPulseWidthUsec": 500,
-        "LaserPulseDelayUsec": 100,
-        "LaserPulseWidthUsec": 500,
-        "LaserPulseSkipInterval": 5,
-        "EnableSyncOut": True,
-        "EnableTaTrigger": True
-    }
-
-    new_setting = interface.console_module.set_trigger_json(data=json_trigger_data)
-    if new_setting:
-        print(f"Trigger Setting: {new_setting}")
-    else:
-        print("Failed to get trigger setting.")
-
-    print("\n[4] Start trigger...")
-    if not interface.console_module.start_trigger():
-        print("Failed to start trigger.")
-    else:    
-        trigger_setting = interface.console_module.get_trigger_json()
+        print("\n[1] Get trigger...")
+        trigger_setting = interface.console.get_trigger_json()
         if trigger_setting:
             print(f"Trigger Setting: {trigger_setting}")
         else:
             print("Failed to get trigger setting.")
 
-        time.sleep(1)
-        fsync_pulsecount = interface.console_module.get_fsync_pulsecount()
-        print(f"FSYNC PulseCount: {fsync_pulsecount}")
+        print("\n[2] Start trigger...")
+        if not interface.console.start_trigger():
+            print("Failed to start trigger.")
+        else:
+            print("Press [ENTER] to stop trigger...")
+            input()
+            interface.console.stop_trigger()
 
-        print("Press [ENTER] to stop trigger...")
-        input()
-        interface.console_module.stop_trigger()
-        
+        print("\n[3] Set trigger...")
+        json_trigger_data = {
+            "TriggerFrequencyHz": 25,
+            "TriggerPulseWidthUsec": 500,
+            "LaserPulseDelayUsec": 100,
+            "LaserPulseWidthUsec": 500,
+            "LaserPulseSkipInterval": 5,
+            "EnableSyncOut": True,
+            "EnableTaTrigger": True,
+        }
+
+        new_setting = interface.console.set_trigger_json(data=json_trigger_data)
+        if new_setting:
+            print(f"Trigger Setting: {new_setting}")
+        else:
+            print("Failed to get trigger setting.")
+
+        print("\n[4] Start trigger...")
+        if not interface.console.start_trigger():
+            print("Failed to start trigger.")
+        else:
+            trigger_setting = interface.console.get_trigger_json()
+            if trigger_setting:
+                print(f"Trigger Setting: {trigger_setting}")
+            else:
+                print("Failed to get trigger setting.")
+
+            time.sleep(1)
+            fsync_pulsecount = interface.console.get_fsync_pulsecount()
+            print(f"FSYNC PulseCount: {fsync_pulsecount}")
+
+            print("Press [ENTER] to stop trigger...")
+            input()
+            interface.console.stop_trigger()
+    finally:
+        interface.stop()
+
+
 if __name__ == "__main__":
     main()

--- a/tests/test_calibration_workflow_compute.py
+++ b/tests/test_calibration_workflow_compute.py
@@ -97,8 +97,8 @@ def test_write_result_csv_round_trip(tmp_path):
     header = content[0].split(",")
     assert header == [
         "camera_index", "side", "cam",
-        "mean", "avg_contrast", "bfi", "bvi",
-        "mean_test", "contrast_test", "bfi_test", "bvi_test",
+        "mean", "avg_contrast", "bfi", "bvi", "dark",
+        "mean_test", "contrast_test", "bfi_test", "bvi_test", "dark_test",
         "security_id", "hwid",
     ]
     fields = content[1].split(",")
@@ -379,3 +379,61 @@ def test_dark_test_fail_when_no_dark_samples_for_active_camera():
     )
     assert math.isnan(rows[0].dark)
     assert rows[0].dark_test == "FAIL"
+
+
+import csv as _csv
+
+
+def test_write_result_csv_includes_dark_columns(tmp_path):
+    rows = [_dark_row(dark=1.5, dark_test="PASS")]
+    path = str(tmp_path / "with-dark.csv")
+    write_result_csv(path, rows)
+    with open(path, newline="", encoding="utf-8") as f:
+        reader = _csv.DictReader(f)
+        assert "dark" in reader.fieldnames
+        assert "dark_test" in reader.fieldnames
+        row0 = next(reader)
+        assert float(row0["dark"]) == 1.5
+        assert row0["dark_test"] == "PASS"
+
+
+def test_write_result_json_includes_dark(tmp_path):
+    rows = [
+        CalibrationResultRow(
+            camera_index=0, side="left", cam_id=0,
+            mean=200.0, avg_contrast=0.4, bfi=5.0, bvi=5.5, dark=1.5,
+            mean_test="PASS", contrast_test="PASS",
+            bfi_test="PASS", bvi_test="PASS", dark_test="PASS",
+            security_id="cam-uid-aaa", hwid="left-hwid-aaa",
+        ),
+    ]
+    thr = CalibrationThresholds(
+        min_mean_per_camera=[50.0] * 8,
+        min_contrast_per_camera=[0.25] * 8,
+        min_bfi_per_camera=[-0.25] * 8,
+        min_bvi_per_camera=[4.75] * 8,
+        max_bfi_per_camera=[0.25] * 8,
+        max_bvi_per_camera=[5.25] * 8,
+        max_dark_per_camera=[3.0] * 8,
+    )
+    req = CalibrationRequest(
+        operator_id="op", output_dir=str(tmp_path),
+        left_camera_mask=0xFF, right_camera_mask=0xFF,
+        thresholds=thr, duration_sec=5,
+    )
+    out = tmp_path / "with-dark.json"
+    write_result_json(
+        str(out),
+        started_timestamp="20260512_140000",
+        passed=True, canceled=False, error="",
+        request=req, rows=rows, calibration=None,
+        scan_paths={"calibration_left": "", "calibration_right": "",
+                    "validation_left": "", "validation_right": ""},
+        interface=_FakeInterface(),
+    )
+    data = json.loads(out.read_text(encoding="utf-8"))
+    assert data["thresholds"]["max_dark_per_camera"] == [3.0] * 8
+    cam = data["cameras"][0]
+    assert cam["dark"] == 1.5
+    assert cam["max_dark"] == 3.0
+    assert cam["dark_test"] == "PASS"

--- a/tests/test_calibration_workflow_compute.py
+++ b/tests/test_calibration_workflow_compute.py
@@ -83,9 +83,9 @@ def test_write_result_csv_round_trip(tmp_path):
     rows = [
         CalibrationResultRow(
             camera_index=0, side="left", cam_id=0,
-            mean=200.0, avg_contrast=0.4, bfi=5.0, bvi=5.5,
+            mean=200.0, avg_contrast=0.4, bfi=5.0, bvi=5.5, dark=0.0,
             mean_test="PASS", contrast_test="PASS",
-            bfi_test="PASS", bvi_test="FAIL",
+            bfi_test="PASS", bvi_test="FAIL", dark_test="NA",
             security_id="sec-0", hwid="hw-x",
         ),
     ]
@@ -141,9 +141,9 @@ def test_write_result_json_includes_full_provenance(tmp_path):
     rows = [
         CalibrationResultRow(
             camera_index=0, side="left", cam_id=0,
-            mean=200.0, avg_contrast=0.4, bfi=5.0, bvi=5.5,
+            mean=200.0, avg_contrast=0.4, bfi=5.0, bvi=5.5, dark=0.0,
             mean_test="PASS", contrast_test="PASS",
-            bfi_test="PASS", bvi_test="FAIL",
+            bfi_test="PASS", bvi_test="FAIL", dark_test="NA",
             security_id="cam-uid-aaa", hwid="left-hwid-aaa",
         ),
     ]
@@ -243,3 +243,32 @@ def test_thresholds_max_dark_accepts_list():
         max_dark_per_camera=[3.0] * 8,
     )
     assert t.max_dark_per_camera == [3.0] * 8
+
+
+def _dark_row(*, dark_test="NA", dark=0.0, mean_test="PASS",
+              contrast_test="PASS", bfi_test="PASS", bvi_test="PASS"):
+    return CalibrationResultRow(
+        camera_index=0, side="left", cam_id=0,
+        mean=100.0, avg_contrast=0.3, bfi=4.0, bvi=4.0, dark=dark,
+        mean_test=mean_test, contrast_test=contrast_test,
+        bfi_test=bfi_test, bvi_test=bvi_test, dark_test=dark_test,
+        security_id="", hwid="",
+    )
+
+
+def test_result_row_has_dark_fields():
+    r = _dark_row(dark=1.5, dark_test="PASS")
+    assert r.dark == 1.5
+    assert r.dark_test == "PASS"
+
+
+def test_evaluate_passed_all_pass_including_dark():
+    assert evaluate_passed([_dark_row(dark_test="PASS")]) is True
+
+
+def test_evaluate_passed_dark_fail_overrides_all_other_pass():
+    assert evaluate_passed([_dark_row(dark_test="FAIL")]) is False
+
+
+def test_evaluate_passed_dark_na_does_not_gate():
+    assert evaluate_passed([_dark_row(dark_test="NA")]) is True

--- a/tests/test_calibration_workflow_compute.py
+++ b/tests/test_calibration_workflow_compute.py
@@ -272,3 +272,110 @@ def test_evaluate_passed_dark_fail_overrides_all_other_pass():
 
 def test_evaluate_passed_dark_na_does_not_gate():
     assert evaluate_passed([_dark_row(dark_test="NA")]) is True
+
+
+# ----- _build_result_rows_from_samples dark-test path (#122) -----
+
+import math
+
+from omotion.CalibrationWorkflow import _build_result_rows_from_samples
+from omotion.MotionProcessing import Sample
+
+
+def _light(side, cam_id, *, mean=200.0, contrast=0.3, bfi=4.0, bvi=6.0,
+           frame_id=10):
+    return Sample(
+        side=side, cam_id=cam_id,
+        frame_id=frame_id, absolute_frame_id=frame_id,
+        timestamp_s=0.0, row_sum=0, temperature_c=0.0,
+        mean=mean, std_dev=mean * contrast, contrast=contrast,
+        bfi=bfi, bvi=bvi,
+        is_corrected=True, is_dark=False,
+    )
+
+
+def _dark(side, cam_id, *, mean=1.0, frame_id=0):
+    # Dark samples come from the firmware's leading/trailing windows;
+    # only the per-camera mean matters for the ambient gate.
+    return Sample(
+        side=side, cam_id=cam_id,
+        frame_id=frame_id, absolute_frame_id=frame_id,
+        timestamp_s=0.0, row_sum=0, temperature_c=0.0,
+        mean=mean, std_dev=0.0, contrast=0.0,
+        bfi=0.0, bvi=0.0,
+        is_corrected=True, is_dark=True,
+    )
+
+
+def _full_thresholds(*, max_dark_per_camera=None):
+    return CalibrationThresholds(
+        min_mean_per_camera=[100.0] * 8,
+        min_contrast_per_camera=[0.2] * 8,
+        min_bfi_per_camera=[-1.0] * 8,
+        min_bvi_per_camera=[5.0] * 8,
+        max_dark_per_camera=max_dark_per_camera,
+    )
+
+
+def test_dark_test_pass_when_below_threshold():
+    light = [_light(side, 0) for side in ("left", "right")]
+    dark = [_dark(side, 0, mean=1.0) for side in ("left", "right")]
+    rows = _build_result_rows_from_samples(
+        light, dark_samples=dark,
+        left_camera_mask=0x01, right_camera_mask=0x01,
+        thresholds=_full_thresholds(max_dark_per_camera=[3.0] * 8),
+        sensor_left=None, sensor_right=None,
+    )
+    assert len(rows) == 2
+    assert all(r.dark_test == "PASS" for r in rows)
+    assert all(r.dark == 1.0 for r in rows)
+
+
+def test_dark_test_fail_when_above_threshold():
+    light = [_light("left", 0)]
+    dark = [_dark("left", 0, mean=5.0)]
+    rows = _build_result_rows_from_samples(
+        light, dark_samples=dark,
+        left_camera_mask=0x01, right_camera_mask=0x00,
+        thresholds=_full_thresholds(max_dark_per_camera=[3.0] * 8),
+        sensor_left=None, sensor_right=None,
+    )
+    assert rows[0].dark == 5.0
+    assert rows[0].dark_test == "FAIL"
+
+
+def test_dark_test_na_when_threshold_missing():
+    light = [_light("left", 0)]
+    dark = [_dark("left", 0, mean=5.0)]
+    rows = _build_result_rows_from_samples(
+        light, dark_samples=dark,
+        left_camera_mask=0x01, right_camera_mask=0x00,
+        thresholds=_full_thresholds(max_dark_per_camera=None),
+        sensor_left=None, sensor_right=None,
+    )
+    assert rows[0].dark_test == "NA"
+
+
+def test_dark_value_present_on_passing_run():
+    light = [_light("left", 0)]
+    dark = [_dark("left", 0, mean=2.0)]
+    rows = _build_result_rows_from_samples(
+        light, dark_samples=dark,
+        left_camera_mask=0x01, right_camera_mask=0x00,
+        thresholds=_full_thresholds(max_dark_per_camera=[3.0] * 8),
+        sensor_left=None, sensor_right=None,
+    )
+    assert rows[0].dark == 2.0
+    assert rows[0].dark_test == "PASS"
+
+
+def test_dark_test_fail_when_no_dark_samples_for_active_camera():
+    light = [_light("left", 0)]
+    rows = _build_result_rows_from_samples(
+        light, dark_samples=[],
+        left_camera_mask=0x01, right_camera_mask=0x00,
+        thresholds=_full_thresholds(max_dark_per_camera=[3.0] * 8),
+        sensor_left=None, sensor_right=None,
+    )
+    assert math.isnan(rows[0].dark)
+    assert rows[0].dark_test == "FAIL"

--- a/tests/test_calibration_workflow_compute.py
+++ b/tests/test_calibration_workflow_compute.py
@@ -224,3 +224,22 @@ def test_write_result_json_handles_missing_sensor(tmp_path):
     assert data["canceled"] is True
     assert data["error"] == "user canceled"
     assert data["cameras"] == []
+
+
+# ----- ft_max_dark_per_camera (#122) -----
+
+
+def test_thresholds_max_dark_defaults_to_none():
+    t = _thresholds()
+    assert t.max_dark_per_camera is None
+
+
+def test_thresholds_max_dark_accepts_list():
+    t = CalibrationThresholds(
+        min_mean_per_camera=[100.0] * 8,
+        min_contrast_per_camera=[0.2] * 8,
+        min_bfi_per_camera=[3.0] * 8,
+        min_bvi_per_camera=[3.0] * 8,
+        max_dark_per_camera=[3.0] * 8,
+    )
+    assert t.max_dark_per_camera == [3.0] * 8


### PR DESCRIPTION
## Summary

Promotes `next` to `main`. Two themes:

1. **Calibration dark-frame handling (#122)** — adds `max_dark_per_camera` to `CalibrationThresholds`, computes per-camera dark mean and gates FT calibration on it, emits `dark` and `dark_test` columns in the CSV log and JSON manifest, and returns dark samples separately from `_run_subscan_capture`. Final fix in the series sources ambient samples from `on_dark_frame_fn` rather than edge-trimming.

2. **Script API fix** — `scripts/test_console_trigger.py` ported to the post-redesign `MotionInterface` API (PR #47). Validated end-to-end against `openmotion-console-fw 1.5.8-rc.2` on real hardware: trigger config round-trips cleanly, including `LaserPulseDelayUsec` which was the regression that motivated the firmware fix.

## Commits

```
a857b7b Merge pull request #47 from OpenwaterHealth/script-fixes
d745b9a fix(scripts): port test_console_trigger.py to current MotionInterface API
3688756 merge: feature/122-ft-max-dark-per-camera
a8a1375 fix(sdk): #122 source ambient samples from on_dark_frame_fn, not edge-trimming
9bf8aaf feat(sdk): include dark/max/D columns in the calibration log table
ff03cc0 feat(sdk): emit dark + dark_test in calibration CSV and JSON manifest
c2dcd26 feat(sdk): compute per-camera dark mean and gate FT calibration on it
11a40d2 feat(sdk): _run_subscan_capture returns dark samples separately
197d508 feat(sdk): add dark + dark_test to CalibrationResultRow; gate evaluate_passed
4e83d32 feat(sdk): add max_dark_per_camera to CalibrationThresholds
```

## Heads-up

The other 33 scripts in `scripts/` still import the removed `MOTIONInterface.acquire_motion_interface()` facade and will fail at import. Only `test_console_trigger.py` was fixed in PR #47. Worth a follow-up sweep before any new SDK consumer tries to run them.

## Test plan

- [x] `test_console_trigger.py` runs against console-fw `1.5.8-rc.2` (hardware-verified)
- [ ] Calibration workflow tests in `tests/test_calibration_workflow_compute.py` pass
- [ ] Calibration end-to-end on real hardware (reviewer to validate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)