### PR TITLE
Release: SDK next -> main (calibration robustness + USB transport fixes)

### DIFF
--- a/docs/Releasing.md
+++ b/docs/Releasing.md
@@ -1,0 +1,97 @@
+# Releasing the SDK
+
+Git workflow and tag rules for `openmotion-sdk`. **Read this before creating
+a tag** — the wrong shape breaks downstream app builds.
+
+## Branch flow
+
+- `main` — production. Only updated by promoting `next` after a release.
+- `next` — integration branch. Everything merges here first.
+- `feature/<issue>-<short-desc>` — branch from `next`, PR back to `next`.
+
+## How downstream apps consume the SDK
+
+The app workflows (`openmotion-bloodflow-app`, `openmotion-test-app`) pick
+their SDK source based on the *app's* tag shape:
+
+| App tag           | SDK source                                                          |
+|-------------------|---------------------------------------------------------------------|
+| `X.Y.Z`           | latest published `openmotion-sdk` wheel from PyPI / GitHub Releases |
+| `X.Y.Z-rc.N`      | latest published `openmotion-sdk` wheel from PyPI / GitHub Releases |
+| `X.Y.Z-dev.N`     | `pip install git+https://...openmotion-sdk.git@next` (source build) |
+
+The third row is the critical one: dev app builds **build the SDK from source
+off `next`**, so `next` must always be installable. That means
+`setuptools_scm` has to successfully parse the most recent reachable tag.
+
+## Tag format — must match the `setuptools_scm` regex
+
+`pyproject.toml` pins:
+
+```toml
+[tool.setuptools_scm]
+tag_regex = "^(?:pre-)?v?(?P<version>\\d+\\.\\d+\\.\\d+)$"
+```
+
+Only these tag shapes are valid on this repo:
+
+| Shape       | Example     | Triggers release pipeline |
+|-------------|-------------|---------------------------|
+| `X.Y.Z`     | `1.6.1`     | yes — stable              |
+| `vX.Y.Z`    | `v1.6.1`    | yes — stable              |
+| `pre-X.Y.Z` | `pre-1.6.2` | yes — pre-release (rc0)   |
+
+**Do not use** anything with a suffix after the three numbers:
+
+- `1.6.2-dev.1`
+- `1.6.2-rc.1`
+- `1.6.2-beta`
+- `1.6.2.post1`
+
+### Why suffixed tags break things
+
+When `pip install git+...@next` runs anywhere downstream, `setuptools_scm`
+calls `git describe`, gets the most recent reachable tag, and runs it through
+`tag_regex`. A non-matching tag returns `None`, which trips
+`assert version is not None` in `setuptools_scm._scm_version._parse_tag` and
+kills the wheel build with `AssertionError`.
+
+The SDK's own `release-build.yml` sidesteps this by setting
+`SETUPTOOLS_SCM_PRETEND_VERSION` from the tag name — so the SDK *can* publish
+a wheel for a bad-shaped tag. That gives a false sense of safety: the SDK
+release succeeds, but every downstream source-install from `@next`
+immediately after will fail until the bad tag is removed.
+
+**Past incident:** tag `1.6.2-dev.1` on `next` broke `openmotion-bloodflow-app`
+build `1.1.1-dev.6`
+([run 26131915045](https://github.com/OpenwaterHealth/openmotion-bloodflow-app/actions/runs/26131915045)).
+The wheel published fine on the SDK side; every consumer broke.
+
+## Cutting a release
+
+1. Land all target commits on `next`.
+2. Choose `X.Y.Z` (stable) or `pre-X.Y.Z` (RC).
+3. From `next`:
+   ```
+   git tag -a 1.6.2 -m "release 1.6.2"
+   git push origin 1.6.2
+   ```
+4. `.github/workflows/release-build.yml` builds wheel + sdist and attaches
+   them to a GitHub release.
+5. PyPI publishing handled by `publish-pypi.yml`.
+6. Promote `next` → `main` after the release stabilizes.
+
+## Manual / test builds (no tag)
+
+Use `workflow_dispatch` on `release-build.yml` with `pretend_version`
+(e.g. `0.0.0-test1`) to produce a one-off build artifact without creating a
+git tag.
+
+## If you tag wrong
+
+Delete the release + tag, then re-run the downstream build:
+
+```
+gh release delete <tag> --repo OpenwaterHealth/openmotion-sdk --cleanup-tag --yes
+git tag -d <tag>
+```

--- a/docs/Releasing.md
+++ b/docs/Releasing.md
@@ -5,9 +5,15 @@ a tag** — the wrong shape breaks downstream app builds.
 
 ## Branch flow
 
-- `main` — production. Only updated by promoting `next` after a release.
+- `main` — production. Only updated by merging an approved PR from `next`.
+  Releases are cut from `main` (tag the merge commit), never directly from
+  `next`.
 - `next` — integration branch. Everything merges here first.
 - `feature/<issue>-<short-desc>` — branch from `next`, PR back to `next`.
+
+A release goes: `feature/* → next → main → tag → PyPI`. The
+`next → main` PR is the release-approval gate; once merged, the tag on
+`main` is what triggers the build + PyPI publish.
 
 ## How downstream apps consume the SDK
 
@@ -24,29 +30,28 @@ The third row is the critical one: dev app builds **build the SDK from source
 off `next`**, so `next` must always be installable. That means
 `setuptools_scm` has to successfully parse the most recent reachable tag.
 
-## Tag format — must match the `setuptools_scm` regex
+## Tag format — current policy
 
-`pyproject.toml` pins:
+Only stable, suffix-free tags are accepted. Pre-release and any other
+suffixed tags are **disallowed by policy** until further notice.
 
-```toml
-[tool.setuptools_scm]
-tag_regex = "^(?:pre-)?v?(?P<version>\\d+\\.\\d+\\.\\d+)$"
-```
+| Shape    | Example  | Triggers release pipeline |
+|----------|----------|---------------------------|
+| `X.Y.Z`  | `1.6.2`  | yes — stable              |
+| `vX.Y.Z` | `v1.6.2` | yes — stable              |
 
-Only these tag shapes are valid on this repo:
+**Do not use** anything with a suffix:
 
-| Shape       | Example     | Triggers release pipeline |
-|-------------|-------------|---------------------------|
-| `X.Y.Z`     | `1.6.1`     | yes — stable              |
-| `vX.Y.Z`    | `v1.6.1`    | yes — stable              |
-| `pre-X.Y.Z` | `pre-1.6.2` | yes — pre-release (rc0)   |
-
-**Do not use** anything with a suffix after the three numbers:
-
+- `pre-1.6.2`  (previously allowed; now disallowed)
 - `1.6.2-dev.1`
 - `1.6.2-rc.1`
 - `1.6.2-beta`
 - `1.6.2.post1`
+
+`pyproject.toml` still pins a permissive `setuptools_scm` regex
+(`^(?:pre-)?v?(?P<version>\\d+\\.\\d+\\.\\d+)$`) and `release-build.yml`
+will still build a `pre-*` tag if pushed — the restriction here is *policy*,
+not enforcement. Don't push them.
 
 ### Why suffixed tags break things
 
@@ -69,29 +74,46 @@ The wheel published fine on the SDK side; every consumer broke.
 
 ## Cutting a release
 
-1. Land all target commits on `next`.
-2. Choose `X.Y.Z` (stable) or `pre-X.Y.Z` (RC).
-3. From `next`:
+1. Land all target commits on `next` via the usual `feature/* → next` PRs.
+2. Open a PR `next → main` titled `Release: SDK next → main (...)`. This
+   PR is the release-approval gate — reviewers sign off on the contents of
+   the release here, not at tag time. Choose `X.Y.Z` for the eventual tag.
+3. After the PR is merged, tag the merge commit on `main`:
    ```
+   git checkout main
+   git pull
    git tag -a 1.6.2 -m "release 1.6.2"
    git push origin 1.6.2
    ```
-4. `.github/workflows/release-build.yml` builds wheel + sdist and attaches
-   them to a GitHub release.
-5. PyPI publishing handled by `publish-pypi.yml`.
-6. Promote `next` → `main` after the release stabilizes.
+   The tag MUST point to a commit reachable from `main`. If you tagged a
+   commit that's only on `next`, delete the tag and re-tag from `main`
+   (see "If you tag wrong" below).
+4. The tag push triggers `.github/workflows/release-build.yml`, which
+   builds the wheel + sdist and creates a GitHub Release with the
+   artifacts attached.
+5. The GitHub Release `published` event triggers
+   `.github/workflows/publish-pypi.yml`, which downloads the release
+   assets and uploads them to PyPI via the OIDC trusted publisher.
+
+The combination of (a) tag exists in the shape above and (b) the tagged
+commit is reachable from `main` is what gates PyPI publication.
 
 ## Manual / test builds (no tag)
 
 Use `workflow_dispatch` on `release-build.yml` with `pretend_version`
 (e.g. `0.0.0-test1`) to produce a one-off build artifact without creating a
-git tag.
+git tag. These artifacts are uploaded to the workflow run, not to a GitHub
+Release, so they do not trigger the PyPI publish path.
 
 ## If you tag wrong
 
-Delete the release + tag, then re-run the downstream build:
+Delete the release + tag, then re-tag from the correct branch (`main`)
+and push again:
 
 ```
 gh release delete <tag> --repo OpenwaterHealth/openmotion-sdk --cleanup-tag --yes
 git tag -d <tag>
+git push origin :refs/tags/<tag>
 ```
+
+Re-run any downstream builds that picked up the bad tag.

--- a/omotion/CalibrationWorkflow.py
+++ b/omotion/CalibrationWorkflow.py
@@ -828,18 +828,6 @@ def _run_subscan_capture(
         )
     if res.canceled:
         return "", "", [], []
-    # Loud failure: if the science pipeline detected dark-frame
-    # schedule/measurement disagreement, abort the calibration. The
-    # interpolated dark baseline would be polluted and the resulting
-    # C_max/I_max would be wrong.
-    if res.dark_integrity_warnings:
-        details = " | ".join(res.dark_integrity_warnings[:3])
-        if len(res.dark_integrity_warnings) > 3:
-            details += f" (+{len(res.dark_integrity_warnings) - 3} more)"
-        raise RuntimeError(
-            f"sub-scan dark integrity check failed ({len(res.dark_integrity_warnings)} "
-            f"warnings): {details}"
-        )
     captured.sort(key=lambda s: (s.side, s.cam_id, s.absolute_frame_id))
     dark.sort(key=lambda s: (s.side, s.cam_id, s.absolute_frame_id))
     return res.left_path or "", res.right_path or "", captured, dark

--- a/omotion/CommInterface.py
+++ b/omotion/CommInterface.py
@@ -76,6 +76,14 @@ class CommInterface(USBInterfaceBase):
         super().__init__(dev, interface_index, desc)
         self.read_thread = None
         self.stop_event = threading.Event()
+        # Set by the read loop when it exits on a fatal USB error
+        # (ENODEV / EIO / EPIPE / other non-timeout failures). send_packet
+        # polls it inside the wait loops so an in-flight command unblocks
+        # the moment the transport drops, instead of spinning for the full
+        # caller-supplied timeout (60 s for program_fpga, etc.). See
+        # bloodflow-app#130: power-cycle mid-configure left the SDK's
+        # configure worker hung for 60 s, blocking the next scan attempt.
+        self._transport_down_evt = threading.Event()
         # Contiguous byte buffer: USB reader extends the end, packet parser chops from the front
         self._read_buffer = bytearray()
         self._buffer_lock = threading.Lock()
@@ -160,6 +168,11 @@ class CommInterface(USBInterfaceBase):
                 data = bytearray()
                 with self._io_lock:
                     while time.monotonic() - start < timeout:
+                        if self._transport_down_evt.is_set():
+                            raise ConnectionError(
+                                f"{self.desc}: transport down, packet id "
+                                f"0x{id:04X} not deliverable"
+                            )
                         try:
                             resp = self.receive()
                             time.sleep(0.005)
@@ -173,6 +186,11 @@ class CommInterface(USBInterfaceBase):
             else:
                 start_time = time.monotonic()
                 while time.monotonic() - start_time < timeout:
+                    if self._transport_down_evt.is_set():
+                        raise ConnectionError(
+                            f"{self.desc}: transport down, packet id "
+                            f"0x{id:04X} not deliverable"
+                        )
                     if self.response_queue.empty():
                         time.sleep(0.0005)
                     else:
@@ -235,6 +253,10 @@ class CommInterface(USBInterfaceBase):
             logger.info(f"{self.desc}: Read thread already running")
             return
         self.stop_event.clear()
+        # Fresh read thread implies transport is up again; any prior
+        # transport-down latch from a previous USB error must clear or
+        # subsequent sends would short-circuit on the stale flag.
+        self._transport_down_evt.clear()
         self.read_thread = threading.Thread(target=self._read_loop, daemon=True)
         self.read_thread.start()
         logger.info(f"{self.desc}: Read thread started")
@@ -297,6 +319,10 @@ class CommInterface(USBInterfaceBase):
                 logger.warning(
                     f"{self.desc}: USB read error (errno={e.errno}); exiting read loop: {e}"
                 )
+                # Latch transport-down BEFORE the io-error callback so any
+                # send_packet that is currently spinning in its wait loop
+                # observes the dead transport on its next tick.
+                self._transport_down_evt.set()
                 self._notify_io_error(e)
                 break
 

--- a/omotion/MotionProcessing.py
+++ b/omotion/MotionProcessing.py
@@ -1149,8 +1149,8 @@ class SciencePipeline:
         # field (frame 10 looks like a light frame: u1≈200, std≈40).
         self._dark_integrity_max_u1_above_pedestal = float(dark_integrity_max_u1_above_pedestal)
         self._dark_integrity_max_std = float(dark_integrity_max_std)
-        # Populated by _check_dark_integrity. Callers (CalibrationWorkflow)
-        # query this after pipeline.stop() to fail loudly.
+        # Populated by _check_dark_integrity. Diagnostic only — surfaced
+        # on ScanResult but no longer fatal to calibration.
         self._dark_integrity_warnings: list[str] = []
         # Per (side, cam_id): deque of the last N uncorrected light Samples.
         # Populated lazily on first light sample for that key; empty when
@@ -1208,8 +1208,9 @@ class SciencePipeline:
         more frames as dark-by-schedule, but the actual measurement
         (u1, std) failed the dark heuristic — i.e. the firmware emitted
         a light frame in a slot the science pipeline expected to be
-        dark. Calibration callers should fail loudly when this is
-        non-empty since the dark interpolation will be polluted.
+        dark, OR the dark slot picked up significant ambient light.
+        Diagnostic only — the per-camera FT dark mean-max check is the
+        authoritative gate for ambient-light failure.
         """
         return list(self._dark_integrity_warnings)
 

--- a/omotion/MotionProcessing.py
+++ b/omotion/MotionProcessing.py
@@ -1130,7 +1130,6 @@ class SciencePipeline:
         noise_floor: int = 10,
         log_dark_endpoints: bool = False,
         dark_integrity_max_u1_above_pedestal: float = 30.0,
-        dark_integrity_max_std: float = 20.0,
     ):
         self._bfi_c_min = bfi_c_min
         self._bfi_c_max = bfi_c_max
@@ -1144,11 +1143,10 @@ class SciencePipeline:
         self._rolling_avg_window = int(rolling_avg_window)
         self._log_dark_endpoints = bool(log_dark_endpoints)
         # Dark-integrity monitor: every frame stored in _dark_history is
-        # cross-checked against these bounds. The defaults catch the
+        # cross-checked against this bound. The default catches the
         # firmware off-by-one symptom we've actually observed in the
-        # field (frame 10 looks like a light frame: u1≈200, std≈40).
+        # field (frame 10 looks like a light frame: u1≈200).
         self._dark_integrity_max_u1_above_pedestal = float(dark_integrity_max_u1_above_pedestal)
-        self._dark_integrity_max_std = float(dark_integrity_max_std)
         # Populated by _check_dark_integrity. Diagnostic only — surfaced
         # on ScanResult but no longer fatal to calibration.
         self._dark_integrity_warnings: list[str] = []
@@ -1205,10 +1203,10 @@ class SciencePipeline:
         """Return the list of dark-integrity warnings collected so far.
 
         A non-empty list means the science pipeline classified one or
-        more frames as dark-by-schedule, but the actual measurement
-        (u1, std) failed the dark heuristic — i.e. the firmware emitted
-        a light frame in a slot the science pipeline expected to be
-        dark, OR the dark slot picked up significant ambient light.
+        more frames as dark-by-schedule, but the actual measurement u1
+        was above pedestal+max — i.e. the firmware emitted a light
+        frame in a slot the science pipeline expected to be dark, OR
+        the dark slot picked up significant ambient light.
         Diagnostic only — the per-camera FT dark mean-max check is the
         authoritative gate for ambient-light failure.
         """
@@ -1220,22 +1218,18 @@ class SciencePipeline:
         cam_id: int,
         absolute_frame: int,
         u1: float,
-        variance: float,
     ) -> None:
         """Verify a frame the schedule classified as dark actually
         looks dark. Logs at ERROR level and stores a warning string on
         the pipeline if not."""
-        std = float(np.sqrt(max(0.0, variance)))
         max_u1 = PEDESTAL_HEIGHT + self._dark_integrity_max_u1_above_pedestal
-        max_std = self._dark_integrity_max_std
-        if u1 <= max_u1 and std <= max_std:
+        if u1 <= max_u1:
             return
         msg = (
             f"DARK INTEGRITY FAILURE: {side} cam {cam_id} frame "
             f"{absolute_frame} was classified as dark by schedule, but "
-            f"its measurement looks like a light frame "
-            f"(u1={u1:.2f} > pedestal+{self._dark_integrity_max_u1_above_pedestal:.0f}={max_u1:.0f}? "
-            f"std={std:.2f} > {max_std:.0f}?). "
+            f"u1={u1:.2f} exceeds pedestal+"
+            f"{self._dark_integrity_max_u1_above_pedestal:.0f}={max_u1:.0f}. "
             "Probable cause: firmware off-by-one in NUM_DARK_FRAMES_AT_START "
             "or unwrapper alignment quirk. Dark-frame interpolation will be "
             "polluted; corrected stream values are unreliable."
@@ -1380,7 +1374,7 @@ class SciencePipeline:
                 # dark? If not, the schedule and the firmware disagree
                 # and we want to know about it.
                 self._check_dark_integrity(
-                    side, cam_id, absolute_frame, u1, variance,
+                    side, cam_id, absolute_frame, u1,
                 )
 
                 # With 2+ dark frames we can correct the preceding interval.
@@ -1553,7 +1547,7 @@ class SciencePipeline:
             # laser-off frame.
             self._check_dark_integrity(
                 key[0], key[1], terminal.absolute_frame_id,
-                terminal.u1, terminal_var,
+                terminal.u1,
             )
             self._emit_corrected_for_camera(key)
 
@@ -1784,7 +1778,6 @@ def create_science_pipeline(
     noise_floor: int = 10,
     log_dark_endpoints: bool = False,
     dark_integrity_max_u1_above_pedestal: float = 30.0,
-    dark_integrity_max_std: float = 20.0,
 ) -> SciencePipeline:
     """
     Factory for a ready-to-run unified science pipeline.
@@ -1846,7 +1839,6 @@ def create_science_pipeline(
         noise_floor=noise_floor,
         log_dark_endpoints=log_dark_endpoints,
         dark_integrity_max_u1_above_pedestal=dark_integrity_max_u1_above_pedestal,
-        dark_integrity_max_std=dark_integrity_max_std,
     )
     pipeline.start()
     return pipeline

--- a/omotion/MotionSensor.py
+++ b/omotion/MotionSensor.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import struct
 import threading
 import time
@@ -70,6 +71,34 @@ logger = logging.getLogger(f"{_log_root}.Sensor" if _log_root else "Sensor")
 
 # Firmware response types that indicate an error condition.
 _ERROR_TYPES = frozenset({OW_ERROR, OW_BAD_CRC, OW_BAD_PARSE, OW_UNKNOWN})
+
+
+# Matches the leading "MAJOR.MINOR.PATCH" of a firmware version, ignoring any
+# leading "v" and any pre-release / build / git-describe suffix that follows.
+# Examples that match: "v1.5.4", "1.5.4-dev", "1.5.4-dev.0-5-g1234abc-dirty",
+# "1.5.4+build.7". Strings with no leading numeric component (e.g. "unknown")
+# do not match.
+_VERSION_RE = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)")
+
+
+def _parse_firmware_version(version_str: str) -> tuple[int, int, int]:
+    """Parse a sensor firmware version string into a ``(major, minor, patch)`` tuple.
+
+    Tolerates a leading ``v`` and any pre-release / build / git-describe suffix
+    (``-dev``, ``-rc.1``, ``-5-g1234abc``, ``-dirty``, ``+build.7``, etc.) by
+    matching only the leading numeric ``MAJOR.MINOR.PATCH`` segment. Sensor
+    firmware embeds ``git describe --tags --dirty --always`` as its version
+    string, so suffixes like these appear in every non-release build.
+
+    Raises ``ValueError`` if the string has no leading numeric component
+    (e.g. ``"unknown"``).
+    """
+    if version_str is None:
+        raise TypeError("version_str must be a string, got None")
+    m = _VERSION_RE.match(version_str)
+    if not m:
+        raise ValueError(f"unparseable firmware version {version_str!r}")
+    return (int(m.group(1)), int(m.group(2)), int(m.group(3)))
 
 
 class MotionSensor(SignalWrapper):
@@ -1152,10 +1181,10 @@ class MotionSensor(SignalWrapper):
         """
         import omotion.MotionProcessing as _mp
 
+        version_str = self.get_version()
         try:
-            version_str = self.get_version().lstrip("v")
-            parts = tuple(int(x) for x in version_str.split("."))
-        except Exception as e:
+            parts = _parse_firmware_version(version_str)
+        except (ValueError, TypeError) as e:
             logger.warning(
                 "Could not parse firmware version for pedestal selection: %s", e
             )
@@ -1164,7 +1193,7 @@ class MotionSensor(SignalWrapper):
         pedestal = 64.0 if parts <= (1, 5, 2) else 128.0
         _mp.PEDESTAL_HEIGHT = pedestal
         logger.info(
-            "Pedestal height set to %g based on sensor firmware v%s",
+            "Pedestal height set to %g based on sensor firmware %s",
             pedestal,
             version_str,
         )

--- a/omotion/ScanWorkflow.py
+++ b/omotion/ScanWorkflow.py
@@ -111,9 +111,9 @@ class ScanResult:
     telemetry_path: str = ""
     # Populated when the science pipeline detected schedule/measurement
     # disagreement on dark frames (firmware off-by-one, unwrapper
-    # alignment quirk, etc.). Empty on a clean scan. Calibration callers
-    # should fail loudly when this is non-empty since dark-frame
-    # interpolation will be polluted.
+    # alignment quirk, or significant ambient light in a dark slot).
+    # Empty on a clean scan. Diagnostic only — calibration no longer
+    # aborts on this; the per-camera FT dark mean-max check gates that.
     dark_integrity_warnings: list[str] = field(default_factory=list)
 
 

--- a/scripts/check_dark_schedule.py
+++ b/scripts/check_dark_schedule.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""Standalone dark-frame schedule integrity check for raw histogram CSVs.
+
+Given a ``*_raw.csv`` produced by ScanWorkflow, verify that every frame
+the firmware schedule expects to be a dark frame actually looks dark in
+the data. Catches firmware off-by-one symptoms (where a light frame
+lands in a slot the SDK treats as dark, polluting the dark-frame
+interpolation) and gross ambient-light contamination of the dark slots.
+
+Standalone by design — only depends on ``csv`` and ``numpy``. No SDK
+import, so it can be vendored into post-processing pipelines or run on
+machines without the openmotion package installed.
+
+Usage
+-----
+    python scripts/check_dark_schedule.py path/to/scan_left_maskFF_raw.csv
+
+    # custom thresholds / schedule:
+    python scripts/check_dark_schedule.py raw.csv \\
+        --pedestal 128 --max-u1-above-pedestal 30 --max-std 20 \\
+        --discard-count 9 --dark-interval 600
+
+Exit code
+---------
+    0 — every scheduled dark frame on every camera passes both bounds
+    1 — at least one scheduled dark frame failed (or CSV unreadable)
+
+Notes
+-----
+- Schedule formula matches ``SciencePipeline._is_dark_frame``: first
+  dark at ``discard_count + 1`` (= 10), subsequent at
+  ``(absolute_frame - 1) % dark_interval == 0`` for
+  absolute_frame > discard+1.
+- ``frame_id`` in the raw CSV is an 8-bit firmware counter that runs
+  ``1,2,…,255,0,1,…`` and wraps every 256 frames. The SDK normally
+  unwraps it via ``FrameIdUnwrapper``; this script does its own
+  per-camera unwrap (backward-jump = wrap) so it can apply the schedule
+  formula on the un-wrapped ``absolute_frame``. Rows are assumed to be
+  in arrival order, which is what the raw writer produces.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import sys
+from dataclasses import dataclass
+from typing import Iterator
+
+import numpy as np
+
+HISTOGRAM_BINS = 1024
+HISTO_BIN_INDICES = np.arange(HISTOGRAM_BINS, dtype=np.float64)
+HISTO_BIN_SQUARES = HISTO_BIN_INDICES ** 2
+# Firmware ships frame_id as a single byte (counts 1..255 then 0,1,…).
+FRAME_ID_MODULUS = 256
+
+
+@dataclass
+class Thresholds:
+    pedestal: float = 128.0
+    max_u1_above_pedestal: float = 30.0
+    max_std: float = 20.0
+    discard_count: int = 9
+    dark_interval: int = 600
+
+    @property
+    def max_u1(self) -> float:
+        return self.pedestal + self.max_u1_above_pedestal
+
+
+@dataclass
+class FrameStats:
+    cam_id: int
+    raw_frame_id: int
+    absolute_frame: int
+    u1: float
+    std: float
+    fail_reasons: list[str]
+
+    @property
+    def ok(self) -> bool:
+        return not self.fail_reasons
+
+
+class FrameIdUnwrapper:
+    """Per-camera ``raw_frame_id`` (0..255, wraps) -> monotonic
+    ``absolute_frame``. A backward step from the previous raw value
+    counts as one wrap; first frame seen is taken as the absolute
+    starting point.
+    """
+    def __init__(self) -> None:
+        self._state: dict[int, dict[str, int]] = {}
+
+    def unwrap(self, cam_id: int, raw: int) -> int:
+        s = self._state.get(cam_id)
+        if s is None:
+            self._state[cam_id] = {"prev_raw": raw, "wraps": 0}
+            return raw
+        if raw < s["prev_raw"]:
+            s["wraps"] += 1
+        s["prev_raw"] = raw
+        return s["wraps"] * FRAME_ID_MODULUS + raw
+
+
+def is_scheduled_dark_frame(frame_id: int, discard_count: int, dark_interval: int) -> bool:
+    """Mirror of ``SciencePipeline._is_dark_frame``."""
+    if frame_id == discard_count + 1:
+        return True
+    return (
+        frame_id > discard_count + 1
+        and (frame_id - 1) % dark_interval == 0
+    )
+
+
+def compute_u1_std(histogram: np.ndarray) -> tuple[float, float]:
+    """Compute the population mean (``u1``) and std of a 1024-bin histogram.
+
+    Returns ``(nan, nan)`` on an empty histogram so the caller can decide
+    whether to surface or silently skip.
+    """
+    total = float(histogram.sum())
+    if total <= 0:
+        return float("nan"), float("nan")
+    u1 = float((HISTO_BIN_INDICES * histogram).sum() / total)
+    u2 = float((HISTO_BIN_SQUARES * histogram).sum() / total)
+    variance = max(0.0, u2 - u1 * u1)
+    return u1, float(np.sqrt(variance))
+
+
+def parse_row(row: list[str]) -> tuple[int, int, np.ndarray] | None:
+    """Pull ``(cam_id, frame_id, histogram)`` out of one raw CSV row.
+
+    The raw CSV layout is::
+
+        cam_id, frame_id, timestamp_s, 0..1023, temperature, sum, tcm, tcl, pdc
+
+    Returns None when the row is too short to contain a full histogram —
+    happens occasionally on truncated CSVs (e.g. scan canceled mid-row).
+    """
+    if len(row) < 3 + HISTOGRAM_BINS:
+        return None
+    try:
+        cam_id = int(row[0])
+        frame_id = int(row[1])
+    except ValueError:
+        return None
+    try:
+        histogram = np.array(row[3:3 + HISTOGRAM_BINS], dtype=np.int64)
+    except ValueError:
+        return None
+    return cam_id, frame_id, histogram
+
+
+def iter_dark_frame_stats(
+    csv_path: str, thresholds: Thresholds,
+) -> Iterator[FrameStats]:
+    """Stream the raw CSV and yield a ``FrameStats`` for every row whose
+    ``absolute_frame`` (unwrapped from the 8-bit raw counter) is a
+    scheduled dark frame."""
+    unwrapper = FrameIdUnwrapper()
+    with open(csv_path, "r", newline="", encoding="utf-8") as fh:
+        reader = csv.reader(fh)
+        try:
+            header = next(reader)
+        except StopIteration:
+            return
+        if not header or header[0] != "cam_id":
+            raise ValueError(
+                f"{csv_path}: header does not start with 'cam_id' — "
+                "is this really a raw histogram CSV?"
+            )
+
+        for row in reader:
+            parsed = parse_row(row)
+            if parsed is None:
+                continue
+            cam_id, raw_frame_id, histogram = parsed
+            absolute_frame = unwrapper.unwrap(cam_id, raw_frame_id)
+            if not is_scheduled_dark_frame(
+                absolute_frame, thresholds.discard_count, thresholds.dark_interval,
+            ):
+                continue
+            u1, std = compute_u1_std(histogram)
+            fail_reasons: list[str] = []
+            if np.isnan(u1):
+                fail_reasons.append("empty histogram")
+            else:
+                if u1 > thresholds.max_u1:
+                    fail_reasons.append(
+                        f"u1={u1:.2f} > pedestal+{thresholds.max_u1_above_pedestal:.0f}"
+                        f"={thresholds.max_u1:.0f}"
+                    )
+                if std > thresholds.max_std:
+                    fail_reasons.append(
+                        f"std={std:.2f} > {thresholds.max_std:.0f}"
+                    )
+            yield FrameStats(
+                cam_id=cam_id,
+                raw_frame_id=raw_frame_id,
+                absolute_frame=absolute_frame,
+                u1=u1, std=std, fail_reasons=fail_reasons,
+            )
+
+
+def check_file(csv_path: str, thresholds: Thresholds) -> tuple[int, int, list[FrameStats]]:
+    """Returns ``(total_checked, fail_count, failures)``."""
+    total = 0
+    failures: list[FrameStats] = []
+    for fs in iter_dark_frame_stats(csv_path, thresholds):
+        total += 1
+        if not fs.ok:
+            failures.append(fs)
+    return total, len(failures), failures
+
+
+def _format_failure(fs: FrameStats) -> str:
+    return (
+        f"  cam={fs.cam_id} frame={fs.absolute_frame} (raw={fs.raw_frame_id})  "
+        f"u1={fs.u1:>7.2f}  std={fs.std:>6.2f}  -> {'; '.join(fs.fail_reasons)}"
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Verify scheduled dark frames in a raw histogram CSV "
+                    "actually look dark.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument("csv_path", help="Path to the *_raw.csv file to check.")
+    p.add_argument(
+        "--pedestal", type=float, default=128.0,
+        help="Sensor pedestal height in DN (128 for sensor-fw >= 1.5.0, "
+             "64 for older firmware).",
+    )
+    p.add_argument(
+        "--max-u1-above-pedestal", type=float, default=30.0,
+        help="Max DN above pedestal for a frame's u1 to still count as dark.",
+    )
+    p.add_argument(
+        "--max-std", type=float, default=20.0,
+        help="Max histogram std for a frame to still count as dark.",
+    )
+    p.add_argument(
+        "--discard-count", type=int, default=9,
+        help="Number of warmup frames the science pipeline discards.",
+    )
+    p.add_argument(
+        "--dark-interval", type=int, default=600,
+        help="Frames between scheduled darks (default 600 = 15 s @ 40 fps).",
+    )
+    p.add_argument(
+        "-q", "--quiet", action="store_true",
+        help="Only print failures and final summary.",
+    )
+    p.add_argument(
+        "--max-print", type=int, default=20,
+        help="Cap the number of failure lines printed (set to 0 for all).",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    thresholds = Thresholds(
+        pedestal=args.pedestal,
+        max_u1_above_pedestal=args.max_u1_above_pedestal,
+        max_std=args.max_std,
+        discard_count=args.discard_count,
+        dark_interval=args.dark_interval,
+    )
+
+    try:
+        total, fail_count, failures = check_file(args.csv_path, thresholds)
+    except FileNotFoundError:
+        print(f"ERROR: file not found: {args.csv_path}", file=sys.stderr)
+        return 1
+    except ValueError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 1
+
+    if not args.quiet:
+        print(
+            f"{args.csv_path}: checked {total} scheduled-dark rows "
+            f"(pedestal={thresholds.pedestal:.0f}, "
+            f"max_u1={thresholds.max_u1:.0f}, max_std={thresholds.max_std:.0f}, "
+            f"discard={thresholds.discard_count}, "
+            f"interval={thresholds.dark_interval})"
+        )
+
+    if not failures:
+        if not args.quiet:
+            print("OK: all scheduled dark frames look dark.")
+        return 0
+
+    print(f"FAIL: {fail_count}/{total} scheduled dark rows look bright:")
+    if args.max_print > 0:
+        for fs in failures[:args.max_print]:
+            print(_format_failure(fs))
+        if len(failures) > args.max_print:
+            print(f"  ... (+{len(failures) - args.max_print} more)")
+    else:
+        for fs in failures:
+            print(_format_failure(fs))
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/enter_dfu.py
+++ b/scripts/enter_dfu.py
@@ -6,15 +6,16 @@ Put a chosen MOTION device (console or left/right sensor) into DFU mode.
 
 Usage
 -----
-    python enter_dfu.py <device>
+    python enter_dfu.py <device> [--no-confirm] [--timeout SECONDS]
 
     device:  console | left | right
 """
 
 import argparse
 import sys
+import time
 
-from omotion.Interface import MOTIONInterface
+from omotion import MotionInterface
 
 
 def parse_cli() -> argparse.Namespace:
@@ -31,56 +32,69 @@ def parse_cli() -> argparse.Namespace:
         action="store_true",
         help="Skip the interactive confirmation before entering DFU mode.",
     )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=10.0,
