### PR TITLE
fix(sdk): drop std check from dark-integrity detector

### DIFF
--- a/omotion/MotionProcessing.py
+++ b/omotion/MotionProcessing.py
@@ -1130,7 +1130,6 @@ class SciencePipeline:
         noise_floor: int = 10,
         log_dark_endpoints: bool = False,
         dark_integrity_max_u1_above_pedestal: float = 30.0,
-        dark_integrity_max_std: float = 20.0,
     ):
         self._bfi_c_min = bfi_c_min
         self._bfi_c_max = bfi_c_max
@@ -1144,11 +1143,10 @@ class SciencePipeline:
         self._rolling_avg_window = int(rolling_avg_window)
         self._log_dark_endpoints = bool(log_dark_endpoints)
         # Dark-integrity monitor: every frame stored in _dark_history is
-        # cross-checked against these bounds. The defaults catch the
+        # cross-checked against this bound. The default catches the
         # firmware off-by-one symptom we've actually observed in the
-        # field (frame 10 looks like a light frame: u1≈200, std≈40).
+        # field (frame 10 looks like a light frame: u1≈200).
         self._dark_integrity_max_u1_above_pedestal = float(dark_integrity_max_u1_above_pedestal)
-        self._dark_integrity_max_std = float(dark_integrity_max_std)
         # Populated by _check_dark_integrity. Diagnostic only — surfaced
         # on ScanResult but no longer fatal to calibration.
         self._dark_integrity_warnings: list[str] = []
@@ -1205,10 +1203,10 @@ class SciencePipeline:
         """Return the list of dark-integrity warnings collected so far.
 
         A non-empty list means the science pipeline classified one or
-        more frames as dark-by-schedule, but the actual measurement
-        (u1, std) failed the dark heuristic — i.e. the firmware emitted
-        a light frame in a slot the science pipeline expected to be
-        dark, OR the dark slot picked up significant ambient light.
+        more frames as dark-by-schedule, but the actual measurement u1
+        was above pedestal+max — i.e. the firmware emitted a light
+        frame in a slot the science pipeline expected to be dark, OR
+        the dark slot picked up significant ambient light.
         Diagnostic only — the per-camera FT dark mean-max check is the
         authoritative gate for ambient-light failure.
         """
@@ -1220,22 +1218,18 @@ class SciencePipeline:
         cam_id: int,
         absolute_frame: int,
         u1: float,
-        variance: float,
     ) -> None:
         """Verify a frame the schedule classified as dark actually
         looks dark. Logs at ERROR level and stores a warning string on
         the pipeline if not."""
-        std = float(np.sqrt(max(0.0, variance)))
         max_u1 = PEDESTAL_HEIGHT + self._dark_integrity_max_u1_above_pedestal
