### PR TITLE
Per-frame telemetry stamping returns (pdc/tcm/tcl)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Three-tier API: facade → device wrapper → transport.
 | Transport | `omotion/StreamInterface.py` | 382 | USB bulk streaming (sensor IF 1 = histo, IF 2 = IMU). Daemon reader thread per endpoint. |
 | Workflow | `omotion/ScanWorkflow.py` | 1110 | Full acquisition orchestration. Owns hardware bring-up + lifecycle; feeds frames into the pipeline. |
 | Workflow | `omotion/CalibrationWorkflow.py` | 1643 | Per-camera gain / I_max calibration. |
-| **Science** | `omotion/pipeline/` | — | **Stage-based BFI/BVI pipeline** (`sources`, stages in `pipeline.py`, `sinks`, `runner`, `factory`, `pedestal`, `batch`, `tee`). **The science lives here.** Full reference: `docs/SciencePipeline.md`. |
+| **Science** | `omotion/pipeline/` | — | **Stage-based BFI/BVI pipeline** (`sources`, stages in `pipeline.py`, `sinks`, `runner`, `factory`, `pedestal`, `batch`, `tee`, `telemetry`). **The science lives here.** Full reference: `docs/SciencePipeline.md`. |
 | Science | `omotion/MotionProcessing.py` | 730 | Wire-level histogram packet **parsing only** — a thin shim feeding the pipeline. (BFI/BVI moved to `omotion/pipeline/`; this module is slated to dissolve eventually.) |
 | Config | `omotion/config.py` | 291 | VID/PID, baud, packet types, command opcodes, `DEBUG_FLAG_*` bits. Single source of truth. |
 | Programming | `omotion/FPGAProgrammer.py` | 567 | Page-by-page Lattice XO2 flash. |

--- a/docs/SciencePipeline.md
+++ b/docs/SciencePipeline.md
@@ -17,10 +17,11 @@ A scan is driven by a `ScanRunner` (`omotion/pipeline/runner.py`). It pulls `Fra
 ```
 ┌────────────┐   FrameBatch  ┌─────────────────────────────────────────┐
 │   Source   ├──────────────►│           Pipeline (Stage list)         │
-│ (live USB, │  N frames per │ Classify → Tee(raw) → TimestampRepair → │
-│ CSV)       │  batch        │ NoiseFloor → Moments → PedestalSub →    │
-└────────────┘               │ DarkCorrection → ShotNoise → BfiBvi →   │
-                             │ DarkFrameHold → SideAvg → Tee(live)     │
+│ (live USB, │  N frames per │ Classify → TelemetryIngest* → Tee(raw) →│
+│ CSV)       │  batch        │ TimestampRepair → NoiseFloor → Moments →│
+└────────────┘               │ PedestalSub → DarkCorrection →          │
+                             │ ShotNoise → BfiBvi → DarkFrameHold →    │
+                             │ SideAvg → Tee(live)                     │
                              └──────────────┬──────────────────────────┘
                                             │ batch.events (LiveEmit /
                                             │ IntervalClosed / diagnostics)
@@ -38,9 +39,9 @@ A scan is driven by a `ScanRunner` (`omotion/pipeline/runner.py`). It pulls `Fra
                                   live/final plot sinks, …)
 ```
 
-(Console telemetry is currently handled *outside* the pipeline: a listener on
-the legacy `ConsoleTelemetryPoller` thread writes the per-scan telemetry CSV —
-see §9. The per-frame telemetry fields on `FrameBatch` are reserved.)
+(*TelemetryIngest is present when a `TelemetryAggregator` is wired — every
+live scan with a running console telemetry poller. The poller also feeds the
+per-scan telemetry CSV via a separate listener, outside the pipeline. See §9.)
 
 The pipeline is **pure transformation**: stages mutate a typed `FrameBatch` dataclass in place and append events to `batch.events`. They never perform I/O. All side effects — file writes, UI emission, DB inserts — happen in sinks downstream of the runner.
 
@@ -65,9 +66,9 @@ Three things characterise this design and make it auditable:
 | `raw_histograms` | `(N, 2, 8, 1024)` uint32 | Source (parse) | Raw 1024-bin histogram per side × cam; mutated in place by NoiseFloorStage |
 | `temperature_c` | `(N, 2, 8)` float32 | Source (parse) | Sensor-reported temperature |
 | `timestamp_s` | `(N,)` float64 | Source (parse) | Sensor timestamp; normalised to scan start by `_BaseSource` |
-| `pdc` | `(N,)` float32 \| None | **Reserved** (always None today) | Mean PDC reading (mA) at the frame's timestamp — per-frame telemetry stamping was removed and is planned to return (§9) |
-| `tcm` | `(N,)` int64 \| None | **Reserved** (always None today) | MCU trigger counter (lsync pulses) |
-| `tcl` | `(N,)` int64 \| None | **Reserved** (always None today) | Laser trigger counter |
+| `pdc` | `(N,)` float32 \| None | TelemetryIngestStage (or replay source) | PDC reading (mA) at the frame's capture time; NaN before the first telemetry sample; None when no aggregator is wired |
+| `tcm` | `(N,)` int64 \| None | TelemetryIngestStage (or replay source) | MCU trigger counter (lsync pulses) |
+| `tcl` | `(N,)` int64 \| None | TelemetryIngestStage (or replay source) | Laser trigger counter |
 | `abs_frame_ids` | `(N,)` int64 | FrameClassificationStage | Monotonic unwrapped frame counter |
 | `frame_type` | `(N,)` `<U8` | FrameClassificationStage | One of `"warmup"`, `"dark"`, `"light"`, `"stale"` |
 | `mean_raw` | `(N, 2, 8)` float32 | MomentsStage | First moment μ₁ of raw histogram (NaN where count == 0) |