+        help="Seconds to wait for the target device to connect (default: 10).",
+    )
     return parser.parse_args()
+
+
+def _wait_for_handle(handle, timeout: float) -> bool:
+    """Poll the specific handle until it reaches CONNECTED or timeout expires."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if handle.is_connected():
+            return True
+        time.sleep(0.1)
+    return handle.is_connected()
 
 
 def main() -> int:
     args = parse_cli()
 
-    print("[*] Acquiring MOTION interface …")
-    interface, console_connected, left_sensor, right_sensor = (
-        MOTIONInterface.acquire_motion_interface()
-    )
+    print("[*] Starting MOTION interface …")
+    interface = MotionInterface()
+    interface.start()
 
-    if args.device == "console":
-        if not console_connected:
-            print("❌  Console module not connected.")
-            return 1
-        target = interface.console_module
-        label = "console module"
-    elif args.device == "left":
-        if not left_sensor:
-            print("❌  Left sensor not connected.")
-            return 1
-        target = interface.sensors["left"]
-        label = "left sensor"
-    else:  # right
-        if not right_sensor:
-            print("❌  Right sensor not connected.")
-            return 1
-        target = interface.sensors["right"]
-        label = "right sensor"
-
-    if not args.no_confirm:
-        answer = input(
-            f"Do you want to put the {label} into DFU mode? (y/N): "
-        ).strip().lower()
-        if answer != "y":
-            print("Aborted.")
-            return 0
-
-    print(f"[+] Requesting DFU mode from {label} …")
     try:
-        ok = target.enter_dfu()
-    except Exception as exc:
-        print(f"   ❌  Exception: {exc}")
-        return 1
+        if args.device == "console":
+            target = interface.console
+            label = "console module"
+        elif args.device == "left":
+            target = interface.left
+            label = "left sensor"
+        else:  # right
+            target = interface.right
+            label = "right sensor"
 
-    if ok:
-        print("   ✅  DFU mode requested successfully. Device should re-enumerate as DFU.")
-        return 0
-    print("   ❌  Device did not report success.")
-    return 1
+        if not _wait_for_handle(target, args.timeout):
+            print(f"❌  {label} not connected (waited {args.timeout:.1f}s).")
+            return 1
+
+        if not args.no_confirm:
+            answer = input(
+                f"Do you want to put the {label} into DFU mode? (y/N): "
+            ).strip().lower()
+            if answer != "y":
+                print("Aborted.")
+                return 0
+
+        print(f"[+] Requesting DFU mode from {label} …")
+        try:
+            ok = target.enter_dfu()
+        except Exception as exc:
+            print(f"   ❌  Exception: {exc}")
+            return 1
+
+        if ok:
+            print("   ✅  DFU mode requested successfully. Device should re-enumerate as DFU.")
+            return 0
+        print("   ❌  Device did not report success.")
+        return 1
+    finally:
+        interface.stop()
 
 
 if __name__ == "__main__":

--- a/tests/test_comm_transport_down.py
+++ b/tests/test_comm_transport_down.py
@@ -1,0 +1,117 @@
+"""Unit tests for CommInterface transport-down cancellation.
+
+Verifies that when the USB read loop signals the transport is down
+(via the new ``_transport_down_evt``), any in-flight ``send_packet``
+call unblocks immediately instead of spinning for the full ``timeout``
+(which is 60 s for ``program_fpga`` / ``camera_configure_registers``
+and was the root cause of bloodflow-app#130 — power-cycle during a
+scan left the SDK's configure worker hung for 60 s, blocking the next
+scan attempt).
+"""
+
+import threading
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from omotion.CommInterface import CommInterface
+from omotion.config import OW_CMD, OW_CMD_NOP
+
+
+def _make_comm(*, async_mode: bool) -> CommInterface:
+    """Build a CommInterface bypassing claim() — dev is a MagicMock so
+    write() succeeds silently and the response stays absent."""
+    dev = MagicMock()
+    dev.write.return_value = 12
+    ci = CommInterface(dev, interface_index=0, desc="TEST", async_mode=async_mode)
+    ci.ep_out = MagicMock(bEndpointAddress=0x01)
+    ci.ep_in = MagicMock(bEndpointAddress=0x81, wMaxPacketSize=64)
+    return ci
+
+
+def test_async_send_unblocks_on_transport_down():
+    """A pending async send must raise within a few ms of the transport
+    flag being set, not wait for the full 60 s timeout."""
+    ci = _make_comm(async_mode=True)
+
+    box: dict = {}
+
+    def _do_send():
+        t0 = time.monotonic()
+        try:
+            ci.send_packet(
+                packetType=OW_CMD, command=OW_CMD_NOP, timeout=60,
+            )
+            box["result"] = "returned"
+        except ConnectionError as e:
+            box["err"] = e
+        box["elapsed"] = time.monotonic() - t0
+
+    t = threading.Thread(target=_do_send, daemon=True)
+    t.start()
+
+    # Let send_packet enter its wait loop.
+    time.sleep(0.05)
+    ci._transport_down_evt.set()
+
+    t.join(timeout=2.0)
+    assert not t.is_alive(), "send_packet did not unblock on transport_down"
+    assert "err" in box, f"expected ConnectionError, got: {box}"
+    assert box["elapsed"] < 1.0, (
+        f"send_packet took {box['elapsed']:.2f}s — should have unblocked "
+        "promptly on transport_down"
+    )
+
+
+def test_sync_send_unblocks_on_transport_down():
+    """Same guarantee for sync (non-async) mode."""
+    ci = _make_comm(async_mode=False)
+    ci.receive = MagicMock(return_value=b"")  # no data arriving
+
+    box: dict = {}
+
+    def _do_send():
+        t0 = time.monotonic()
+        try:
+            ci.send_packet(
+                packetType=OW_CMD, command=OW_CMD_NOP, timeout=60,
+            )
+            box["result"] = "returned"
+        except ConnectionError as e:
+            box["err"] = e
+        box["elapsed"] = time.monotonic() - t0
+
+    t = threading.Thread(target=_do_send, daemon=True)
+    t.start()
+
+    time.sleep(0.05)
+    ci._transport_down_evt.set()
+
+    t.join(timeout=2.0)
+    assert not t.is_alive(), "sync send_packet did not unblock on transport_down"
+    assert "err" in box, f"expected ConnectionError, got: {box}"
+    assert box["elapsed"] < 1.0, (
+        f"sync send_packet took {box['elapsed']:.2f}s — should have unblocked "
+        "promptly on transport_down"
+    )
+
+
+def test_start_read_thread_clears_transport_down():
+    """Restarting the read thread (e.g. after reconnect) must clear the
+    transport-down flag so subsequent sends are not poisoned."""
+    ci = _make_comm(async_mode=True)
+    ci._transport_down_evt.set()
+
+    # Avoid spawning a real read thread (no real dev to read from); patch
+    # the loop to exit immediately so start_read_thread just runs the
+    # bookkeeping (clearing stop_event + transport_down_evt).
+    ci._read_loop = lambda: None
+    ci.start_read_thread()
+
+    # Let the (no-op) read thread finish before we assert.
+    if ci.read_thread is not None:
+        ci.read_thread.join(timeout=1.0)
+    assert not ci._transport_down_evt.is_set(), (
+        "_transport_down_evt should be cleared when read thread (re)starts"
+    )

--- a/tests/test_dark_integrity.py
+++ b/tests/test_dark_integrity.py
@@ -58,17 +58,17 @@ def _drive_through_first_dark(pipeline: SciencePipeline, dark_mean: float, dark_
 
 
 def test_dark_integrity_passes_for_real_dark():
-    """A frame whose u1 ≈ pedestal and std ≈ 5 should pass the integrity
-    check. No warnings produced."""
+    """A frame whose u1 ≈ pedestal should pass the integrity check
+    regardless of std. No warnings produced."""
     p = _make_pipeline()
     _drive_through_first_dark(p, dark_mean=PEDESTAL_HEIGHT, dark_std=5.0)
     assert p.dark_integrity_warnings == []
 
 
 def test_dark_integrity_flags_light_frame_in_dark_slot():
-    """A frame at the 'first dark' position whose u1 is high and std is
-    high (i.e. a real light frame, the firmware off-by-one symptom)
-    must produce a warning."""
+    """A frame at the 'first dark' position whose u1 is high (i.e. a
+    real light frame, the firmware off-by-one symptom) must produce a
+    warning."""
     p = _make_pipeline()
     _drive_through_first_dark(p, dark_mean=200.0, dark_std=40.0)
     warnings = p.dark_integrity_warnings
@@ -87,9 +87,10 @@ def test_dark_integrity_flags_high_u1_only():
     assert len(p.dark_integrity_warnings) >= 1
 
 
-def test_dark_integrity_flags_high_std_only():
-    """Frame with pedestal-ish u1 but unexpectedly high std (light leak,
-    speckle pattern) should flag."""
+def test_dark_integrity_ignores_high_std_when_u1_is_pedestal():
+    """High std alone must NOT flag the frame — std is too noisy a
+    signal across the scan (warms up over time on fw 1.5.3). The u1
+    bound is the sole criterion."""
     p = _make_pipeline()
     _drive_through_first_dark(p, dark_mean=PEDESTAL_HEIGHT, dark_std=30.0)
-    assert len(p.dark_integrity_warnings) >= 1
+    assert p.dark_integrity_warnings == []

--- a/tests/test_pedestal_height.py
+++ b/tests/test_pedestal_height.py
@@ -1,0 +1,109 @@
+"""
+Unit tests for sensor firmware version parsing used by pedestal selection.
+
+These exercise the pure helper ``_parse_firmware_version`` so they do not
+require any connected hardware.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import omotion.MotionProcessing as _mp
+from omotion.MotionSensor import MotionSensor, _parse_firmware_version
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        # Plain release-style versions
+        ("v1.5.2", (1, 5, 2)),
+        ("1.5.2", (1, 5, 2)),
+        ("v1.5.3", (1, 5, 3)),
+        ("1.5.4", (1, 5, 4)),
+        # Pre-release / dev suffixes (the original bug)
+        ("1.5.4-dev", (1, 5, 4)),
+        ("v1.5.4-dev", (1, 5, 4)),
+        ("1.5.4-dev.0", (1, 5, 4)),
+        ("1.5.4-rc.1", (1, 5, 4)),
+        # git-describe output: <tag>-<n>-g<sha>[-dirty]
+        ("1.5.4-5-g1234abc", (1, 5, 4)),
+        ("1.5.4-dev.0-5-g1234abc", (1, 5, 4)),
+        ("1.5.4-dirty", (1, 5, 4)),
+        ("1.5.4-5-g1234abc-dirty", (1, 5, 4)),
+        # Build-metadata form (+build.N)
+        ("1.5.4+build.7", (1, 5, 4)),
+    ],
+)
+def test_parse_firmware_version_valid(raw, expected):
+    assert _parse_firmware_version(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "",
+        "unknown",
+        "v",
+        "vunknown",
+        "not-a-version",
+        None,
+    ],
+)
+def test_parse_firmware_version_invalid(raw):
+    """Strings with no leading numeric component must raise ValueError."""
+    with pytest.raises((ValueError, TypeError)):
+        _parse_firmware_version(raw)
+
+
+def _make_sensor_stub(version: str) -> MotionSensor:
+    """Construct a MotionSensor without going through __init__/USB enumeration."""
+    s = MotionSensor.__new__(MotionSensor)
+    s.get_version = MagicMock(return_value=version)
+    return s
+
+
+@pytest.mark.parametrize(
+    "version, expected_pedestal",
+    [
+        ("v1.5.1", 64.0),
+        ("v1.5.2", 64.0),
+        ("v1.5.3", 128.0),
+        ("v1.5.4", 128.0),
+        # Regression: dev / git-describe builds were silently leaving the
+        # module-level default of 64 in place. Anything that parses as
+        # >(1,5,2) must select 128.
+        ("1.5.4-dev", 128.0),
+        ("1.5.4-dev.0-5-g1234abc", 128.0),
+        ("1.5.4-dirty", 128.0),
+        ("v2.0.0", 128.0),
+    ],
+)
+def test_refresh_pedestal_height_selects_correct_value(version, expected_pedestal):
+    saved = _mp.PEDESTAL_HEIGHT
+    try:
+        _mp.PEDESTAL_HEIGHT = -1.0  # poison value so we can see whether it was set
+        sensor = _make_sensor_stub(version)
+        sensor._refresh_pedestal_height()
+        assert _mp.PEDESTAL_HEIGHT == expected_pedestal, (
+            f"version={version!r} expected pedestal {expected_pedestal} "
+            f"but got {_mp.PEDESTAL_HEIGHT}"
+        )
+    finally:
+        _mp.PEDESTAL_HEIGHT = saved
+
+
+def test_refresh_pedestal_height_unknown_version_keeps_default(caplog):
+    """Unparseable versions must leave PEDESTAL_HEIGHT untouched and warn."""
+    saved = _mp.PEDESTAL_HEIGHT
+    try:
+        _mp.PEDESTAL_HEIGHT = 99.0
+        sensor = _make_sensor_stub("unknown")
+        with caplog.at_level("WARNING"):
+            sensor._refresh_pedestal_height()
+        assert _mp.PEDESTAL_HEIGHT == 99.0
+        assert any(
+            "pedestal" in rec.message.lower() for rec in caplog.records
+        ), "expected a warning mentioning pedestal selection"
+    finally:
+        _mp.PEDESTAL_HEIGHT = saved


