### PR TITLE
test(pipeline): skip LiveUsbSource smoke test gracefully without hardware

### DIFF
--- a/tests/test_pipeline/test_sources.py
+++ b/tests/test_pipeline/test_sources.py
@@ -203,34 +203,35 @@ def test_live_usb_source_reader_loop_builds_batches_from_packet_queue(monkeypatc
 
 
 @pytest.mark.sensor
-def test_live_usb_source_smoke_yields_framebatches():
-    """Hardware-marked smoke test — requires a connected sensor."""
-    from omotion import MotionInterface
+def test_live_usb_source_smoke_yields_framebatches(console, sensor_left):
+    """Hardware-marked smoke test — requires a connected sensor.
+
+    Uses the session ``console``/``sensor_left`` fixtures so it skips
+    gracefully on a rig with no sensor attached. Passing an unconnected
+    ``motion.left`` handle (whose ``uart`` is still None) straight into
+    LiveUsbSource would crash in __iter__ at ``sensor.uart.histo`` — the
+    source legitimately assumes it only ever sees connected handles, so the
+    presence gate belongs here in the test, matching every other HIL test."""
     from omotion.pipeline.sources import LiveUsbSource
     from omotion.pipeline.sinks import ScanMetadata
 
-    motion = MotionInterface(data_dir=None, scan_db_path=None, operator_id="test")
-    motion.start()
-    try:
-        meta = ScanMetadata(
-            scan_id="smoke", subject_id="x", operator="test",
-            started_at_iso="2026-05-22T00:00:00Z", duration_sec=2,
-            left_camera_mask=0xFF, right_camera_mask=0, reduced_mode=False,
-        )
-        src = LiveUsbSource(
-            console=motion.console, left=motion.left, right=motion.right,
-            batch_size_frames=10, metadata=meta,
-        )
-        batches_seen = 0
-        for batch in src:
-            batches_seen += 1
-            assert batch.raw_histograms.shape[-1] == 1024
-            if batches_seen >= 3:
-                src.close()
-                break
-        assert batches_seen >= 1
-    finally:
-        motion.stop()
+    meta = ScanMetadata(
+        scan_id="smoke", subject_id="x", operator="test",
+        started_at_iso="2026-05-22T00:00:00Z", duration_sec=2,
+        left_camera_mask=0xFF, right_camera_mask=0, reduced_mode=False,
+    )
+    src = LiveUsbSource(
+        console=console, left=sensor_left, right=None,
+        batch_size_frames=10, metadata=meta,
+    )
+    batches_seen = 0
+    for batch in src:
+        batches_seen += 1
+        assert batch.raw_histograms.shape[-1] == 1024
+        if batches_seen >= 3:
+            src.close()
+            break
+    assert batches_seen >= 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
@
## Problem

`tests/test_pipeline/test_sources.py::test_live_usb_source_smoke_yields_framebatches` fails on a clean checkout (no hardware) with:

```
omotion/pipeline/sources.py:202: in __iter__
    sensor.uart.histo.start_streaming(...)
AttributeError: 'NoneType' object has no attribute 'histo'
```

## Root cause

This is a `@pytest.mark.sensor` HIL test, but it hand-rolled its own `MotionInterface()` + `start()` and passed `motion.left`/`motion.right` straight into `LiveUsbSource` **without gating on connection**. On a rig with no sensor, `motion.left` is a *non-None* handle whose `.uart` is still `None`. `LiveUsbSource._packet_queues` includes any side where `sensor is not None`, so `__iter__` then dereferences `sensor.uart.histo` and crashes instead of skipping.

The source is correct as written — it legitimately assumes it only ever receives *connected* handles. Guarding the source against a missing `uart` would just mask a test feeding it an unconnected handle. The presence gate belongs in the test. (The mock test `test_live_usb_source_reader_loop_builds_batches_from_packet_queue` already has a proper `uart`→`histo` namespace and was never affected.)

## Fix

Rewrite the smoke test to depend on the existing session `console`/`sensor_left` fixtures from `tests/conftest.py`, which already `pytest.skip` when hardware is absent — the same convention every other HIL test follows (e.g. `test_facade_connects_to_full_rig`). Pass `right=None` since the test only exercises the left side (`right_camera_mask=0`).

## Verification

`pytest tests/test_pipeline/test_sources.py` on a no-hardware box:

```
11 passed, 1 skipped
SKIPPED [1] tests/test_pipeline/test_sources.py:205: Console module not connected
```

Previously: `1 failed, 11 passed`. The smoke test now skips gracefully off-rig and still runs against connected handles on a real rig.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@