### PR TITLE
fix(logging): demote chatty connect/scan log lines to their right levels

### DIFF
--- a/omotion/CommInterface.py
+++ b/omotion/CommInterface.py
@@ -373,7 +373,10 @@ class CommInterface(USBInterfaceBase):
                 except Exception:
                     _text = ""
                 if _text:
-                    logger.warning("[%s PRINTF] %s", self.desc, _text)
+                    # Firmware debug printf passthrough — an informational
+                    # relay of the MCU's own messages, not a host-side
+                    # warning condition.
+                    logger.info("[%s PRINTF] %s", self.desc, _text)
                 else:
                     logger.warning("[%s] MCU echo: data=%s", self.desc, _raw.hex() if _raw else "")
             else:

--- a/omotion/MotionConsole.py
+++ b/omotion/MotionConsole.py
@@ -451,7 +451,9 @@ class MotionConsole(SignalWrapper):
                     ver = "v0.0.0"
             else:
                 ver = "v0.0.0"
-            logger.info(ver)
+            # Bare version at DEBUG — callers (log_console_info) compose
+            # the INFO "Console: firmware=... hw_id=..." line.
+            logger.debug(ver)
             return ver
         except ValueError as v:
             logger.error("ValueError: %s", v)
@@ -1602,7 +1604,7 @@ class MotionConsole(SignalWrapper):
                 return 0
             elif r.data_len == 4:
                 tec_voltage = struct.unpack("<f", r.data)[0]
-                logger.info(f"TEC Voltage is {tec_voltage} V")
+                logger.info("TEC Voltage is %.3f V", tec_voltage)
                 return tec_voltage
 
         except ValueError as v:

--- a/omotion/laser.py
+++ b/omotion/laser.py
@@ -171,7 +171,7 @@ def apply_laser_power(
             data_to_send = bytearray(laser_param["dataToSend"])
 
             if (channel, offset) in skip_entries:
-                logger.info(
+                logger.debug(
                     "Skipping JSON entry ch=%d off=0x%02X (overridden by user config)",
                     channel, offset,
                 )
@@ -196,7 +196,7 @@ def apply_laser_power(
                         friendly_name, e,
                     )
 
-            logger.info(
+            logger.debug(
                 "(%d/%d) Writing I2C: muxIdx=%d, channel=%d, i2cAddr=0x%02X, "
                 "offset=0x%02X, data=%s",
                 idx, len(laser_params), mux_idx, channel, i2c_addr, offset,


### PR DESCRIPTION
Log-noise fixes found by reviewing a bloodflow-app bench log (2026-06-10 run), companion to openmotion-bloodflow-app#161:

- **CommInterface**: firmware printf passthrough was logged at WARNING — ordinary MCU chatter (`Enabled Power for Camera N`, `Scan started`, `already done` ×16 per scan teardown) drowning out real warnings. Now INFO.
- **laser**: the 18 per-register `(n/18) Writing I2C` lines + `Skipping JSON entry` lines → DEBUG (the `Setting laser power…` / `Laser power set successfully.` bookends stay at INFO). These now fire on every console connect since the app applies laser power at connect time.
- **MotionConsole.get_version**: bare version string at INFO duplicated the composed `Console: firmware=… hw_id=…` line one line later → DEBUG.
- **MotionConsole.tec_voltage**: readback formatted `%.3f` instead of raw float repr (`-0.07000000029802322 V`).

Verification: `py_compile` clean; 56 targeted software tests pass (timestamp-repair caplog tests, console telemetry unit, pedestal height, scan DB); no test asserts on the changed message levels; exercised live on bench hardware alongside the app changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)