### PR DESCRIPTION
## Summary

Promotes `next` to `main` per the release policy in `docs/Releasing.md`
(#54). 9 commits since the last next->main promotion (#48).

### Calibration / processing
- fix(sdk): stop aborting calibration on dark-integrity warnings (4fc9139)
- fix(sdk): drop std check from dark-integrity detector; warn on u1 only (#51)
- chore(scripts): add standalone dark-frame schedule integrity checker (`scripts/check_dark_schedule.py`)

### Transport / DFU
- fix(sdk): cancel in-flight sends when USB transport drops (a41da93)
- fix(sdk): parse sensor firmware versions with non-numeric suffixes (13338c4)
- fix: enter-DFU script fix (8794e57, merged via 4463378)

### Docs
- docs: document SDK tag format and branch workflow (#52)
- docs: require next->main PR before tagging; ban suffixed tags (#54)

### Diffstat
```
11 files changed, 774 insertions(+), 91 deletions(-)
```
New tests: `test_comm_transport_down.py`, `test_pedestal_height.py`.

## After merge
Per `docs/Releasing.md`, tag the merge commit on `main` with `X.Y.Z`
(stable, no suffix) to trigger `release-build.yml` -> GitHub Release ->
`publish-pypi.yml` -> PyPI.

## Test plan
- [ ] Tag the merge commit on `main` (probably `1.6.2`) and let CI build the wheel
- [ ] Spot-check calibration on hardware against right + left sensors
- [ ] Confirm enter-DFU script works against a sensor module
- [ ] Verify dark-integrity warnings surface in logs without aborting
- [ ] Confirm PyPI publish succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)