### PR TITLE
fix: suppress realtime BFI/BVI for dark-like light frames (live display railed at scan end)

### DIFF
--- a/omotion/pipeline/stages/dark.py
+++ b/omotion/pipeline/stages/dark.py
@@ -467,9 +467,25 @@ class DarkCorrectionStage:
                         self._emit_interval((side, cam_id), interval, batch.events)
 
             else:  # light
-                pred = self._realtime.predict(
-                    side, cam_id, history=self._history, target_t=t,
-                )
+                # Dark-like "light" frame — the laser was actually off; most
+                # commonly the firmware's terminal laser-off frame at scan
+                # stop, which never falls on a scheduled dark position so the
+                # classifier types it "light". Realtime dark subtraction
+                # would emit a near-zero mean and a garbage contrast that
+                # rails the live BFI/BVI display, so suppress realtime
+                # emission (row stays NaN) and keep _last_realtime on the
+                # last genuine light. Same threshold as the on_scan_stop tail
+                # detection, which still needs the frame buffered below for
+                # the batch path.
+                pedestal = (self._pedestals.left if side == "left"
+                            else self._pedestals.right)
+                dark_like = u1 <= pedestal + self._guard.max_above_pedestal
+
+                pred = None
+                if not dark_like:
+                    pred = self._realtime.predict(
+                        side, cam_id, history=self._history, target_t=t,
+                    )
                 if pred is not None:
                     u1_hat, std_hat = pred
                     baseline_rt[i, side_idx, cam_id] = np.float32(u1_hat)
@@ -492,12 +508,15 @@ class DarkCorrectionStage:
                         float(std_dc_rt[i, side_idx, cam_id]),
                     )
 
-                    pi = self._pending.get((side, cam_id))
-                    if pi is not None:
-                        u2 = std ** 2 + u1 ** 2
-                        q = str(batch.quality[i]) if batch.quality is not None else "ok"
-                        pi.add_light(abs_frame_id=abs_id, t=t, u1=u1, u2=u2,
-                                     quality=q)
+                # Buffer for the batch path even when realtime emission was
+                # suppressed (dark-like frame) — the terminal flush finds the
+                # dark-like tail in the pending light list.
+                pi = self._pending.get((side, cam_id))
+                if pi is not None:
+                    u2 = std ** 2 + u1 ** 2
+                    q = str(batch.quality[i]) if batch.quality is not None else "ok"
+                    pi.add_light(abs_frame_id=abs_id, t=t, u1=u1, u2=u2,
+                                 quality=q)
 
         batch.dark_baseline_rt = baseline_rt
         batch.mean_dc_rt = mean_dc_rt

--- a/tests/test_pipeline/test_dark_correction_stage.py
+++ b/tests/test_pipeline/test_dark_correction_stage.py
@@ -89,6 +89,36 @@ def test_realtime_dark_frame_reuses_previous_live_corrected_values():
     assert batch.dark_baseline_rt[2, 0, 0] == pytest.approx(batch.dark_baseline_rt[1, 0, 0])
 
 
+def test_dark_like_light_frame_suppresses_realtime_emission():
+    """The firmware-guaranteed terminal laser-off frame is positionally
+    classified as "light" (it doesn't fall on a scheduled dark position).
+    Dark-subtracting it realtime yields a near-zero mean and a garbage
+    contrast that rails the live BFI/BVI display at scan end. A light frame
+    whose u1 is within the dark-integrity threshold (pedestal +
+    max_above_pedestal) must not emit realtime values — NaN, the established
+    "no valid realtime sample" convention.
+    """
+    # dark@10 (u1=65), genuine light@11 (u1=500), laser-off frame@12 typed
+    # "light" but dark-like (u1=66 <= pedestal 64 + guard 5).
+    mean = np.array([[65.0], [500.0], [66.0]], dtype=np.float32).reshape(3, 1, 1) * np.ones((1, 2, 8))
+    std  = np.array([[10.0], [20.0], [11.0]], dtype=np.float32).reshape(3, 1, 1) * np.ones((1, 2, 8))
+    batch = _batch(3, ["dark", "light", "light"], [10, 11, 12],
+                   mean_raw=mean.astype(np.float32), std_raw=std.astype(np.float32))
+
+    stage = DarkCorrectionStage(
+        realtime_estimator=HybridRealtimePredictor(),
+        batch_estimator=LinearInterpolation(),
+    )
+    stage.process(batch)
+
+    # Genuine light frame emits normally: 500 - 65 = 435.
+    assert batch.mean_dc_rt[1, 0, 0] == pytest.approx(435.0)
+    # Dark-like light frame must not emit realtime values.
+    assert np.isnan(batch.mean_dc_rt[2, 0, 0])
+    assert np.isnan(batch.std_dc_rt[2, 0, 0])
+    assert np.isnan(batch.dark_baseline_rt[2, 0, 0])
+
+
 def test_emits_corrected_interval():
     """DarkCorrectionStage emits raw CorrectedInterval (enrichment is done
     by downstream stages ShotNoiseCorrectionStage and BfiBviStage)."""


### PR DESCRIPTION
## Problem

At the last frame of a scan, the live BFI/BVI display often hits the 0/10 clamp rails in the bloodflow app.

Root cause: the firmware-guaranteed terminal laser-off frame at scan stop never falls on a scheduled dark position, so `FrameClassificationStage` (positional-only) types it `"light"`. The realtime path then dark-subtracts a black image — near-zero `mean_dc_rt`, blown-up `contrast_sn_rt` — and `BfiBviStage` maps that far outside [0, 10]. Evidence from a real scan export (20-second scan, last two frames):

| frame | mean (typical cam) | contrast | BFI | BVI |
|---|---|---|---|---|
| 861 | ~47–94 | ~0.36–0.56 | −0.1 to 0.3 | 4.3–6.0 |
| 862 (terminal) | 0.006–0.09 | 9.7 to 932 | −25,000 to 10 | ~9.999 |

The **batch** path already handles this content-based (`on_scan_stop` strips the dark-like tail by `u1 <= pedestal + guard`); the **realtime** path had no equivalent net.

## Fix

In `DarkCorrectionStage.process`, a `"light"` frame whose `u1` is within the dark-integrity threshold (same check as the terminal flush) no longer emits realtime values — the row keeps NaN, the established "no valid realtime sample" convention that `_LivePlotSink` and downstream consumers already skip — and no longer updates `_last_realtime`. The frame is still buffered into the pending interval, which the terminal flush depends on.

Side benefit: zero-filled dropout rows (`u1 = 0`) previously emitted a garbage negative realtime mean; they're now suppressed too.

Deliberately **not** done: timing-based classification of the terminal frame (its ~151 ms arrival gap is shared with mid-scan EMI deviations and multi-frame drops, and is only decidable retrospectively — see `_is_terminal_artifact` in `timestamp_repair.py`, which already uses it in the one place it's safe).

## Testing

- New test `test_dark_like_light_frame_suppresses_realtime_emission` (written first, failed on the exact garbage value from the bug).
- `tests/test_pipeline` (excl. benchmarks): 247 passed, 1 failed — `test_live_usb_source_smoke_yields_framebatches`, hardware-dependent (no free sensor on the bench), fails before any pipeline stage runs.
- Top-level unit tests (excl. `tests/hardware`): 328 passed, 2 failed — `test_console.py` TEC voltage / telemetry listener, console hardware state, unrelated.
- Terminal-flush, golden-replay, determinism, and EFT-regression tests all pass, confirming the batch path still receives the buffered dark-like tail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