-        max_std = self._dark_integrity_max_std
-        if u1 <= max_u1 and std <= max_std:
+        if u1 <= max_u1:
             return
         msg = (
             f"DARK INTEGRITY FAILURE: {side} cam {cam_id} frame "
             f"{absolute_frame} was classified as dark by schedule, but "
-            f"its measurement looks like a light frame "
-            f"(u1={u1:.2f} > pedestal+{self._dark_integrity_max_u1_above_pedestal:.0f}={max_u1:.0f}? "
-            f"std={std:.2f} > {max_std:.0f}?). "
+            f"u1={u1:.2f} exceeds pedestal+"
+            f"{self._dark_integrity_max_u1_above_pedestal:.0f}={max_u1:.0f}. "
             "Probable cause: firmware off-by-one in NUM_DARK_FRAMES_AT_START "
             "or unwrapper alignment quirk. Dark-frame interpolation will be "
             "polluted; corrected stream values are unreliable."
@@ -1380,7 +1374,7 @@ class SciencePipeline:
                 # dark? If not, the schedule and the firmware disagree
                 # and we want to know about it.
                 self._check_dark_integrity(
-                    side, cam_id, absolute_frame, u1, variance,
+                    side, cam_id, absolute_frame, u1,
                 )
 
                 # With 2+ dark frames we can correct the preceding interval.
@@ -1553,7 +1547,7 @@ class SciencePipeline:
             # laser-off frame.
             self._check_dark_integrity(
                 key[0], key[1], terminal.absolute_frame_id,
-                terminal.u1, terminal_var,
+                terminal.u1,
             )
             self._emit_corrected_for_camera(key)
 
@@ -1784,7 +1778,6 @@ def create_science_pipeline(
     noise_floor: int = 10,
     log_dark_endpoints: bool = False,
     dark_integrity_max_u1_above_pedestal: float = 30.0,
-    dark_integrity_max_std: float = 20.0,
 ) -> SciencePipeline:
     """
     Factory for a ready-to-run unified science pipeline.
@@ -1846,7 +1839,6 @@ def create_science_pipeline(
         noise_floor=noise_floor,
         log_dark_endpoints=log_dark_endpoints,
         dark_integrity_max_u1_above_pedestal=dark_integrity_max_u1_above_pedestal,
-        dark_integrity_max_std=dark_integrity_max_std,
     )
     pipeline.start()
     return pipeline

--- a/tests/test_dark_integrity.py
+++ b/tests/test_dark_integrity.py
@@ -58,17 +58,17 @@ def _drive_through_first_dark(pipeline: SciencePipeline, dark_mean: float, dark_
 
 
 def test_dark_integrity_passes_for_real_dark():
-    """A frame whose u1 ≈ pedestal and std ≈ 5 should pass the integrity
-    check. No warnings produced."""
+    """A frame whose u1 ≈ pedestal should pass the integrity check
+    regardless of std. No warnings produced."""
     p = _make_pipeline()
     _drive_through_first_dark(p, dark_mean=PEDESTAL_HEIGHT, dark_std=5.0)
     assert p.dark_integrity_warnings == []
 
 
 def test_dark_integrity_flags_light_frame_in_dark_slot():
-    """A frame at the 'first dark' position whose u1 is high and std is
-    high (i.e. a real light frame, the firmware off-by-one symptom)
-    must produce a warning."""
+    """A frame at the 'first dark' position whose u1 is high (i.e. a
+    real light frame, the firmware off-by-one symptom) must produce a
+    warning."""
     p = _make_pipeline()
     _drive_through_first_dark(p, dark_mean=200.0, dark_std=40.0)
     warnings = p.dark_integrity_warnings
@@ -87,9 +87,10 @@ def test_dark_integrity_flags_high_u1_only():
     assert len(p.dark_integrity_warnings) >= 1
 
 
-def test_dark_integrity_flags_high_std_only():
-    """Frame with pedestal-ish u1 but unexpectedly high std (light leak,
-    speckle pattern) should flag."""
+def test_dark_integrity_ignores_high_std_when_u1_is_pedestal():
+    """High std alone must NOT flag the frame — std is too noisy a
+    signal across the scan (warms up over time on fw 1.5.3). The u1
+    bound is the sole criterion."""
     p = _make_pipeline()
     _drive_through_first_dark(p, dark_mean=PEDESTAL_HEIGHT, dark_std=30.0)
-    assert len(p.dark_integrity_warnings) >= 1
+    assert p.dark_integrity_warnings == []


### PR DESCRIPTION
## Summary
- ``_check_dark_integrity`` flagged any dark frame whose std exceeded 20 DN, which on fw 1.5.3 drifts naturally from ~20 at scan start to ~120 mid-scan. This generated false-positive dark-integrity warnings.
- Drop the std check; warn on the ``u1`` (mean) signal only.

## Test plan
- [ ] Run a scan that previously tripped the std false-positive — no dark-integrity warnings should fire.
- [ ] A real dark-integrity issue (light leak into a dark slot) still warns via the u1 path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)