### PR TITLE
feat(pipeline): ScanDBSink deletes its session when no rows were persisted

### DIFF
--- a/omotion/pipeline/sinks.py
+++ b/omotion/pipeline/sinks.py
@@ -609,6 +609,7 @@ class ScanDBSink:
         self._meta: Optional[ScanMetadata] = None
         self._session_meta: Optional[dict] = None
         self._buffer: list = []
+        self._rows_written = 0
         self._diag: dict[str, dict] = {}
         self._closed = False
 
@@ -657,18 +658,30 @@ class ScanDBSink:
         try:
             self._flush()
             if self._db is not None and self._session_id is not None:
-                if self._diag and self._session_meta is not None:
-                    try:
-                        self._db.update_session(
-                            self._session_id,
-                            session_meta={**self._session_meta,
-                                          "diagnostics": self._diag},
-                        )
-                    except Exception:
-                        logger.exception(
-                            "ScanDBSink: failed to write diagnostics summary"
-                        )
-                self._db.close_session(self._session_id, time.time())
+                if self._rows_written == 0:
+                    # Nothing was persisted (scan interrupted before any dark
+                    # interval closed). Drop the orphan session header so it
+                    # never appears as a viewable scan in History.
+                    scan_id = (self._session_meta or {}).get("scan_id", "?")
+                    logger.warning(
+                        "ScanDBSink: session %d (%s) recorded no corrected "
+                        "rows — deleting empty session row.",
+                        self._session_id, scan_id,
+                    )
+                    self._db.delete_session(self._session_id)
+                else:
+                    if self._diag and self._session_meta is not None:
+                        try:
+                            self._db.update_session(
+                                self._session_id,
+                                session_meta={**self._session_meta,
+                                              "diagnostics": self._diag},
+                            )
+                        except Exception:
+                            logger.exception(
+                                "ScanDBSink: failed to write diagnostics summary"
+                            )
+                    self._db.close_session(self._session_id, time.time())
         except Exception:
             logger.exception("ScanDBSink.on_complete: failed to finalise session")
         finally:
@@ -759,11 +772,12 @@ class ScanDBSink:
     def _flush(self) -> None:
         if not self._buffer or self._db is None:
             return
+        n = len(self._buffer)
         try:
             self._db.insert_session_data_rows(self._buffer)
+            self._rows_written += n
         except Exception:
             logger.exception(
-                "ScanDBSink: failed to insert %d corrected rows",
-                len(self._buffer),
+                "ScanDBSink: failed to insert %d corrected rows", n
             )
         self._buffer = []

--- a/omotion/pipeline/sinks.py
+++ b/omotion/pipeline/sinks.py
@@ -619,6 +619,7 @@ class ScanDBSink:
         self._meta = meta
         self._closed = False
         self._diag = {}
+        self._rows_written = 0
         label = f"{meta.scan_id}_{meta.subject_id}"
         self._db = ScanDatabase(db_path=self._db_path)
         # data_semantics distinguishes final-branch sessions from legacy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ markers = [
     "sequence: multi-step round-trip tests",
     "fpga: requires a loaded FPGA bitstream — temporarily skipped",
     "imu: exercises the IMU subsystem — temporarily skipped",
+    "unit: fast tests that require no hardware",
 ]
 
 [tool.setuptools_scm]

--- a/tests/test_scan_db_sink_empty.py
+++ b/tests/test_scan_db_sink_empty.py
@@ -46,3 +46,31 @@ def test_nonempty_scan_session_is_retained(tmp_path):
         assert next(db.iter_session_data(int(sess["id"])), None) is not None
     finally:
         db.close()
