### PR TITLE
fix(pipeline): anchor live t0 per side, not shared across sensors

### DIFF
--- a/omotion/pipeline/sources.py
+++ b/omotion/pipeline/sources.py
@@ -14,6 +14,7 @@ import logging
 import queue
 import threading
 import time
+from functools import partial
 from pathlib import Path
 from typing import Any, Iterator, Optional, Protocol, runtime_checkable
 
@@ -43,6 +44,7 @@ class _BaseSource:
         self.metadata = metadata
         self._normalize_timestamps = normalize_timestamps
         self._t0: Optional[float] = None
+        self._t0_by_side: dict[str, float] = {}
 
     def _apply_timestamp_normalization(self, timestamp_s: np.ndarray) -> np.ndarray:
         """Subtract the first observed timestamp so scans always start at t=0.
@@ -51,9 +53,11 @@ class _BaseSource:
         batches in the same scan. Thread-safety is not a concern here because
         sources are consumed by a single thread.
 
-        Replay sources (CSV, DB) use this array-based form. LiveUsbSource
-        receives samples one at a time and uses ``_t0_normalize`` below
-        instead; both share ``self._t0`` so whichever fires first sets it.
+        Replay sources (CSV, DB) use this array-based form: a recording's
+        timestamps already share one coherent timebase (they were normalized
+        when recorded), so one shared zero is correct there. LiveUsbSource
+        uses the per-SIDE ``_t0_normalize`` below instead — deliberately NOT
+        shared with this method's ``self._t0``.
         """
         if not self._normalize_timestamps:
             return timestamp_s
@@ -64,17 +68,30 @@ class _BaseSource:
                 return timestamp_s
         return timestamp_s - self._t0
 
