### PR TITLE
docs: tighten SDK release policy (next->main PR + stable tags only)

### DIFF
--- a/docs/Releasing.md
+++ b/docs/Releasing.md
@@ -5,9 +5,15 @@ a tag** — the wrong shape breaks downstream app builds.
 
 ## Branch flow
 
-- `main` — production. Only updated by promoting `next` after a release.
+- `main` — production. Only updated by merging an approved PR from `next`.
+  Releases are cut from `main` (tag the merge commit), never directly from
+  `next`.
 - `next` — integration branch. Everything merges here first.
 - `feature/<issue>-<short-desc>` — branch from `next`, PR back to `next`.
+
+A release goes: `feature/* → next → main → tag → PyPI`. The
+`next → main` PR is the release-approval gate; once merged, the tag on
+`main` is what triggers the build + PyPI publish.
 
 ## How downstream apps consume the SDK
 
@@ -24,29 +30,28 @@ The third row is the critical one: dev app builds **build the SDK from source
 off `next`**, so `next` must always be installable. That means
 `setuptools_scm` has to successfully parse the most recent reachable tag.
 
-## Tag format — must match the `setuptools_scm` regex
+## Tag format — current policy
 
-`pyproject.toml` pins:
+Only stable, suffix-free tags are accepted. Pre-release and any other
+suffixed tags are **disallowed by policy** until further notice.
 
-```toml
-[tool.setuptools_scm]
-tag_regex = "^(?:pre-)?v?(?P<version>\\d+\\.\\d+\\.\\d+)$"
-```
+| Shape    | Example  | Triggers release pipeline |
+|----------|----------|---------------------------|
+| `X.Y.Z`  | `1.6.2`  | yes — stable              |
+| `vX.Y.Z` | `v1.6.2` | yes — stable              |
 
-Only these tag shapes are valid on this repo:
+**Do not use** anything with a suffix:
 
-| Shape       | Example     | Triggers release pipeline |
-|-------------|-------------|---------------------------|
-| `X.Y.Z`     | `1.6.1`     | yes — stable              |
-| `vX.Y.Z`    | `v1.6.1`    | yes — stable              |
-| `pre-X.Y.Z` | `pre-1.6.2` | yes — pre-release (rc0)   |
-
-**Do not use** anything with a suffix after the three numbers:
-
+- `pre-1.6.2`  (previously allowed; now disallowed)
 - `1.6.2-dev.1`
 - `1.6.2-rc.1`
 - `1.6.2-beta`
 - `1.6.2.post1`
+
+`pyproject.toml` still pins a permissive `setuptools_scm` regex
+(`^(?:pre-)?v?(?P<version>\\d+\\.\\d+\\.\\d+)$`) and `release-build.yml`
+will still build a `pre-*` tag if pushed — the restriction here is *policy*,
+not enforcement. Don't push them.
 
 ### Why suffixed tags break things
 
@@ -69,29 +74,46 @@ The wheel published fine on the SDK side; every consumer broke.
 
 ## Cutting a release
 
-1. Land all target commits on `next`.
-2. Choose `X.Y.Z` (stable) or `pre-X.Y.Z` (RC).
-3. From `next`:
+1. Land all target commits on `next` via the usual `feature/* → next` PRs.
+2. Open a PR `next → main` titled `Release: SDK next → main (...)`. This
+   PR is the release-approval gate — reviewers sign off on the contents of
+   the release here, not at tag time. Choose `X.Y.Z` for the eventual tag.
+3. After the PR is merged, tag the merge commit on `main`:
    ```
+   git checkout main
+   git pull
    git tag -a 1.6.2 -m "release 1.6.2"
    git push origin 1.6.2
    ```
-4. `.github/workflows/release-build.yml` builds wheel + sdist and attaches
-   them to a GitHub release.
-5. PyPI publishing handled by `publish-pypi.yml`.
-6. Promote `next` → `main` after the release stabilizes.
+   The tag MUST point to a commit reachable from `main`. If you tagged a
+   commit that's only on `next`, delete the tag and re-tag from `main`
+   (see "If you tag wrong" below).
+4. The tag push triggers `.github/workflows/release-build.yml`, which
+   builds the wheel + sdist and creates a GitHub Release with the
+   artifacts attached.
+5. The GitHub Release `published` event triggers
+   `.github/workflows/publish-pypi.yml`, which downloads the release
+   assets and uploads them to PyPI via the OIDC trusted publisher.
+
+The combination of (a) tag exists in the shape above and (b) the tagged
+commit is reachable from `main` is what gates PyPI publication.
 
 ## Manual / test builds (no tag)
 
 Use `workflow_dispatch` on `release-build.yml` with `pretend_version`
 (e.g. `0.0.0-test1`) to produce a one-off build artifact without creating a
-git tag.
+git tag. These artifacts are uploaded to the workflow run, not to a GitHub
+Release, so they do not trigger the PyPI publish path.
 
 ## If you tag wrong
 
-Delete the release + tag, then re-run the downstream build:
+Delete the release + tag, then re-tag from the correct branch (`main`)
+and push again:
 
 ```
 gh release delete <tag> --repo OpenwaterHealth/openmotion-sdk --cleanup-tag --yes
 git tag -d <tag>
+git push origin :refs/tags/<tag>
 ```
+
+Re-run any downstream builds that picked up the bad tag.


### PR DESCRIPTION
## Summary

Updates `docs/Releasing.md` to reflect two policy changes:

1. **`next → main` PR is the release-approval gate.** Tags now go on the
   merge commit on `main`, not on `next`. Flow is
   `feature/* → next → main → tag → PyPI`. Reviewers sign off at the PR,
   not at tag time.
2. **Only stable, suffix-free tags are allowed.** `X.Y.Z` and `vX.Y.Z`
   only. Pre-release tags (`pre-X.Y.Z`) are explicitly disallowed by
   policy until further notice — they previously worked but caused
   downstream confusion. The `setuptools_scm` regex and
   `release-build.yml` are unchanged; the constraint is policy, not
   enforcement.

Also clarifies that the (tag exists) + (tag reachable from `main`)
combination is what gates PyPI publication via `publish-pypi.yml`.

No CI / code changes in this PR — docs only.

## Test plan
- [ ] Read through the updated doc end-to-end and sanity-check the steps
- [ ] Confirm the policy matches what the team actually wants before the
  next release goes out

🤖 Generated with [Claude Code](https://claude.com/claude-code)