@@ -120,6 +121,7 @@ The full chain assembled by `default_pipeline()` is:
 
 ```
 FrameClassificationStage
+TelemetryIngestStage                                       # when telemetry wired
 Tee("raw", emit_if_any=ft != "stale", max_duration_s=…)   # conditional
 TimestampRepairStage
 NoiseFloorStage
@@ -181,17 +183,27 @@ A `delta > 128` (apparent large backward jump) is treated as a packet anomaly an
 
 Under the defaults, dark frames occur at `n = 10, 601, 1201, 1801, …`. Every other frame with `n > d` is `"light"`.
 
-### 5.2 Per-frame telemetry — RESERVED (not currently in the pipeline)
+### 5.2 TelemetryIngestStage
 
-There is no telemetry stage today. A `TelemetryIngestStage` that stamped each
-frame with `pdc`/`tcm`/`tcl` from a `TelemetryAggregator` existed and was
-removed (commit `9a2d8e0`, "drop telemetry stage/source/sink for now"); it is
-**planned to return**. Until then:
+**File:** `omotion/pipeline/telemetry.py`. **Writes:** `pdc`, `tcm`, `tcl`.
+Present only when `default_pipeline(telemetry=...)` receives a
+`TelemetryAggregator` (every live scan with a running console telemetry
+poller; omitted for replays and tests).
 
-- `FrameBatch.pdc` / `tcm` / `tcl` are always `None`.
-- The raw CSV's `tcm,tcl,pdc` columns are always blank (the schema keeps them
-  so old and new files stay column-compatible).
-- The per-scan telemetry CSV is written *outside* the pipeline — see §9.
+Stamps each frame with the most recent `TelemetrySample` at-or-before the
+frame's capture time: `pdc[i]` (photodiode current, mA), `tcm[i]` (MCU
+trigger count), `tcl[i]` (laser trigger count). Frames before the first
+sample get `pdc = NaN`, `tcm = tcl = 0` — the CSV writers render those as
+blank cells.
+
+**Clock bridging.** Frame timestamps are sensor-firmware clock normalised
+to scan start; telemetry samples carry host `time.time()`. The stage
+captures `wall_offset = time.time() − first_frame_ts` on its first
+non-empty batch — alignment error is bounded by the source's flush
+latency (~0.25 s), comfortably inside the poller's ~10 Hz cadence.
+
+`reset()` re-anchors the offset but deliberately does **not** clear the
+aggregator — telemetry history is owned by the scan, not the pipeline pass.
 
 ### 5.3 Tee("raw")
 
@@ -554,7 +566,7 @@ The runner calls `on_scan_start(metadata)` on every sink before the first batch,
 
 Writes the two legacy CSV families. File creation is lazy on first `consume()`.
 
-- **Raw CSV** — one file per side, named `{scan_id}_{subject_id}_{side}_mask{XX}_raw.csv`. Schema: `cam_id, frame_id, timestamp_s, type, 0..1023, temperature, sum, tcm, tcl, pdc`. Each frame's `type` column is the `frame_type` written by FrameClassificationStage (`"warmup" | "dark" | "light" | "stale"`). Telemetry columns (`tcm`, `tcl`, `pdc`) are **always blank today** — per-frame telemetry stamping is reserved (§5.2/§9); the columns stay so old and new files are column-compatible.
+- **Raw CSV** — one file per side, named `{scan_id}_{subject_id}_{side}_mask{XX}_raw.csv`. Schema: `cam_id, frame_id, timestamp_s, type, 0..1023, temperature, sum, tcm, tcl, pdc`. Each frame's `type` column is the `frame_type` written by FrameClassificationStage (`"warmup" | "dark" | "light" | "stale"`). Telemetry columns (`tcm`, `tcl`, `pdc`) carry TelemetryIngestStage's per-frame stamps (§5.2); cells are blank when no telemetry sample preceded the frame or no aggregator was wired (replays of pre-telemetry scans stay column-compatible).
 - **Corrected CSV** — one file per scan, named `{scan_id}_corrected.csv`.
   - **Normal mode** (82 columns): `frame_id, timestamp_s, {bfi,bvi,mean,contrast,temp}_{l,r}{1..8}`. Per-frame rows are accumulated in `_corrected_acc` until every expected `(side, cam)` slot has contributed a `mean`; only then is the row written.
   - **Reduced mode** (6 columns): `frame_id, timestamp_s, bfi_left, bfi_right, bvi_left, bvi_right`. Each `EnrichedCorrectedFrame` writes into the row's `bfi_{side}`/`bvi_{side}` slot based on `frame.side`; a row is flushed once both expected sides have contributed (or only one, if the other's camera mask is zero).
@@ -625,25 +637,30 @@ Sink-authoring rules:
 
 ---
 
-## 9. Telemetry — current state and reservation
+## 9. Telemetry
 
-**Per-frame telemetry stamping is currently absent from the pipeline.** The
-`TelemetryIngestStage` / `TelemetryAggregator` / `ConsoleTelemetrySource` /
-`TelemetrySink` subsystem was removed in commit `9a2d8e0` ("drop telemetry
-stage/source/sink for now") and is **planned to return**. The reserved
-surface that remains:
+Two independent telemetry paths exist, both fed by the long-lived
+`ConsoleTelemetryPoller` daemon thread (~10 Hz; see
+[`ConsoleTelemetry.md`](ConsoleTelemetry.md)) via per-scan listeners that
+`ScanWorkflow` registers at scan start and removes in the worker's
+`finally`:
 
-- `FrameBatch.pdc` / `tcm` / `tcl` fields — always `None`.
-- The raw CSV's `tcm,tcl,pdc` columns — always blank.
+- **Per-frame stamping (in the pipeline)** — `omotion/pipeline/telemetry.py`.
+  A `TelemetryFeeder` listener converts each snapshot to a
+  `TelemetrySample(timestamp_s, pdc_ma, tcm, tcl)` and pushes it into a
+  per-scan `TelemetryAggregator` (thread-safe ring buffer, default 256
+  entries ≈ 25 s). `TelemetryIngestStage` (§5.2) queries
+  `snapshot_at(t)` per frame and stamps `batch.pdc/tcm/tcl`, which flow
+  into the raw CSV's `tcm,tcl,pdc` columns. `CsvReplaySource` reads those
+  columns back, so replays carry the recorded telemetry without needing a
+  live aggregator.
+- **Telemetry CSV (outside the pipeline)** — the `_TelemetryCsvWriter`
+  listener writes one row per snapshot to
+  `{scan_id}_{subject_id}_telemetry.csv` (full snapshot: TEC, PDU,
+  safety, counters). Not a pipeline sink; no channel.
 
-What runs today instead: `ScanWorkflow` registers a `_TelemetryCsvWriter`
-listener on the legacy `ConsoleTelemetryPoller` daemon thread for the
-duration of each scan, writing one row per ~10 Hz snapshot to
-`{scan_id}_{subject_id}_telemetry.csv` (columns: `timestamp_s,
-pdc_samples_ma, tec_setpoint_c, tec_actual_c, tec_setpoint_raw,
-tec_actual_raw, tcm, tcl, safety_status`). This path bypasses the pipeline
-entirely — it is not a pipeline sink and has no channel. See
-[`ConsoleTelemetry.md`](ConsoleTelemetry.md) for the poller itself.
+The aggregator and the CSV writer are independent listeners; closing one
+does not affect the other.
 
 ---
 
@@ -652,7 +669,7 @@ entirely — it is not a pipeline sink and has no channel. See
 | Thread | Owner | Lifecycle | Purpose |
 |---|---|---|---|
 | `LiveUsbSource-{left,right}` | `LiveUsbSource` | per scan, daemon | Per-side packet parsing → FrameBatch → shared batch queue |
-| `ConsoleTelemetryPoller` | `MotionConsole.telemetry` | long-lived, daemon | ~10 Hz console telemetry snapshots; `_TelemetryCsvWriter` listener writes the per-scan telemetry CSV (outside the pipeline, §9) |
+| `ConsoleTelemetryPoller` | `MotionConsole.telemetry` | long-lived, daemon | ~10 Hz console telemetry snapshots; per-scan listeners feed the `TelemetryAggregator` (per-frame stamping, §5.2) and the telemetry CSV writer (§9) |
 | Runner thread (`ScanWorkflow._worker`) | `ScanWorkflow` | per scan, non-daemon | Iterate the source, call `pipeline.process(batch)`, dispatch events to sinks |
 
 The pipeline stages and all pipeline sinks run **on the runner thread** — there is no cross-thread interaction inside the pipeline itself.
@@ -705,6 +722,7 @@ Both consumers are pure sinks — they add no pipeline stages, do not modify Fra
 | `_FRAME_ROLLOVER_THRESHOLD` | 128 | `FrameClassificationStage` | Max forward delta before rollover is detected |
 | `batch_size_frames` | 10 (live) / 100 (replay) | `LiveUsbSource` / `CsvReplaySource` | N frames per FrameBatch |
 | `flush_interval_s` | 0.25 | `LiveUsbSource` | Time-based flush so partial batches don't stall the live UI |
+| `TelemetryAggregator` ring size | 256 (≈25 s at ~10 Hz) | `omotion/pipeline/telemetry.py` | Telemetry samples retained for per-frame stamping |
 
 ---
 

--- a/omotion/ScanWorkflow.py
+++ b/omotion/ScanWorkflow.py
@@ -423,6 +423,25 @@ class ScanWorkflow:
             right=_safe_pedestal(self._interface.right),
         )
 
+        # ── Per-frame telemetry stamping ──────────────────────────────────
+        # When the console's telemetry poller is running, feed its snapshots
+        # into a per-scan aggregator and insert TelemetryIngestStage so every
+        # frame (including the raw CSV record) carries pdc/tcm/tcl context.
+        # The feeder is a poller listener (same pattern as the telemetry CSV
+        # writer below) — no extra thread; unregistered in _worker's finally.
+        telemetry_feeder = None
+        telemetry_aggregator = None
+        _poller = getattr(getattr(self._interface, "console", None), "telemetry", None)
+        if _poller is not None:
+            try:
+                from omotion.pipeline.telemetry import TelemetryAggregator, TelemetryFeeder
+                telemetry_aggregator = TelemetryAggregator()
+                telemetry_feeder = TelemetryFeeder(telemetry_aggregator, _poller)
+            except Exception:
+                logger.exception("failed to wire per-frame telemetry; continuing without")
+                telemetry_aggregator = None
+                telemetry_feeder = None
+
         # ── Build pipeline ────────────────────────────────────────────────
         calibration = self._calibration
         pipeline = default_pipeline(
@@ -430,6 +449,7 @@ class ScanWorkflow:
             calibration=calibration,
             pedestals=pedestals,
             raw_save_max_duration_s=request.raw_save_max_duration_s,
+            telemetry=telemetry_aggregator,
         )
 
         # ── Auto-inject default sinks ──────────────────────────────────────
@@ -689,6 +709,8 @@ class ScanWorkflow:
             finally:
                 if telemetry_writer is not None:
                     telemetry_writer.close()
+                if telemetry_feeder is not None:
+                    telemetry_feeder.close()
                 with self._lock:
                     self._running = False
                     self._thread = None

--- a/omotion/pipeline/__init__.py
+++ b/omotion/pipeline/__init__.py
@@ -37,6 +37,9 @@ from .factory import default_pipeline
 from .pedestal import SensorPedestals
 from .sinks import Sink, ScanMetadata, CsvSink, ScanDBSink, DiagnosticsLogSink
 from .sources import Source, LiveUsbSource, CsvReplaySource
+from .telemetry import (
+    TelemetryAggregator, TelemetryFeeder, TelemetryIngestStage, TelemetrySample,
+)
 
 
 __all__ = [
@@ -50,4 +53,6 @@ __all__ = [
     "Sink", "ScanMetadata",
     "CsvSink", "ScanDBSink", "DiagnosticsLogSink",
     "Source", "LiveUsbSource", "CsvReplaySource",
+    "TelemetryAggregator", "TelemetryFeeder", "TelemetryIngestStage",
+    "TelemetrySample",
 ]

--- a/omotion/pipeline/factory.py
+++ b/omotion/pipeline/factory.py
@@ -33,13 +33,19 @@ def default_pipeline(*,
                      discard_count: int = 9,
                      dark_interval: int = 600,
                      realtime_dark_history_size: int = 4,
-                     raw_save_max_duration_s: Optional[float] = None) -> Pipeline:
+                     raw_save_max_duration_s: Optional[float] = None,
+                     telemetry: Optional[Any] = None) -> Pipeline:
     """Build the canonical pipeline. See SciencePipeline.md for the algorithm.
 
     Args:
         raw_save_max_duration_s: If provided and > 0, includes Tee("raw") with
             max_duration_s set. If 0 or negative, omits the raw tee. If None
             (default), includes unbounded raw tee.
+        telemetry: Optional TelemetryAggregator. When provided, a
+            TelemetryIngestStage is inserted after classification (before the
+            raw tee) so every frame — including the raw CSV record — carries
+            the pdc/tcm/tcl context at its capture time. None (default)
+            omits the stage (replay sources, tests, no console telemetry).
     """
 
     not_warmup_or_stale = lambda ft: ft != "warmup" and ft != "stale"
@@ -47,6 +53,10 @@ def default_pipeline(*,
     stages: list = [
         FrameClassificationStage(discard_count=discard_count, dark_interval=dark_interval),
     ]
+
+    if telemetry is not None:
+        from .telemetry import TelemetryIngestStage
+        stages.append(TelemetryIngestStage(telemetry))
 
     # Conditionally add raw tee based on raw_save_max_duration_s.
     # snapshot=True: the raw tee runs before TimestampRepair/NoiseFloor,

--- a/omotion/pipeline/sources.py
+++ b/omotion/pipeline/sources.py
@@ -129,11 +129,27 @@ class CsvReplaySource(_BaseSource):
 
         raw_hist = np.zeros((n, 2, 8, 1024), dtype=np.uint32)
         temp_arr = np.zeros((n, 2, 8), dtype=np.float32)
+        # Recorded telemetry context (blank cells on scans captured without
+        # console telemetry → NaN / 0, matching TelemetryIngestStage's
+        # no-sample convention). Carried through so a replay's raw CSV is
+        # column-faithful to the original.
+        pdc = np.full(n, np.nan, dtype=np.float32)
+        tcm = np.zeros(n, dtype=np.int64)
+        tcl = np.zeros(n, dtype=np.int64)
         for i, row in enumerate(rows):
             cam = int(row["cam_id"])
             for b in range(1024):
                 raw_hist[i, side_idx, cam, b] = int(row[str(b)])
             temp_arr[i, side_idx, cam] = float(row["temperature"])
+            v = row.get("pdc")
+            if v:
+                pdc[i] = float(v)
+            v = row.get("tcm")
+            if v:
+                tcm[i] = int(float(v))
+            v = row.get("tcl")
+            if v:
+                tcl[i] = int(float(v))
 
         return FrameBatch(
             cam_ids=cam_ids,
@@ -142,7 +158,7 @@ class CsvReplaySource(_BaseSource):
             raw_histograms=raw_hist,
             temperature_c=temp_arr,
             timestamp_s=timestamp_s,
-            pdc=None, tcm=None, tcl=None,
+            pdc=pdc, tcm=tcm, tcl=tcl,
         )
 
 

--- a/omotion/pipeline/telemetry.py
+++ b/omotion/pipeline/telemetry.py
@@ -1,0 +1,168 @@
+"""Per-frame console telemetry stamping.
+
+Restores the per-frame ``pdc`` / ``tcm`` / ``tcl`` stamping that was removed
+in 9a2d8e0 ("drop telemetry stage/source/sink for now"). Three pieces:
+
+- ``TelemetrySample`` — one (wall-clock timestamp, pdc, tcm, tcl) tuple.
+- ``TelemetryAggregator`` — thread-safe ring buffer. ``update()`` is called
+  from the ConsoleTelemetryPoller thread (via the feeder listener that
+  ScanWorkflow registers for the duration of a scan); ``snapshot_at()`` is
+  called from the pipeline/runner thread by TelemetryIngestStage.
+- ``TelemetryIngestStage`` — stamps each frame with the most recent
+  telemetry sample at-or-before the frame's capture time.
+
+Clock domains: frame timestamps are sensor-firmware clock normalised to
+scan start (t=0 at the first frame); telemetry samples carry host
+``time.time()``. The stage bridges the two by capturing
+``wall_offset = time.time() - first_frame_ts`` when it sees its first
+non-empty batch — the batch is processed within one source flush interval
+(~0.25 s) of capture, so the alignment error is bounded by that latency.
+Telemetry is ~10 Hz context data (laser power, trigger counters), so
+sub-poll-interval alignment is not required.
+
+When no aggregator is supplied (replay sources, tests), the stage is a
+no-op and ``FrameBatch.pdc/tcm/tcl`` keep whatever the source set.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from collections import deque
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+import numpy as np
+
+from .batch import FrameBatch
+
+logger = logging.getLogger("openmotion.sdk.pipeline.telemetry")
+
+_DEFAULT_RING_SIZE = 256   # ~25 s of history at the poller's ~10 Hz
+
+
+@dataclass(frozen=True)
+class TelemetrySample:
+    """One console-telemetry observation, host wall-clock stamped."""
+    timestamp_s: float   # host time.time() when the poll completed
+    pdc_ma: float        # photodiode current, mA
+    tcm: int             # MCU trigger (lsync) count
+    tcl: int             # laser trigger count
+
+
+class TelemetryAggregator:
+    """Thread-safe ring buffer of TelemetrySamples.
+
+    ``update()`` runs on the poller thread; ``snapshot_at()`` on the
+    runner thread. Owned by ScanWorkflow (one per scan) — the ingest
+    stage deliberately does NOT clear it on reset(), so telemetry history
+    survives a dropped batch.
+    """
+
+    def __init__(self, maxlen: int = _DEFAULT_RING_SIZE) -> None:
+        self._lock = threading.Lock()
+        self._samples: deque[TelemetrySample] = deque(maxlen=max(2, int(maxlen)))
+
+    def update(self, sample: TelemetrySample) -> None:
+        with self._lock:
+            self._samples.append(sample)
+
+    def snapshot_at(self, t_wall: float) -> Optional[TelemetrySample]:
+        """Most recent sample with ``timestamp_s <= t_wall``, else None.
+
+        Scans from the newest end — frames query near-now, so the hit is
+        almost always within the first couple of entries.
+        """
+        with self._lock:
+            for sample in reversed(self._samples):
+                if sample.timestamp_s <= t_wall:
+                    return sample
+        return None
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._samples)
+
+
+class TelemetryFeeder:
+    """ConsoleTelemetryPoller listener → TelemetryAggregator adapter.
+
+    Registered by ScanWorkflow for the duration of one scan (same pattern
+    as the telemetry CSV writer). Runs on the poller thread — must stay
+    non-blocking. ``close()`` unregisters; safe to call twice.
+    """
+
+    def __init__(self, aggregator: TelemetryAggregator, poller) -> None:
+        self._aggregator = aggregator
+        self._poller = poller
+        poller.add_listener(self)
+
+    def __call__(self, snap) -> None:
+        try:
+            self._aggregator.update(TelemetrySample(
+                timestamp_s=float(snap.timestamp),
+                pdc_ma=float(snap.pdc),
+                tcm=int(snap.tcm),
+                tcl=int(snap.tcl),
+            ))
+        except Exception:
+            logger.exception("telemetry feeder failed to ingest snapshot")
+
+    def close(self) -> None:
+        try:
+            self._poller.remove_listener(self)
+        except Exception:
+            pass
+
+
+class TelemetryIngestStage:
+    """Stamp each frame with the telemetry context at its capture time.
+
+    Writes ``batch.pdc`` (float32, NaN when no sample), ``batch.tcm`` and
+    ``batch.tcl`` (int64, 0 when no sample). Placed right after
+    FrameClassificationStage and BEFORE Tee("raw"), so the raw CSV's
+    telemetry columns carry the stamped values.
+
+    ``reset()`` clears the wall-clock offset (a new scan re-anchors) but
+    deliberately does NOT clear the aggregator — telemetry history is
+    owned by the scan, not the pipeline pass.
+    """
+
+    name = "telemetry_ingest"
+
+    def __init__(self, aggregator: Optional[TelemetryAggregator] = None, *,
+                 now: Callable[[], float] = time.time) -> None:
+        self._aggregator = aggregator
+        self._now = now            # injectable for tests
+        self._wall_offset: Optional[float] = None
+
+    def process(self, batch: FrameBatch) -> FrameBatch:
+        agg = self._aggregator
+        if agg is None:
+            return batch
+        n = batch.timestamp_s.shape[0] if batch.timestamp_s is not None else 0
+        if n == 0:
+            return batch
+
+        if self._wall_offset is None:
+            # First non-empty batch: anchor scan-relative frame time to the
+            # host clock. Error is bounded by the source's flush latency.
+            self._wall_offset = self._now() - float(batch.timestamp_s[0])
+
+        pdc = np.full(n, np.nan, dtype=np.float32)
+        tcm = np.zeros(n, dtype=np.int64)
+        tcl = np.zeros(n, dtype=np.int64)
+        for i in range(n):
+            sample = agg.snapshot_at(float(batch.timestamp_s[i]) + self._wall_offset)
+            if sample is not None:
+                pdc[i] = sample.pdc_ma
+                tcm[i] = sample.tcm
+                tcl[i] = sample.tcl
+        batch.pdc = pdc
+        batch.tcm = tcm
+        batch.tcl = tcl
+        return batch
+
+    def reset(self) -> None:
+        self._wall_offset = None

--- a/tests/test_pipeline/test_public_api.py
+++ b/tests/test_pipeline/test_public_api.py
@@ -14,6 +14,8 @@ def test_public_api_symbols_importable() -> None:
         Source, LiveUsbSource, CsvReplaySource,
         Sink, ScanMetadata,
         CsvSink, ScanDBSink, DiagnosticsLogSink,
+        TelemetryAggregator, TelemetryFeeder, TelemetryIngestStage,
+        TelemetrySample,
         Tee, default_pipeline,
         SensorPedestals,
     )
@@ -24,6 +26,8 @@ def test_public_api_symbols_importable() -> None:
         ScanRunner, CriticalSinkError,
         Source, LiveUsbSource, CsvReplaySource,
         Sink, ScanMetadata, CsvSink, ScanDBSink, DiagnosticsLogSink,
+        TelemetryAggregator, TelemetryFeeder, TelemetryIngestStage,
+        TelemetrySample,
         Tee, default_pipeline, SensorPedestals,
     ):
         assert sym is not None
@@ -44,6 +48,8 @@ def test_public_api_all_list_complete() -> None:
         "Sink", "ScanMetadata",
         "CsvSink", "ScanDBSink", "DiagnosticsLogSink",
         "Source", "LiveUsbSource", "CsvReplaySource",
+        "TelemetryAggregator", "TelemetryFeeder", "TelemetryIngestStage",
+        "TelemetrySample",
     }
 
     assert set(pkg.__all__) == expected

--- a/tests/test_pipeline/test_telemetry_ingest.py
+++ b/tests/test_pipeline/test_telemetry_ingest.py
@@ -1,0 +1,218 @@
+"""Per-frame telemetry stamping — TelemetryAggregator / Feeder / IngestStage."""
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from omotion.pipeline.batch import FrameBatch
+from omotion.pipeline.telemetry import (
+    TelemetryAggregator,
+    TelemetryFeeder,
+    TelemetryIngestStage,
+    TelemetrySample,
+)
+
+
+def _batch(timestamps):
+    n = len(timestamps)
+    return FrameBatch(
+        cam_ids=np.zeros(n, dtype=np.int8),
+        frame_ids=np.arange(n, dtype=np.uint8),
+        side_ids=np.zeros(n, dtype=np.int8),
+        raw_histograms=np.zeros((n, 2, 8, 1024), dtype=np.uint32),
+        temperature_c=np.zeros((n, 2, 8), dtype=np.float32),
+        timestamp_s=np.array(timestamps, dtype=np.float64),
+        pdc=None, tcm=None, tcl=None,
+    )
+
+
+# ── TelemetryAggregator ─────────────────────────────────────────────────────
+
+def test_aggregator_empty_returns_none():
+    agg = TelemetryAggregator()
+    assert agg.snapshot_at(1000.0) is None
+
+
+def test_aggregator_returns_most_recent_at_or_before():
+    agg = TelemetryAggregator()
+    agg.update(TelemetrySample(timestamp_s=10.0, pdc_ma=1.0, tcm=100, tcl=50))
+    agg.update(TelemetrySample(timestamp_s=10.1, pdc_ma=2.0, tcm=104, tcl=52))
+    agg.update(TelemetrySample(timestamp_s=10.2, pdc_ma=3.0, tcm=108, tcl=54))
+
+    assert agg.snapshot_at(10.15).pdc_ma == pytest.approx(2.0)
+    assert agg.snapshot_at(10.2).pdc_ma == pytest.approx(3.0)   # inclusive
+    assert agg.snapshot_at(99.0).pdc_ma == pytest.approx(3.0)
+    assert agg.snapshot_at(9.9) is None                          # all in future
+
+
+def test_aggregator_ring_bound():
+    agg = TelemetryAggregator(maxlen=3)
+    for i in range(10):
+        agg.update(TelemetrySample(timestamp_s=float(i), pdc_ma=float(i), tcm=i, tcl=i))
+    assert len(agg) == 3
+    assert agg.snapshot_at(100.0).pdc_ma == pytest.approx(9.0)
+    # Oldest entries were evicted.
+    assert agg.snapshot_at(5.0) is None
+
+
+# ── TelemetryIngestStage ────────────────────────────────────────────────────
+
+def test_stage_stamps_pdc_tcm_tcl_via_wall_offset():
+    """Frame times are scan-relative; aggregator samples are wall-clock.
+    The stage anchors the offset on its first batch using the injected
+    clock, then stamps each frame with the sample at-or-before its
+    capture time."""
+    agg = TelemetryAggregator()
+    wall0 = 1000.0
+    agg.update(TelemetrySample(timestamp_s=wall0 - 0.05, pdc_ma=1.5, tcm=10, tcl=5))
+    agg.update(TelemetrySample(timestamp_s=wall0 + 0.10, pdc_ma=2.5, tcm=14, tcl=7))
+
+    # Injected clock: "now" is wall0, and the first frame is at t=0.0 →
+    # wall_offset = wall0.
+    stage = TelemetryIngestStage(agg, now=lambda: wall0)
+    batch = _batch([0.0, 0.05, 0.15])
+    stage.process(batch)
+
+    assert batch.pdc[0] == pytest.approx(1.5)   # wall0 + 0.00 → first sample
+    assert batch.pdc[1] == pytest.approx(1.5)   # wall0 + 0.05 → still first
+    assert batch.pdc[2] == pytest.approx(2.5)   # wall0 + 0.15 → second
+    assert list(batch.tcm) == [10, 10, 14]
+    assert list(batch.tcl) == [5, 5, 7]
+
+
+def test_stage_nan_before_first_sample():
+    agg = TelemetryAggregator()
+    agg.update(TelemetrySample(timestamp_s=2000.0, pdc_ma=9.0, tcm=1, tcl=1))
+    stage = TelemetryIngestStage(agg, now=lambda: 1000.0)   # samples all in future
+    batch = _batch([0.0, 0.025])
+    stage.process(batch)
+    assert np.isnan(batch.pdc).all()
+    assert list(batch.tcm) == [0, 0]
+    assert list(batch.tcl) == [0, 0]
+
+
+def test_stage_without_aggregator_is_noop():
+    stage = TelemetryIngestStage(None)
+    batch = _batch([0.0, 0.025])
+    stage.process(batch)
+    assert batch.pdc is None and batch.tcm is None and batch.tcl is None
+
+
+def test_stage_reset_reanchors_offset_but_keeps_aggregator():
+    agg = TelemetryAggregator()
+    agg.update(TelemetrySample(timestamp_s=1000.0, pdc_ma=4.0, tcm=2, tcl=1))
+    clock = {"now": 1000.0}
+    stage = TelemetryIngestStage(agg, now=lambda: clock["now"])
+    stage.process(_batch([0.0]))
+    stage.reset()
+    # Aggregator history survives reset; the offset re-anchors on the
+    # next batch using the (advanced) clock.
+    clock["now"] = 1010.0
+    batch = _batch([10.0])   # scan-relative 10 s → wall 1010 + (10-10) ...
+    stage.process(batch)
+    assert batch.pdc[0] == pytest.approx(4.0)
+    assert len(agg) == 1
+
+
+# ── TelemetryFeeder ─────────────────────────────────────────────────────────
+
+class _FakePoller:
+    def __init__(self):
+        self.listeners = []
+
+    def add_listener(self, fn):
+        self.listeners.append(fn)
+
+    def remove_listener(self, fn):
+        self.listeners.remove(fn)
+
+
+def test_feeder_registers_converts_and_unregisters():
+    agg = TelemetryAggregator()
+    poller = _FakePoller()
+    feeder = TelemetryFeeder(agg, poller)
+    assert poller.listeners == [feeder]
+
+    snap = SimpleNamespace(timestamp=1234.5, pdc=3.25, tcm=400, tcl=200)
+    for listener in poller.listeners:
+        listener(snap)
+    sample = agg.snapshot_at(1234.5)
+    assert sample == TelemetrySample(timestamp_s=1234.5, pdc_ma=3.25, tcm=400, tcl=200)
+
+    feeder.close()
+    assert poller.listeners == []
+    feeder.close()   # idempotent
+
+
+def test_feeder_swallows_bad_snapshots():
+    agg = TelemetryAggregator()
+    poller = _FakePoller()
+    feeder = TelemetryFeeder(agg, poller)
+    feeder(SimpleNamespace())   # missing fields — must not raise
+    assert len(agg) == 0
+    feeder.close()
+
+
+# ── Factory wiring ──────────────────────────────────────────────────────────
+
+def _factory_pipeline(telemetry=None):
+    from omotion.pipeline.factory import default_pipeline
+    from omotion.pipeline.pedestal import SensorPedestals
+    from omotion.pipeline.sinks import ScanMetadata
+
+    class _Cal:
+        c_min = np.zeros((2, 8)); c_max = np.ones((2, 8))
+        i_min = np.zeros((2, 8)); i_max = np.ones((2, 8))
+
+    meta = ScanMetadata(
+        scan_id="t", subject_id="s", operator="o",
+        started_at_iso="2026-06-10T00:00:00Z", duration_sec=10,
+        left_camera_mask=0x01, right_camera_mask=0, reduced_mode=False,
+    )
+    return default_pipeline(metadata=meta, calibration=_Cal(),
+                            pedestals=SensorPedestals(left=64.0, right=64.0),
+                            telemetry=telemetry)
+
+
+def test_factory_omits_telemetry_stage_by_default():
+    names = [s.name for s in _factory_pipeline().stages]
+    assert "telemetry_ingest" not in names
+
+
+def test_factory_inserts_telemetry_stage_before_raw_tee():
+    names = [s.name for s in _factory_pipeline(telemetry=TelemetryAggregator()).stages]
+    assert "telemetry_ingest" in names
+    # Must run before the raw tee so the raw CSV carries the stamps.
+    assert names.index("telemetry_ingest") < names.index("tee:raw")
+    assert names.index("frame_classification") < names.index("telemetry_ingest")
+
+
+# ── CsvReplaySource roundtrip ───────────────────────────────────────────────
+
+def test_csv_replay_carries_recorded_telemetry(tmp_path):
+    from omotion.pipeline.sources import CsvReplaySource
+    from omotion.pipeline.sinks import ScanMetadata
+
+    bins = ",".join("0" for _ in range(1024))
+    header = "cam_id,frame_id,timestamp_s,type," + \
+        ",".join(str(b) for b in range(1024)) + ",temperature,sum,tcm,tcl,pdc"
+    rows = [
+        f"0,1,0.025,light,{bins},27.0,0,400,200,3.25",
+        f"0,2,0.050,light,{bins},27.0,0,,,",   # blank cells → no telemetry
+    ]
+    path = tmp_path / "replay_raw.csv"
+    path.write_text(header + "\n" + "\n".join(rows) + "\n", encoding="utf-8")
+
+    meta = ScanMetadata(
+        scan_id="r", subject_id="s", operator="o",
+        started_at_iso="2026-06-10T00:00:00Z", duration_sec=10,
+        left_camera_mask=0x01, right_camera_mask=0, reduced_mode=False,
+    )
+    src = CsvReplaySource(raw_csv_left=path, raw_csv_right=None,
+                          batch_size_frames=10, metadata=meta)
+    batch = next(iter(src))
+    assert batch.pdc[0] == pytest.approx(3.25)
+    assert np.isnan(batch.pdc[1])
+    assert list(batch.tcm) == [400, 0]
+    assert list(batch.tcl) == [200, 0]


### PR DESCRIPTION
## What changed

Per-frame telemetry stamping (`pdc` / `tcm` / `tcl`) returns to the pipeline, filling the `FrameBatch` fields and raw-CSV columns that have been reserved-and-blank since 9a2d8e0 ("drop telemetry stage/source/sink for now").

- **`omotion/pipeline/telemetry.py`** — `TelemetrySample`, `TelemetryAggregator` (thread-safe ring buffer, 256 entries ≈ 25 s at the poller's ~10 Hz), `TelemetryFeeder` (a `ConsoleTelemetryPoller` listener, same pattern as the telemetry CSV writer — no new thread), and `TelemetryIngestStage`.
- **Clock bridging is self-contained**: frame timestamps are firmware-clock normalised to scan start; telemetry samples carry host `time.time()`. The stage anchors `wall_offset = now − first_frame_ts` on its first batch — alignment error is bounded by the source flush latency (~0.25 s), well inside the 10 Hz telemetry cadence. `reset()` re-anchors but never clears the aggregator.
- **`default_pipeline(telemetry=...)`** inserts the stage after classification and **before `Tee("raw")`**, so the raw CSV record carries the stamps. Omitted when no aggregator is wired (replays, tests) — stage list unchanged for existing callers.
- **`ScanWorkflow`** wires the aggregator + feeder per scan when the console poller is running; the feeder is unregistered in the worker's `finally`.
- **`CsvReplaySource`** reads the `tcm,tcl,pdc` columns back into the batch, so replayed raw CSVs stay column-faithful to the original (blank cells → NaN/0, matching the stage's no-sample convention).
- SciencePipeline.md §§1, 2.1, 3, 5.2, 8.1, 9, 10, 12 un-reserved and rewritten to the implemented architecture.

## Verification

- 238 software tests green, including 12 new ones (aggregator semantics, wall-offset stamping, no-op without aggregator, reset behavior, feeder register/convert/unregister + bad-snapshot tolerance, factory placement before the raw tee, CSV replay round-trip).
- **Hardware-verified on the bench**: a 12 s dual-sensor scan fills `tcm` on every raw row (0 → 429, tracking the frame sync) and `pdc` on ~85% of rows — the blanks are exactly the frames before the poller's first sample. Terminal stop frame stayed at INFO (no regression from #67's exemption).

## Reviewer notes

- `tcm/tcl = 0` means "no sample yet" (matches the pre-removal convention); `pdc` uses NaN → blank cell, which is unambiguous.
- The telemetry CSV path (`_TelemetryCsvWriter`) is untouched — the two poller listeners are independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
