### PR TITLE
feat: identify terminal dark frame by firmware fsync count

### DIFF
--- a/omotion/ScanWorkflow.py
+++ b/omotion/ScanWorkflow.py
@@ -655,6 +655,10 @@ class ScanWorkflow:
                     except Exception:
                         logger.warning("stop_trigger raised in duration guard", exc_info=True)
                     time.sleep(0.5)
+                    # The deferred final FSYNC pulse (the terminal dark) has
+                    # fired by now — report its index for positive terminal-
+                    # dark identification in the flush.
+                    self._report_terminal_fsync()
                     for side, mask, _ in active_sides:
                         try:
                             self._interface.run_on_sensors(
@@ -749,6 +753,43 @@ class ScanWorkflow:
         except Exception:
             logger.warning("_emit_trigger_event raised", exc_info=True)
 
+    def _report_terminal_fsync(self) -> None:
+        """Read the console's final fsync pulse count and deliver it to the
+        dark stage + diagnostics channel.
+
+        Trigger_Stop hard-disables the laser timer before the FSYNC timer's
+        deferred final pulse fires, so the frame captured on the last pulse
+        is laser-off by construction — the count positively identifies the
+        terminal dark frame (content checking demotes to verification).
+
+        Must be called >= ~150 ms after stop_trigger (the deferred final
+        pulse's worst-case latency) so the firmware counter includes it;
+        both call sites sit after the teardown's 0.5 s settle sleep.
+        Best-effort: failure must never break scan teardown.
+        """
+        try:
+            from omotion.pipeline.batch import TerminalFsyncCount
+            runner = self._runner
+            if runner is None:
+                return
+            count = self._interface.console.get_fsync_pulsecount()
+            if not isinstance(count, int) or count <= 0:
+                logger.warning(
+                    "get_fsync_pulsecount returned %r — terminal dark will "
+                    "be identified content-based", count,
+                )
+                return
+            for stage in runner.pipeline.stages:
+                if getattr(stage, "name", "") == "dark_correction":
+                    stage.set_terminal_fsync_count(count)
+                    break
+            t0 = getattr(self, "_scan_t0_monotonic", None)
+            ts = (time.monotonic() - t0) if t0 is not None else 0.0
+            runner.dispatch_event(TerminalFsyncCount(count=count, timestamp_s=ts))
+            logger.info("terminal fsync count reported: %d", count)
+        except Exception:
+            logger.warning("_report_terminal_fsync raised", exc_info=True)
+
     @property
     def last_scan_error(self) -> str | None:
         """Error message from the most recent scan worker, or None on
@@ -824,6 +865,10 @@ class ScanWorkflow:
         active = list(self._scan_active_sides)
         if active:
             time.sleep(0.5)
+            # Deferred final FSYNC pulse has fired — report the terminal
+            # frame index before the source drains it (same as the
+            # duration-guard path).
+            self._report_terminal_fsync()
             for side, mask, _ in active:
                 try:
                     self._interface.run_on_sensors(

--- a/omotion/pipeline/batch.py
+++ b/omotion/pipeline/batch.py
@@ -74,6 +74,12 @@ class TerminalDarkResult(BatchEvent):
     appears to have been on for the final frame. This is a firmware issue:
     the trigger-stop did not produce the expected laser-off frame. The
     interval is left open (data for this interval is lost).
+
+    ``identified_by``: "fsync" when the terminal frame was identified by
+    the console's reported final fsync pulse index (ground truth, content
+    used only as verification); "content" when identified by the legacy
+    dark-like content scan (no fsync count available, or it didn't match
+    a buffered frame).
     """
     side:           str
     cam_id:         int
@@ -81,6 +87,7 @@ class TerminalDarkResult(BatchEvent):
     u1:             float
     threshold:      float
     found:          bool
+    identified_by:  str = "content"
 
 
 @dataclass
@@ -130,6 +137,24 @@ class TriggerStateEvent(BatchEvent):
     ``timestamp_s`` is scan-relative, matching the other event types.
     """
     state:        str    # "ON" or "OFF"
+    timestamp_s:  float
+
+
+@dataclass
+class TerminalFsyncCount(BatchEvent):
+    """The console's fsync pulse count read after stop_trigger.
+
+    Trigger_Stop hard-disables the laser timer, then the FSYNC timer fires
+    one final deferred pulse — so the frame captured on the last pulse is
+    laser-off by construction, and this count is the ground-truth identity
+    of the terminal dark frame. ScanWorkflow reads it via OW_CTRL_GET_FSYNC
+    during teardown, hands it to DarkCorrectionStage (positive terminal-dark
+    identification), and dispatches this event on the "diagnostics" channel
+    for observability.
+
+    ``timestamp_s`` is scan-relative, matching the other event types.
+    """
+    count:        int
     timestamp_s:  float
 
 

--- a/omotion/pipeline/sinks.py
+++ b/omotion/pipeline/sinks.py
@@ -504,12 +504,12 @@ class CsvSink:
 def _is_integrity_event(event) -> bool:
     """True for events that indicate a correction-integrity problem.
 
-    TriggerStateEvent is routine operational telemetry, and a
-    TerminalDarkResult with found=True is the expected happy path —
-    neither belongs in the integrity record.
+    TriggerStateEvent and TerminalFsyncCount are routine operational
+    telemetry, and a TerminalDarkResult with found=True is the expected
+    happy path — none belongs in the integrity record.
     """
-    from .batch import TerminalDarkResult, TriggerStateEvent
-    if isinstance(event, TriggerStateEvent):
+    from .batch import TerminalDarkResult, TerminalFsyncCount, TriggerStateEvent
+    if isinstance(event, (TriggerStateEvent, TerminalFsyncCount)):
         return False
     if isinstance(event, TerminalDarkResult) and event.found:
         return False

--- a/omotion/pipeline/stages/dark.py
+++ b/omotion/pipeline/stages/dark.py
@@ -467,9 +467,25 @@ class DarkCorrectionStage:
                         self._emit_interval((side, cam_id), interval, batch.events)
 
             else:  # light
-                pred = self._realtime.predict(
-                    side, cam_id, history=self._history, target_t=t,
-                )
+                # Dark-like "light" frame — the laser was actually off; most
+                # commonly the firmware's terminal laser-off frame at scan
+                # stop, which never falls on a scheduled dark position so the
+                # classifier types it "light". Realtime dark subtraction
+                # would emit a near-zero mean and a garbage contrast that
+                # rails the live BFI/BVI display, so suppress realtime
+                # emission (row stays NaN) and keep _last_realtime on the
+                # last genuine light. Same threshold as the on_scan_stop tail
+                # detection, which still needs the frame buffered below for
+                # the batch path.
+                pedestal = (self._pedestals.left if side == "left"
+                            else self._pedestals.right)
+                dark_like = u1 <= pedestal + self._guard.max_above_pedestal
+
+                pred = None
+                if not dark_like:
+                    pred = self._realtime.predict(
+                        side, cam_id, history=self._history, target_t=t,
+                    )
                 if pred is not None:
                     u1_hat, std_hat = pred
                     baseline_rt[i, side_idx, cam_id] = np.float32(u1_hat)
@@ -492,12 +508,15 @@ class DarkCorrectionStage:
                         float(std_dc_rt[i, side_idx, cam_id]),
                     )
 
-                    pi = self._pending.get((side, cam_id))
-                    if pi is not None:
-                        u2 = std ** 2 + u1 ** 2
-                        q = str(batch.quality[i]) if batch.quality is not None else "ok"
-                        pi.add_light(abs_frame_id=abs_id, t=t, u1=u1, u2=u2,
-                                     quality=q)
+                # Buffer for the batch path even when realtime emission was
+                # suppressed (dark-like frame) — the terminal flush finds the
+                # dark-like tail in the pending light list.
+                pi = self._pending.get((side, cam_id))
+                if pi is not None:
+                    u2 = std ** 2 + u1 ** 2
+                    q = str(batch.quality[i]) if batch.quality is not None else "ok"
+                    pi.add_light(abs_frame_id=abs_id, t=t, u1=u1, u2=u2,
+                                 quality=q)
 
         batch.dark_baseline_rt = baseline_rt
         batch.mean_dc_rt = mean_dc_rt

--- a/omotion/pipeline/stages/dark.py
+++ b/omotion/pipeline/stages/dark.py
@@ -23,6 +23,13 @@ from ..pedestal import SensorPedestals
 
 logger = logging.getLogger("openmotion.sdk.pipeline.stages.dark")
 
+# Maps the console's fsync pulse count (OW_CTRL_GET_FSYNC, read by the
+# workflow after stop_trigger) onto the camera-side abs_frame_id of the
+# terminal laser-off frame: expected_abs = count + offset. Initial value
+# pending HIL confirmation — a mismatch logs the observed delta and falls
+# back to content-based detection, so a wrong offset cannot corrupt data.
+_TERMINAL_FSYNC_ABS_OFFSET = 0
+
 
 @dataclass(frozen=True)
 class DarkObservation:
@@ -395,6 +402,19 @@ class DarkCorrectionStage:
             max_above_pedestal=integrity_max_above_pedestal
         )
         self._last_realtime: dict[tuple[str, int], tuple[float, float, float]] = {}
+        self._terminal_fsync_count: Optional[int] = None
+
+    def set_terminal_fsync_count(self, count: int) -> None:
+        """Ground-truth index of the final FSYNC pulse, from the console
+        firmware (OW_CTRL_GET_FSYNC). Trigger_Stop hard-disables the laser
+        timer before the deferred final pulse fires, so the frame captured
+        on that pulse is laser-off by construction — this count identifies
+        the terminal dark positively; content is demoted to verification.
+
+        Called from the workflow teardown thread after stop_trigger; read
+        in on_scan_stop, which runs strictly after source close, so plain
+        assignment is safely ordered."""
+        self._terminal_fsync_count = int(count)
 
     def _emit_interval(
         self,
@@ -527,6 +547,7 @@ class DarkCorrectionStage:
         self._history.clear()
         self._pending.clear()
         self._last_realtime.clear()
+        self._terminal_fsync_count = None
 
     def on_scan_stop(self, batch: FrameBatch) -> None:
         """Terminal dark flush — see SciencePipeline.md §8.6.
@@ -538,7 +559,13 @@ class DarkCorrectionStage:
         dark-like frames at the end are removed from the light list.
 
         Following the legacy SciencePipeline._flush_terminal_dark logic:
-          1. Find the trailing dark-like tail in pi._light.
+          0. When the workflow reported the firmware's final fsync pulse
+             index (set_terminal_fsync_count), identify the terminal frame
+             by abs_frame_id — ground truth from the chip that fired the
+             pulse — and use content only to VERIFY it is dark-like. A
+             count that matches no buffered frame falls back to step 1.
+          1. Find the trailing dark-like tail in pi._light (content-based,
+             used when no fsync count is available or it didn't match).
           2. Use the last tail frame's actual data (not the last scheduled dark's)
              as the right boundary of the synthetic interval.
           3. Remove the whole tail from the light list so it is not double-counted.
@@ -546,6 +573,11 @@ class DarkCorrectionStage:
              The stencil for D_prev is applied as normal; if there are no lights,
              D_prev cannot be stencilled (no right neighbours) and is skipped.
         """
+        expected_abs = (
+            None if self._terminal_fsync_count is None
+            else self._terminal_fsync_count + _TERMINAL_FSYNC_ABS_OFFSET
+        )
+
         for (side, cam_id), pi in self._pending.items():
             if not pi._light:
                 continue
@@ -558,39 +590,85 @@ class DarkCorrectionStage:
             def _is_dark_like(light_frame) -> bool:
                 return light_frame.u1 <= threshold
 
-            # The final buffered frame should be the hardware-guaranteed
-            # terminal dark.  If it is not dark-like, leave the interval open
-            # and log loudly — the firmware did not produce the expected
-            # laser-off frame, which indicates a trigger/firmware issue.
+            # ── Step 0: positive identification by fsync count ────────────
+            identified_by = "content"
+            if expected_abs is not None:
+                match_idx = next(
+                    (j for j in range(len(pi._light) - 1, -1, -1)
+                     if pi._light[j].abs_frame_id == expected_abs),
+                    None,
+                )
+                if match_idx is None:
+                    logger.warning(
+                        "terminal fsync count %d (expected abs_id %d) matches "
+                        "no buffered light for side=%s cam_id=%d (last buffered "
+                        "abs_id=%d) — falling back to content-based detection; "
+                        "_TERMINAL_FSYNC_ABS_OFFSET may need calibration "
+                        "(observed delta %+d)",
+                        self._terminal_fsync_count, expected_abs, side, cam_id,
+                        pi._light[-1].abs_frame_id,
+                        pi._light[-1].abs_frame_id - expected_abs,
+                    )
+                else:
+                    identified_by = "fsync"
+                    if match_idx != len(pi._light) - 1:
+                        # No pulse can follow the final pulse — anything after
+                        # it is drain garbage; drop it with the tail.
+                        logger.warning(
+                            "%d buffered frames follow the firmware-identified "
+                            "terminal frame abs_id=%d for side=%s cam_id=%d — "
+                            "dropping them",
+                            len(pi._light) - 1 - match_idx, expected_abs,
+                            side, cam_id,
+                        )
+                        pi._light = pi._light[:match_idx + 1]
+
+            # The terminal candidate must be dark-like. If not, leave the
+            # interval open and log loudly: with an fsync identification the
+            # laser was demonstrably ON during the final pulse (trigger/laser
+            # fault); without one, the firmware did not produce the expected
+            # laser-off frame at all.
             terminal_light = pi._light[-1]
             if not _is_dark_like(terminal_light):
-                logger.error(
-                    "TERMINAL DARK MISSING: side=%s cam_id=%d — "
-                    "last frame abs_id=%d u1=%.3f exceeds dark threshold %.3f. "
-                    "Firmware did not produce a laser-off frame at scan stop. "
-                    "Interval left open; corrected data for this interval is lost.",
-                    side, cam_id, terminal_light.abs_frame_id,
-                    terminal_light.u1, threshold,
-                )
+                if identified_by == "fsync":
+                    logger.error(
+                        "TERMINAL DARK CONTAMINATED: side=%s cam_id=%d — "
+                        "firmware reports abs_id=%d was the final (laser-off) "
+                        "pulse but u1=%.3f exceeds dark threshold %.3f; the "
+                        "laser appears to have been on during the terminal "
+                        "pulse. Interval left open; corrected data for this "
+                        "interval is lost.",
+                        side, cam_id, terminal_light.abs_frame_id,
+                        terminal_light.u1, threshold,
+                    )
+                else:
+                    logger.error(
+                        "TERMINAL DARK MISSING: side=%s cam_id=%d — "
+                        "last frame abs_id=%d u1=%.3f exceeds dark threshold %.3f. "
+                        "Firmware did not produce a laser-off frame at scan stop. "
+                        "Interval left open; corrected data for this interval is lost.",
+                        side, cam_id, terminal_light.abs_frame_id,
+                        terminal_light.u1, threshold,
+                    )
                 batch.events.append(TerminalDarkResult(
                     side=side, cam_id=cam_id,
                     abs_frame_id=terminal_light.abs_frame_id,
                     u1=terminal_light.u1, threshold=threshold,
-                    found=False,
+                    found=False, identified_by=identified_by,
                 ))
                 continue
 
             logger.info(
-                "terminal dark confirmed: side=%s cam_id=%d "
+                "terminal dark confirmed (%s): side=%s cam_id=%d "
                 "abs_id=%d u1=%.3f (threshold=%.3f)",
-                side, cam_id, terminal_light.abs_frame_id,
+                identified_by, side, cam_id, terminal_light.abs_frame_id,
                 terminal_light.u1, threshold,
             )
             batch.events.append(TerminalDarkResult(
                 side=side, cam_id=cam_id,
                 abs_frame_id=terminal_light.abs_frame_id,
                 u1=terminal_light.u1, threshold=threshold,
-                found=True,
+                found=True, identified_by=identified_by,
             ))
 
             tail_start = len(pi._light) - 1

--- a/omotion/pipeline/stages/dark.py
+++ b/omotion/pipeline/stages/dark.py
@@ -25,9 +25,11 @@ logger = logging.getLogger("openmotion.sdk.pipeline.stages.dark")
 
 # Maps the console's fsync pulse count (OW_CTRL_GET_FSYNC, read by the
 # workflow after stop_trigger) onto the camera-side abs_frame_id of the
-# terminal laser-off frame: expected_abs = count + offset. Initial value
-# pending HIL confirmation — a mismatch logs the observed delta and falls
-# back to content-based detection, so a wrong offset cannot corrupt data.
+# terminal laser-off frame: expected_abs = count + offset. Confirmed exact
+# on HIL 2026-06-11: every live camera across four scans (counts 47 to
+# 20851) matched abs_id == count. A camera whose last buffered frame is
+# older than the count stopped delivering before scan end (dropout); the
+# flush logs that and falls back to content-based detection per camera.
 _TERMINAL_FSYNC_ABS_OFFSET = 0
 
 
@@ -600,14 +602,13 @@ class DarkCorrectionStage:
                 )
                 if match_idx is None:
                     logger.warning(
-                        "terminal fsync count %d (expected abs_id %d) matches "
-                        "no buffered light for side=%s cam_id=%d (last buffered "
-                        "abs_id=%d) — falling back to content-based detection; "
-                        "_TERMINAL_FSYNC_ABS_OFFSET may need calibration "
-                        "(observed delta %+d)",
+                        "terminal fsync count %d names abs_id %d but side=%s "
+                        "cam_id=%d last delivered abs_id=%d — camera stopped "
+                        "delivering %d frames before scan end (dropout); "
+                        "falling back to content-based detection",
                         self._terminal_fsync_count, expected_abs, side, cam_id,
                         pi._light[-1].abs_frame_id,
-                        pi._light[-1].abs_frame_id - expected_abs,
+                        expected_abs - pi._light[-1].abs_frame_id,
                     )
                 else:
                     identified_by = "fsync"

--- a/tests/test_pipeline/test_dark_correction_stage.py
+++ b/tests/test_pipeline/test_dark_correction_stage.py
@@ -89,6 +89,36 @@ def test_realtime_dark_frame_reuses_previous_live_corrected_values():
     assert batch.dark_baseline_rt[2, 0, 0] == pytest.approx(batch.dark_baseline_rt[1, 0, 0])
 
 
+def test_dark_like_light_frame_suppresses_realtime_emission():
+    """The firmware-guaranteed terminal laser-off frame is positionally
+    classified as "light" (it doesn't fall on a scheduled dark position).
+    Dark-subtracting it realtime yields a near-zero mean and a garbage
+    contrast that rails the live BFI/BVI display at scan end. A light frame
+    whose u1 is within the dark-integrity threshold (pedestal +
+    max_above_pedestal) must not emit realtime values — NaN, the established
+    "no valid realtime sample" convention.
+    """
+    # dark@10 (u1=65), genuine light@11 (u1=500), laser-off frame@12 typed
+    # "light" but dark-like (u1=66 <= pedestal 64 + guard 5).
+    mean = np.array([[65.0], [500.0], [66.0]], dtype=np.float32).reshape(3, 1, 1) * np.ones((1, 2, 8))
+    std  = np.array([[10.0], [20.0], [11.0]], dtype=np.float32).reshape(3, 1, 1) * np.ones((1, 2, 8))
+    batch = _batch(3, ["dark", "light", "light"], [10, 11, 12],
+                   mean_raw=mean.astype(np.float32), std_raw=std.astype(np.float32))
+
+    stage = DarkCorrectionStage(
+        realtime_estimator=HybridRealtimePredictor(),
+        batch_estimator=LinearInterpolation(),
+    )
+    stage.process(batch)
+
+    # Genuine light frame emits normally: 500 - 65 = 435.
+    assert batch.mean_dc_rt[1, 0, 0] == pytest.approx(435.0)
+    # Dark-like light frame must not emit realtime values.
+    assert np.isnan(batch.mean_dc_rt[2, 0, 0])
+    assert np.isnan(batch.std_dc_rt[2, 0, 0])
+    assert np.isnan(batch.dark_baseline_rt[2, 0, 0])
+
+
 def test_emits_corrected_interval():
     """DarkCorrectionStage emits raw CorrectedInterval (enrichment is done
     by downstream stages ShotNoiseCorrectionStage and BfiBviStage)."""

--- a/tests/test_pipeline/test_dark_correction_stage.py
+++ b/tests/test_pipeline/test_dark_correction_stage.py
@@ -407,6 +407,156 @@ def test_terminal_flush_discards_trailing_dark_like_tail():
     assert 14 not in abs_ids_in_iv
 
 
+def test_terminal_fsync_count_positively_identifies_terminal_dark():
+    """When the workflow reports the firmware's final fsync pulse index,
+    the terminal flush identifies the terminal dark by abs_frame_id instead
+    of content-scanning, and verifies it is dark-like.
+
+    Scenario: dark@10 (u1=65), lights@11-12 (bright), terminal laser-off
+    frame@13 (u1=66, typed "light"). Firmware count maps to abs_id 13.
+    """
+    from omotion.pipeline.stages.dark import _TERMINAL_FSYNC_ABS_OFFSET
+
+    stage = _make_stage_with_cal()
+    n = 4
+    mean_raw = np.array(
+        [[[65.0]*8]*2, [[500.0]*8]*2, [[510.0]*8]*2, [[66.0]*8]*2],
+        dtype=np.float32,
+    )
+    std_raw = np.array(
+        [[[10.0]*8]*2, [[20.0]*8]*2, [[21.0]*8]*2, [[11.0]*8]*2],
+        dtype=np.float32,
+    )
+    raw_hist = np.zeros((n, 2, 8, 1024), dtype=np.uint32)
+    raw_hist[:, 0, 0, 0] = 1
+
+    process_batch = FrameBatch(
+        cam_ids=np.zeros(n, dtype=np.int8),
+        frame_ids=np.arange(n, dtype=np.uint8),
+        side_ids=np.zeros(n, dtype=np.int8),
+        raw_histograms=raw_hist,
+        temperature_c=np.zeros((n, 2, 8), dtype=np.float32),
+        timestamp_s=np.arange(n, dtype=np.float64) * 0.025,
+        pdc=None, tcm=None, tcl=None,
+        abs_frame_ids=np.array([10, 11, 12, 13], dtype=np.int64),
+        frame_type=np.array(["dark", "light", "light", "light"], dtype="<U8"),
+        mean_raw=mean_raw, std_raw=std_raw,
+    )
+    stage.process(process_batch)
+
+    stage.set_terminal_fsync_count(13 - _TERMINAL_FSYNC_ABS_OFFSET)
+
+    stop_batch = _batch(
+        0, [], [], mean_raw=np.zeros((0, 2, 8), dtype=np.float32),
+        std_raw=np.zeros((0, 2, 8), dtype=np.float32)
+    )
+    stage.on_scan_stop(stop_batch)
+
+    closed = [e.corrected_batch for e in stop_batch.events if isinstance(e, IntervalClosed)]
+    assert len(closed) == 1
+    abs_ids_in_iv = [f.abs_frame_id for f in closed[0].frames]
+    assert 11 in abs_ids_in_iv
+    assert 12 in abs_ids_in_iv
+    assert 13 not in abs_ids_in_iv
+
+    from omotion.pipeline.batch import TerminalDarkResult
+    tdr = [e for e in stop_batch.events if isinstance(e, TerminalDarkResult)]
+    assert len(tdr) == 1
+    assert tdr[0].found is True
+    assert tdr[0].abs_frame_id == 13
+    # Identified by firmware fsync count, not content scan.
+    assert tdr[0].identified_by == "fsync"
+
+
+def _process_dark_lights_terminal(stage, mean_last=66.0):
+    """dark@10 (65), lights@11-12 (bright), final frame@13 with u1=mean_last."""
+    n = 4
+    mean_raw = np.array(
+        [[[65.0]*8]*2, [[500.0]*8]*2, [[510.0]*8]*2, [[mean_last]*8]*2],
+        dtype=np.float32,
+    )
+    std_raw = np.array(
+        [[[10.0]*8]*2, [[20.0]*8]*2, [[21.0]*8]*2, [[11.0]*8]*2],
+        dtype=np.float32,
+    )
+    raw_hist = np.zeros((n, 2, 8, 1024), dtype=np.uint32)
+    raw_hist[:, 0, 0, 0] = 1
+    batch = FrameBatch(
+        cam_ids=np.zeros(n, dtype=np.int8),
+        frame_ids=np.arange(n, dtype=np.uint8),
+        side_ids=np.zeros(n, dtype=np.int8),
+        raw_histograms=raw_hist,
+        temperature_c=np.zeros((n, 2, 8), dtype=np.float32),
+        timestamp_s=np.arange(n, dtype=np.float64) * 0.025,
+        pdc=None, tcm=None, tcl=None,
+        abs_frame_ids=np.array([10, 11, 12, 13], dtype=np.int64),
+        frame_type=np.array(["dark", "light", "light", "light"], dtype="<U8"),
+        mean_raw=mean_raw, std_raw=std_raw,
+    )
+    stage.process(batch)
+
+
+def _flush(stage):
+    stop_batch = _batch(
+        0, [], [], mean_raw=np.zeros((0, 2, 8), dtype=np.float32),
+        std_raw=np.zeros((0, 2, 8), dtype=np.float32)
+    )
+    stage.on_scan_stop(stop_batch)
+    return stop_batch
+
+
+def test_terminal_fsync_count_mismatch_falls_back_to_content(caplog):
+    """A count that matches no buffered frame must not break the flush —
+    log the observed delta and use the legacy content-based detection."""
+    from omotion.pipeline.batch import TerminalDarkResult
+
+    stage = _make_stage_with_cal()
+    _process_dark_lights_terminal(stage)
+    stage.set_terminal_fsync_count(99)  # matches nothing
+
+    with caplog.at_level(logging.WARNING,
+                         logger="openmotion.sdk.pipeline.stages.dark"):
+        stop_batch = _flush(stage)
+
+    assert "falling back to content-based detection" in caplog.text
+    closed = [e.corrected_batch for e in stop_batch.events
+              if isinstance(e, IntervalClosed)]
+    assert len(closed) == 1
+    assert [f.abs_frame_id for f in closed[0].frames] == [11, 12]
+    tdr = [e for e in stop_batch.events if isinstance(e, TerminalDarkResult)]
+    assert tdr[0].found is True
+    assert tdr[0].identified_by == "content"
+
+
+def test_terminal_frame_bright_with_fsync_id_logs_contaminated(caplog):
+    """Firmware says frame 13 was the final laser-off pulse, but it's bright:
+    the laser was on during the terminal pulse. Refuse the interval with a
+    distinct error (not TERMINAL DARK MISSING)."""
+    from omotion.pipeline.batch import TerminalDarkResult
+    from omotion.pipeline.stages.dark import _TERMINAL_FSYNC_ABS_OFFSET
+
+    stage = _make_stage_with_cal()
+    _process_dark_lights_terminal(stage, mean_last=500.0)  # bright terminal
+    stage.set_terminal_fsync_count(13 - _TERMINAL_FSYNC_ABS_OFFSET)
+
+    with caplog.at_level(logging.ERROR,
+                         logger="openmotion.sdk.pipeline.stages.dark"):
+        stop_batch = _flush(stage)
+
+    assert "TERMINAL DARK CONTAMINATED" in caplog.text
+    assert [e for e in stop_batch.events if isinstance(e, IntervalClosed)] == []
+    tdr = [e for e in stop_batch.events if isinstance(e, TerminalDarkResult)]
+    assert tdr[0].found is False
+    assert tdr[0].identified_by == "fsync"
+
+
+def test_reset_clears_terminal_fsync_count():
+    stage = _make_stage_with_cal()
+    stage.set_terminal_fsync_count(123)
+    stage.reset()
+    assert stage._terminal_fsync_count is None
+
+
 def test_terminal_flush_uses_actual_terminal_dark_moments():
     stage = _make_stage_with_cal()
     n = 3

--- a/tests/test_pipeline/test_dark_correction_stage.py
+++ b/tests/test_pipeline/test_dark_correction_stage.py
@@ -507,7 +507,8 @@ def _flush(stage):
 
 def test_terminal_fsync_count_mismatch_falls_back_to_content(caplog):
     """A count that matches no buffered frame must not break the flush —
-    log the observed delta and use the legacy content-based detection."""
+    log it as a camera dropout (how early the camera stopped) and use the
+    legacy content-based detection."""
     from omotion.pipeline.batch import TerminalDarkResult
 
     stage = _make_stage_with_cal()
@@ -519,6 +520,10 @@ def test_terminal_fsync_count_mismatch_falls_back_to_content(caplog):
         stop_batch = _flush(stage)
 
     assert "falling back to content-based detection" in caplog.text
+    # HIL 2026-06-11 confirmed the count↔abs_id mapping is exact, so a
+    # mismatch means the camera stopped delivering before scan end.
+    assert "stopped delivering" in caplog.text
+    assert "86 frames before scan end" in caplog.text  # 99 - 13
     closed = [e.corrected_batch for e in stop_batch.events
               if isinstance(e, IntervalClosed)]
     assert len(closed) == 1

--- a/tests/test_pipeline/test_diagnostics_sink.py
+++ b/tests/test_pipeline/test_diagnostics_sink.py
@@ -49,6 +49,7 @@ def test_log_sink_warns_on_integrity_events(caplog):
 
 
 def test_log_sink_ignores_routine_events(caplog):
+    from omotion.pipeline.batch import TerminalFsyncCount
     sink = DiagnosticsLogSink()
     sink.on_scan_start(_meta())
     with caplog.at_level(logging.WARNING, logger="openmotion.sdk.pipeline.sinks"):
@@ -56,6 +57,7 @@ def test_log_sink_ignores_routine_events(caplog):
         sink.consume("diagnostics", TerminalDarkResult(
             side="left", cam_id=0, abs_frame_id=100, u1=64.0,
             threshold=69.0, found=True))
+        sink.consume("diagnostics", TerminalFsyncCount(count=842, timestamp_s=60.0))
         sink.on_complete()
     assert caplog.text == ""
 

--- a/tests/test_scan_workflow.py
+++ b/tests/test_scan_workflow.py
@@ -275,6 +275,56 @@ def test_duration_guard_skips_redundant_stop_trigger_and_close_on_cancel(tmp_pat
         )
 
 
+class _DiagnosticsCollector:
+    """Minimal sink capturing diagnostics-channel events."""
+    channels = {"diagnostics"}
+
+    def __init__(self):
+        self.events = []
+
+    def on_scan_start(self, meta):
+        pass
+
+    def consume(self, channel, payload):
+        self.events.append(payload)
+
+    def on_complete(self):
+        pass
+
+
+def test_duration_guard_reports_terminal_fsync_count(tmp_path):
+    """After stop_trigger (+ settle), the duration guard reads the console's
+    final fsync pulse count — the index of the laser-off terminal pulse —
+    hands it to the dark stage for positive terminal-dark identification,
+    and emits a TerminalFsyncCount diagnostics event."""
+    from omotion.pipeline.batch import TerminalFsyncCount
+
+    motion = _build_motion_with_data_dir(None)
+    collector = _DiagnosticsCollector()
+    request = ScanRequest(
+        subject_id="x", duration_sec=1,
+        left_camera_mask=0xFF, right_camera_mask=0, reduced_mode=False,
+        skip_default_storage=True, sinks=[collector],
+    )
+
+    with mock.patch.object(motion.console, "get_fsync_pulsecount",
+                           return_value=842):
+        assert motion.scan_workflow.start_scan(request)
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline and motion.scan_workflow.running:
+            time.sleep(0.05)
+        assert not motion.scan_workflow.running, "scan did not finish"
+
+    dark_stage = next(s for s in motion.scan_workflow._runner.pipeline.stages
+                      if s.name == "dark_correction")
+    assert dark_stage._terminal_fsync_count == 842
+
+    fsync_events = [e for e in collector.events
+                    if isinstance(e, TerminalFsyncCount)]
+    assert len(fsync_events) == 1
+    assert fsync_events[0].count == 842
+
+
 def test_start_scan_passes_raw_save_max_duration_s_to_pipeline():
     motion = _build_motion_with_data_dir(None)
     request = ScanRequest(


### PR DESCRIPTION
﻿## What

Replaces inference with ground truth for terminal-dark identification. Now based directly on `next` and carries two commits: the realtime rail-fix from #75 (closed as superseded — its commit is the first one here, rebased) plus the fsync identification.

**Background (from #75):** at the last frame of a scan the live BFI/BVI display often railed at the 0/10 clamps. The firmware's terminal laser-off frame isn't on a scheduled dark position, so the classifier types it "light" and the realtime path dark-subtracts a black image into garbage BFI/BVI. The first commit adds the missing content-based net to the realtime path (same pedestal threshold the batch path already used). Verified on hardware: the rail no longer appears.

The terminal laser-off frame at scan stop was detected purely content-based (`u1` at pedestal). But the console firmware *knows* which pulse was the terminal one: `Trigger_Stop` hard-disables the laser timer first, then the FSYNC timer fires one final deferred pulse — so the frame captured on the last pulse is laser-off **by construction**, and `fsync_counter` (already exposed via `OW_CTRL_GET_FSYNC` / `MotionConsole.get_fsync_pulsecount()`) names it.

## How

- **`ScanWorkflow`**: after `stop_trigger` + the 0.5 s settle (deferred final pulse worst-case is ~150 ms), both the duration guard and `cancel_scan` call `_report_terminal_fsync()` — reads the count, hands it to the dark stage, emits a `TerminalFsyncCount` diagnostics event. Best-effort: any failure logs and falls back, never breaks teardown.
- **`DarkCorrectionStage.on_scan_stop`**: when a count is set, the terminal frame is identified by `abs_frame_id == count + _TERMINAL_FSYNC_ABS_OFFSET`; the pedestal content check is demoted to *verification*:
  - reported frame found + dark-like → promoted as terminal boundary (`TerminalDarkResult.identified_by="fsync"`)
  - reported frame found but **bright** → new `TERMINAL DARK CONTAMINATED` error (laser provably on during the final pulse — distinct from `TERMINAL DARK MISSING`), interval refused as before
  - count matches no buffered frame → WARNING with the observed delta, falls back to the legacy content scan
- No count (replay sources, calibration paths, UART failure) → legacy content path, byte-for-byte unchanged.
- `TerminalFsyncCount` is classified as routine telemetry, not an integrity event (caught via the DiagnosticsLogSink summary warning during testing).

## Offset calibration

`_TERMINAL_FSYNC_ABS_OFFSET = 0` is an initial guess — the exact `fsync_counter` ↔ camera `abs_frame_id` phase needs one real scan to confirm. The mismatch path logs the observed delta, and a wrong offset degrades safely to content-based detection, so this is calibratable from the first HIL scan's log with zero data risk.

## Testing

TDD throughout (each path watched failing first; the fsync branches additionally verified by mutation). 43 tests pass across the directly affected files: dark stage (18, incl. 4 new), diagnostics sink, batch, scan workflow (13, incl. 1 new end-to-end with a mocked console), reduced mode. Full replay-suite run (golden replay / EFT regression, ~30 min) skipped per reviewer request — those exercise the no-count legacy path, which is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