-    def _t0_normalize(self, ts: float) -> float:
-        """Scalar version of ``_apply_timestamp_normalization`` for callbacks
-        that fire per-sample (e.g. ``parse_histogram_stream`` in
-        LiveUsbSource). Shares ``self._t0`` with the array form so the first
-        sample seen by either path sets the per-scan zero.
+    def _t0_normalize(self, side_name: str, ts: float) -> float:
+        """Per-SIDE scalar normalization for callbacks that fire per-sample
+        (``parse_histogram_stream`` in LiveUsbSource). Each side anchors its
+        own zero at its first sample.
+
+        Frame timestamps are each sensor's since-boot firmware clock (TIM5),
+        and the two sensors boot independently — one shared zero (the old
+        behavior: whichever side's first sample arrived set it) left the
+        later-booted side offset by the whole boot-time difference. Bench
+        repro 2026-06-11: sensors booted ~83 s apart put one side's entire
+        live trace outside the plot window while its numeric readouts kept
+        updating. Both sides start streaming within milliseconds of scan
+        start, so per-side anchoring is what actually aligns the sides.
+
+        Called concurrently from the two per-side reader threads; safe
+        because each thread only ever touches its own dict key.
         """
         if not self._normalize_timestamps:
             return ts
-        if self._t0 is None:
-            self._t0 = float(ts)
-        return float(ts) - self._t0
+        t0 = self._t0_by_side.get(side_name)
+        if t0 is None:
+            t0 = float(ts)
+            self._t0_by_side[side_name] = t0
+        return float(ts) - t0
 
     def close(self) -> None:
         pass
@@ -348,7 +365,7 @@ class LiveUsbSource(_BaseSource):
             self._packet_queues[side_name], self._stop, buf,
             on_row_fn=on_row,
             expected_row_sum=EXPECTED_HISTOGRAM_SUM,
-            t0_normalizer=self._t0_normalize,
+            t0_normalizer=partial(self._t0_normalize, side_name),
         )
         # Flush any remaining samples after parse_histogram_stream returns
         if accumulated:

--- a/tests/test_pipeline/test_sources.py
+++ b/tests/test_pipeline/test_sources.py
@@ -293,3 +293,100 @@ def test_csv_replay_no_normalization_when_disabled(tmp_path):
     )
     batches = list(src)
     assert batches[0].timestamp_s[0] == pytest.approx(630.915)
+
+
+def test_t0_normalize_anchors_each_side_independently():
+    """The scalar (live-path) normalizer must anchor each side at its OWN
+    first sample. Frame timestamps are each sensor's since-boot firmware
+    clock, and the sensors boot independently — here the right sensor
+    booted ~83 s before the left (bench repro, 2026-06-11)."""
+    class _Sub(_BaseSource):
+        def __iter__(self): yield from []
+
+    src = _Sub(metadata=_meta())
+    assert src._t0_normalize("left", 100.000) == pytest.approx(0.0)
+    assert src._t0_normalize("right", 8283.000) == pytest.approx(0.0)
+    assert src._t0_normalize("left", 100.025) == pytest.approx(0.025)
+    assert src._t0_normalize("right", 8283.025) == pytest.approx(0.025)
+
+
+def test_t0_normalize_passthrough_when_disabled():
+    """normalize_timestamps=False preserves raw firmware timestamps in the
+    scalar (live-path) form, same as the array form."""
+    class _Sub(_BaseSource):
+        def __iter__(self): yield from []
+
+    src = _Sub(metadata=_meta(), normalize_timestamps=False)
+    assert src._t0_normalize("left", 630.915) == pytest.approx(630.915)
+    assert src._t0_normalize("right", 8283.000) == pytest.approx(8283.000)
+
+
+def test_live_usb_reader_loops_anchor_t0_per_side(monkeypatch):
+    """Two sensors with divergent since-boot clocks must each anchor their
+    own t=0. A single shared t0 (whichever side's first sample wins) leaves
+    the other side offset by the boot-time difference, and the live plot
+    prunes that side to empty (bench repro 2026-06-11: left 0.2-12.8 s vs
+    right 82.9-95.5 s within the same scan)."""
+
+    class _FakeSensor:
+        class _FakeStream:
+            def start_streaming(self, q, expected_size):
+                pass
+            def stop_streaming(self):
+                pass
+            def drain_final(self, expected_size):
+                return []
+        class _FakeUart:
+            def __init__(self, stream):
+                self.histo = stream
+        def __init__(self):
+            self.uart = self._FakeUart(self._FakeStream())
+
+    src = LiveUsbSource(
+        console=None, left=_FakeSensor(), right=_FakeSensor(),
+        batch_size_frames=10, metadata=_meta(),
+    )
+
+    # Absolute firmware clocks: right booted ~82.6 s before left.
+    clock_base = {"left": 100.0, "right": 8283.0}
+
+    def _fake_parse_histogram_stream(q, stop_evt, buf, *, on_row_fn=None,
+                                     expected_row_sum=None, t0_normalizer=None):
+        side = next(s for s, sq in src._packet_queues.items() if sq is q)
+        base = clock_base[side]
+        for i in range(15):
+            ts = base + 0.025 * i
+            # Same call the real parser makes before firing on_row_fn.
+            if t0_normalizer is not None:
+                ts = t0_normalizer(ts)
+            if on_row_fn is not None:
+                on_row_fn(0, i + 1, ts,
+                          np.ones(1024, dtype=np.uint32), 1024, 27.0)
+        return 15
+
+    monkeypatch.setattr(
+        "omotion.MotionProcessing.parse_histogram_stream",
+        _fake_parse_histogram_stream,
+    )
+
+    # 15 samples per side at batch_size=10 → 2 batches per side (10 + 5).
+    batches = []
+    for batch in src:
+        batches.append(batch)
+        if len(batches) >= 4:
+            src.close()
+            break
+
+    seen_sides = set()
+    for b in batches:
+        seen_sides.add(int(b.side_ids[0]))
+        # Every side's samples must sit on its own near-zero time axis.
+        assert float(b.timestamp_s.min()) >= 0.0, (
+            f"side {int(b.side_ids[0])} timestamps below its own zero: "
+            f"{b.timestamp_s[:3]}"
+        )
+        assert float(b.timestamp_s.max()) <= 1.0, (
+            f"side {int(b.side_ids[0])} timestamps not anchored at its own "
+            f"zero: {b.timestamp_s[:3]}"
+        )
+    assert seen_sides == {0, 1}


### PR DESCRIPTION
## Problem

In the live bloodflow app (reduced mode), the left plot drew no trace while its numeric readouts kept updating in real time. Bench repro 2026-06-11, scan DB sessions 69/70: left side-average samples at 0.2-12.8 s, right at 82.9-95.5 s **within the same scan** - an ~83 s skew.

Root cause: frame timestamps are each sensor's since-boot firmware clock (TIM5), and the two sensors boot independently. `LiveUsbSource` normalized both sides against a **single shared `_t0`** set by whichever side's first sample arrived first, leaving the later-booted side offset by the whole boot-time difference. The plot's visible window tracks the max timestamp across all buffers, so the lagging side is pruned to empty; the numeric readouts use `value_at()` (nearest sample, no window check), so they keep ticking - which is exactly the confusing symptom observed.

This went unnoticed because bench power-cycling reboots both sensors together, keeping their clocks within ~50 ms (raw CSVs from earlier scans show left 0.000 vs right 0.044). Once one sensor rebooted alone, every scan reproduced. The skew also persists into the scan DB, so replays of affected sessions are misaligned too.

## Fix

`_t0_normalize` (the scalar, live-path normalizer) now anchors **per side**: each side's first sample sets that side's own zero. Both sides start streaming within milliseconds of scan start, so per-side anchoring is what actually aligns the sides - the old behavior only looked aligned when both sensors happened to boot simultaneously.

The array-based normalization used by replay sources (CSV/DB) keeps the shared zero: a recording's timestamps already share one coherent timebase from when they were recorded.

## Tests (TDD - all three watched failing first)

- `test_t0_normalize_anchors_each_side_independently` - scalar normalizer anchors each side at its own first sample
- `test_t0_normalize_passthrough_when_disabled` - `normalize_timestamps=False` still passes raw timestamps through
- `test_live_usb_reader_loops_anchor_t0_per_side` - wiring test through both `_reader_loop` threads with divergent boot clocks (~82.6 s apart, mirroring the bench); under the old shared t0 it fails with side-1 timestamps at ~8183 s

`tests/test_pipeline/test_sources.py`: 14 passed (sensor-marked smoke test excluded).

## Notes for review/test

- Quick bench check: with the two sensors booted at different times (power-cycle one but not the other), start a reduced-mode scan - both side traces should now draw; before this fix the later-booted side's plot is empty.
- Scan DB sessions recorded while skewed (e.g. 69/70 on the bench DB) stay skewed on replay; this fix only affects newly recorded scans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)