+
+
+def test_rows_written_reset_between_scans(tmp_path):
+    db_path = str(tmp_path / "scans.db")
+    sink = ScanDBSink(db_path)
+    # First scan persists a row.
+    sink.on_scan_start(_meta())
+    frame = SimpleNamespace(
+        cam_id=-1, side="left", abs_frame_id=1, t=0.1,
+        bfi=1.0, bvi=2.0, mean=3.0, contrast=0.4, quality="ok",
+    )
+    sink.consume("final", SimpleNamespace(frames=[frame]))
+    sink.on_complete()
+    # Reuse the same instance for an empty second scan.
+    sink.on_scan_start(SimpleNamespace(
+        scan_id="20260615_111111", subject_id="subjY", operator="test",
+        started_at_iso="2026-06-15T11:11:11+00:00", duration_sec=10,
+        reduced_mode=True, left_camera_mask=195, right_camera_mask=195,
+    ))
+    sink.on_complete()
+    db = ScanDatabase(db_path)
+    try:
+        # Second (empty) session must be deleted despite the first scan's rows.
+        assert db.get_session_by_label("20260615_111111_subjY") is None
+        # First (non-empty) session is still present.
+        assert db.get_session_by_label("20260615_000000_subjX") is not None
+    finally:
+        db.close()

--- a/tests/test_scan_db_sink_empty.py
+++ b/tests/test_scan_db_sink_empty.py
@@ -1,0 +1,48 @@
+# tests/test_scan_db_sink_empty.py
+from types import SimpleNamespace
+
+import pytest
+
+from omotion.pipeline.sinks import ScanDBSink
+from omotion.ScanDatabase import ScanDatabase
+
+pytestmark = pytest.mark.unit
+
+
+def _meta():
+    return SimpleNamespace(
+        scan_id="20260615_000000", subject_id="subjX", operator="test",
+        started_at_iso="2026-06-15T00:00:00+00:00", duration_sec=10,
+        reduced_mode=True, left_camera_mask=195, right_camera_mask=195,
+    )
+
+
+def test_empty_scan_session_is_deleted(tmp_path):
+    db_path = str(tmp_path / "scans.db")
+    sink = ScanDBSink(db_path)
+    sink.on_scan_start(_meta())
+    sink.on_complete()  # no "final" frames fed
+    db = ScanDatabase(db_path)
+    try:
+        assert db.get_session_by_label("20260615_000000_subjX") is None
+    finally:
+        db.close()
+
+
+def test_nonempty_scan_session_is_retained(tmp_path):
+    db_path = str(tmp_path / "scans.db")
+    sink = ScanDBSink(db_path)
+    sink.on_scan_start(_meta())
+    frame = SimpleNamespace(
+        cam_id=-1, side="left", abs_frame_id=1, t=0.1,
+        bfi=1.0, bvi=2.0, mean=3.0, contrast=0.4, quality="ok",
+    )
+    sink.consume("final", SimpleNamespace(frames=[frame]))
+    sink.on_complete()
+    db = ScanDatabase(db_path)
+    try:
+        sess = db.get_session_by_label("20260615_000000_subjX")
+        assert sess is not None
+        assert next(db.iter_session_data(int(sess["id"])), None) is not None
+    finally:
+        db.close()


### PR DESCRIPTION
## Summary
When a scan is interrupted before any dark-bounded interval closes (e.g. the console/sensors drop off USB mid-scan), `ScanDBSink` persists **zero** `session_data` rows — but the `sessions` header row it created at scan start is left behind. Downstream (the bloodflow app's History view) that orphan shows up as an empty, blank-loading scan.

This change makes `ScanDBSink` track how many rows it actually wrote and, at scan end, **delete its own session row if it wrote none** instead of `close_session`. Non-empty scans are unchanged (diagnostics summary + `close_session` as before).

This is the SDK half of the fix for OpenwaterHealth/openmotion-bloodflow-app#191. Companion app PR handles the user-facing toast + History guards.

## Changes
- `ScanDBSink._rows_written` counter, incremented only on a successful `insert_session_data_rows`, reset in both `__init__` and `on_scan_start` (so a reused sink instance can't carry a stale count).
- `on_complete`: if `_rows_written == 0`, log a warning and `delete_session`; else the existing diagnostics-write + `close_session` path. The `finally` db-close is preserved (fail-soft).

## Test Plan
- [x] `python -m pytest tests/test_scan_db_sink_empty.py -v` → 3 passed (empty→deleted, non-empty→retained, counter resets between scans on a reused instance).
- [ ] HIL: trigger a mid-scan disconnect and confirm no empty session row remains in `scans.db`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)