### PR TITLE
Merge next-next → next: I2C health-at-connect

### DIFF
--- a/omotion/MotionConsole.py
+++ b/omotion/MotionConsole.py
@@ -76,6 +76,7 @@ from omotion.config import (
 
 from omotion.GitHubReleases import GitHubReleases
 from omotion.MotionConfig import MotionConfig, MotionConfigHeader
+from omotion.utils import log_i2c_health
 from omotion.Calibration import (
     Calibration,
     parse_calibration,
@@ -169,6 +170,10 @@ class MotionConsole(SignalWrapper):
         self._state_cv = threading.Condition()
         self._monitor = None  # set by MotionInterface.start()
         self._version = "v0.0.0"
+
+        # Boot-time I2C health snapshot, populated at connection (None until
+        # then, or if the device firmware predates the I2C-status command).
+        self._i2c_health: Optional[dict] = None
 
     # ──────────────────────────────────────────────────────────────────
     # State (read-only from outside)
@@ -280,6 +285,7 @@ class MotionConsole(SignalWrapper):
     def _drive_connecting(self, reason: str) -> None:
         if self.uart.demo_mode:
             self._set_state(ConnectionState.CONNECTING, reason=reason)
+            self._check_i2c_health()
             self._set_state(ConnectionState.CONNECTED, reason="demo_mode")
             try:
                 self.telemetry.start()
@@ -315,6 +321,11 @@ class MotionConsole(SignalWrapper):
                 # version invoke `get_version()` from their own
                 # CONNECTED handler (e.g. `log_console_info`), which
                 # works correctly post-transition.
+                # Assess device health from the firmware's boot-time I2C scan.
+                # Best-effort: never blocks or fails the connection. Done
+                # before the CONNECTED transition so handle.i2c_health is
+                # ready the instant a waiter observes is_connected().
+                self._check_i2c_health()
                 self._set_state(ConnectionState.CONNECTED, reason="ping_ok")
                 try:
                     self.telemetry.start()
@@ -371,6 +382,7 @@ class MotionConsole(SignalWrapper):
             self.uart.close()
         except Exception:
             logger.exception("uart close failed")
+        self._i2c_health = None
         self._set_state(ConnectionState.DISCONNECTED, reason=reason)
 
     # ──────────────────────────────────────────────────────────────────
@@ -817,6 +829,32 @@ class MotionConsole(SignalWrapper):
         except Exception as e:
             self._log_command_error("get_i2c_health", e)
             return None
+
+    def _check_i2c_health(self) -> None:
+        """Read and cache the boot-time I2C health snapshot (connection step).
+
+        Best-effort: reads the cached firmware snapshot (no disruptive rescan),
+        never raises, and never affects the connection result. Stores the
+        snapshot on the handle and logs the outcome.
+        """
+        try:
+            self._i2c_health = self.get_i2c_health()
+        except Exception as e:
+            logger.debug("%s: I2C health check failed: %s", self.name, e)
+            self._i2c_health = None
+        log_i2c_health(self.name, self._i2c_health, logger)
+
+    @property
+    def i2c_health(self) -> Optional[dict]:
+        """Cached boot-time I2C health snapshot, or None if unavailable.
+
+        Populated at connection. See :meth:`get_i2c_health` for the shape.
+        """
+        return self._i2c_health
+
+    def is_i2c_healthy(self) -> bool:
+        """True iff a health snapshot is present and every expected device responded."""
+        return bool(self._i2c_health and self._i2c_health.get("all_present"))
 
     def read_i2c_packet(
         self,

--- a/omotion/MotionConsole.py
+++ b/omotion/MotionConsole.py
@@ -56,6 +56,7 @@ from omotion.config import (
     OW_CTRL_GET_TRIG,
     OW_CTRL_I2C_RD,
     OW_CTRL_I2C_SCAN,
+    OW_CTRL_I2C_STATUS,
     OW_CTRL_I2C_WR,
     OW_CTRL_PDUMON,
     OW_CTRL_READ_ADC,
@@ -742,6 +743,80 @@ class MotionConsole(SignalWrapper):
                 e,
             )
             raise
+
+    def get_i2c_health(self, rescan: bool = False) -> dict | None:
+        """Return the boot-time I2C health snapshot, or None on error.
+
+        At startup the console firmware passively pings every expected I2C
+        device across its two TCA9548 muxes and the fan bus, and caches the
+        result. This reads that snapshot.
+
+        Args:
+            rescan: if True, ask the firmware to re-run the (passive) scan live
+                before returning; if False, returns the cached boot snapshot.
+
+        Returns a dict::
+
+            {
+                "version": int,
+                "mux0": bool,          # TCA9548 #0 @0x70 on I2C1
+                "mux1": bool,          # TCA9548 #1 @0x70 on I2C2
+                "seed_cfg_fpga": bool, # XO2 config @0x40, mux0 ch0
+                "gpio_exp": bool,      # PCA9535 @0x20, mux1 ch0
+                "pdu_adc0": bool,      # ADS7828 @0x48, mux1 ch0
+                "pdu_adc1": bool,      # ADS7828 @0x4B, mux1 ch0
+                "tec_adc": bool,       # ADS7924 @0x49, mux1 ch3
+                "fan": bool,           # MAX6663 @0x2C, I2C4
+                "temps": [bool, bool, bool],  # MAX31875 0x49/0x4A/0x4B, mux1 ch1
+                "fpgas": {"ta": bool, "seed": bool, "ee": bool, "opt": bool},  # 0x41, mux1 ch4-7
+                "all_present": bool,
+            }
+        """
+        if self.uart.demo_mode:
+            return {
+                "version": 1,
+                "mux0": True, "mux1": True, "seed_cfg_fpga": True,
+                "gpio_exp": True, "pdu_adc0": True, "pdu_adc1": True,
+                "tec_adc": True, "fan": True,
+                "temps": [True, True, True],
+                "fpgas": {"ta": True, "seed": True, "ee": True, "opt": True},
+                "all_present": True,
+            }
+        try:
+            r = self.uart.send_packet(
+                id=None,
+                packetType=OW_CONTROLLER,
+                command=OW_CTRL_I2C_STATUS,
+                reserved=(1 if rescan else 0),
+            )
+            self.uart.clear_buffer()
+            if r is None or r.packetType == OW_ERROR or not r.data or r.data_len < 12:
+                return None
+            d = r.data
+            temp_mask = d[9]
+            fpga_mask = d[10]
+            return {
+                "version": d[0],
+                "mux0": bool(d[1]),
+                "mux1": bool(d[2]),
+                "seed_cfg_fpga": bool(d[3]),
+                "gpio_exp": bool(d[4]),
+                "pdu_adc0": bool(d[5]),
+                "pdu_adc1": bool(d[6]),
+                "tec_adc": bool(d[7]),
+                "fan": bool(d[8]),
+                "temps": [bool(temp_mask & (1 << i)) for i in range(3)],
+                "fpgas": {
+                    "ta": bool(fpga_mask & (1 << 4)),
+                    "seed": bool(fpga_mask & (1 << 5)),
+                    "ee": bool(fpga_mask & (1 << 6)),
+                    "opt": bool(fpga_mask & (1 << 7)),
+                },
+                "all_present": bool(d[11]),
+            }
+        except Exception as e:
+            self._log_command_error("get_i2c_health", e)
+            return None
 
     def read_i2c_packet(
         self,

--- a/omotion/MotionSensor.py
+++ b/omotion/MotionSensor.py
@@ -72,7 +72,7 @@ from omotion.config import (
 from omotion.i2c_packet import I2C_Packet
 from omotion.GitHubReleases import GitHubReleases
 from omotion.MotionProcessing import bytes_to_integers
-from omotion.utils import calculate_file_crc
+from omotion.utils import calculate_file_crc, log_i2c_health
 from omotion import _log_root
 
 logger = logging.getLogger(f"{_log_root}.Sensor" if _log_root else "Sensor")
@@ -146,6 +146,10 @@ class MotionSensor(SignalWrapper):
         self._cached_hwid: Optional[str] = None
         self.hardware_id: Optional[str] = None  # alias kept on the handle for clarity
         self._version: str = "v0.0.0"
+
+        # Boot-time I2C health snapshot, populated at connection (None until
+        # then, or if the device firmware predates the I2C-status command).
+        self._i2c_health: Optional[dict] = None
 
         # State machine
         self._state = ConnectionState.DISCONNECTED
@@ -317,6 +321,11 @@ class MotionSensor(SignalWrapper):
                 except Exception as e:
                     logger.debug("get_version during connect failed: %s", e)
 
+                # Assess device health from the firmware's boot-time I2C scan.
+                # Best-effort: never blocks or fails the connection. Done
+                # before the CONNECTED transition so handle.i2c_health is
+                # ready the instant a waiter observes is_connected().
+                self._check_i2c_health()
                 self._set_state(ConnectionState.CONNECTED, reason="ping_ok")
                 return
             except Exception as e:
@@ -335,6 +344,7 @@ class MotionSensor(SignalWrapper):
                 self._cached_camera_uids = None
                 self._cached_hwid = None
                 self.hardware_id = None
+                self._i2c_health = None
                 time.sleep(delay)
 
         self._set_state(
@@ -353,6 +363,7 @@ class MotionSensor(SignalWrapper):
         self._cached_camera_uids = None
         self._cached_hwid = None
         self.hardware_id = None
+        self._i2c_health = None
         self._set_state(ConnectionState.DISCONNECTED, reason=reason)
 
     # ------------------------------------------------------------------
@@ -502,6 +513,32 @@ class MotionSensor(SignalWrapper):
             "cameras_expected": d[5],
             "all_present": bool(d[6]),
         }
+
+    def _check_i2c_health(self) -> None:
+        """Read and cache the boot-time I2C health snapshot (connection step).
+
+        Best-effort: reads the cached firmware snapshot (no disruptive rescan),
+        never raises, and never affects the connection result. Stores the
+        snapshot on the handle and logs the outcome.
+        """
+        try:
+            self._i2c_health = self.get_i2c_health()
+        except Exception as e:
+            logger.debug("%s: I2C health check failed: %s", self.name, e)
+            self._i2c_health = None
+        log_i2c_health(self.name, self._i2c_health, logger)
+
+    @property
+    def i2c_health(self) -> Optional[dict]:
+        """Cached boot-time I2C health snapshot, or None if unavailable.
+
+        Populated at connection. See :meth:`get_i2c_health` for the shape.
+        """
+        return self._i2c_health
+
+    def is_i2c_healthy(self) -> bool:
+        """True iff a health snapshot is present and every expected device responded."""
+        return bool(self._i2c_health and self._i2c_health.get("all_present"))
 
     # ------------------------------------------------------------------
     # Fan control

--- a/omotion/MotionSensor.py
+++ b/omotion/MotionSensor.py
@@ -22,6 +22,7 @@ from omotion.config import (
     OW_CMD,
     OW_CMD_ECHO,
     OW_CMD_HWID,
+    OW_CMD_I2C_STATUS,
     OW_CMD_PING,
     OW_CMD_RESET,
     OW_CMD_TOGGLE_LED,
@@ -442,6 +443,65 @@ class MotionSensor(SignalWrapper):
             return bytes.fromhex("deadbeefcafebabe1122334455667788")
         r = self._send(packetType=OW_CMD, command=OW_CMD_HWID)
         return r.data.hex() if r.data_len == 16 else None
+
+    # ------------------------------------------------------------------
+    # I2C health
+    # ------------------------------------------------------------------
+
+    def get_i2c_health(self, rescan: bool = False) -> dict | None:
+        """Return the boot-time I2C health snapshot, or None on error.
+
+        The firmware verifies, at startup, that every expected I2C device is
+        present: the TCA9548A mux, the ICM-20948 IMU, and all 8 cameras
+        (OV2312) + 8 FPGAs (CrossLink) behind the mux. The USB PHY is not on
+        I2C (ULPI) and is excluded.
+
+        Args:
+            rescan: if True, ask the firmware to re-run the scan live (powers
+                each camera one at a time, ~2 s) before returning. If False,
+                returns the cached boot snapshot immediately.
+
+        Returns a dict::
+
+            {
+                "version": int,
+                "mux": bool,             # TCA9548A 0x70
+                "imu": bool,             # ICM-20948 0x68
+                "cameras": [bool] * 8,   # OV2312 0x36 per mux channel
+                "fpgas":   [bool] * 8,   # CrossLink 0x40 per mux channel
+                "cameras_expected": int, # bitmask, 0xFF = all 8
+                "all_present": bool,
+            }
+        """
+        if self.demo_mode:
+            return {
+                "version": 1,
+                "mux": True,
+                "imu": True,
+                "cameras": [True] * 8,
+                "fpgas": [True] * 8,
+                "cameras_expected": 0xFF,
+                "all_present": True,
+            }
+        r = self._send(
+            packetType=OW_CMD,
+            command=OW_CMD_I2C_STATUS,
+            reserved=(1 if rescan else 0),
+        )
+        if r is None or r.packetType in _ERROR_TYPES or r.data_len < 8:
+            return None
+        d = r.data
+        cam_mask = d[3]
+        fpga_mask = d[4]
+        return {
+            "version": d[0],
+            "mux": bool(d[1]),
+            "imu": bool(d[2]),
+            "cameras": [bool(cam_mask & (1 << i)) for i in range(8)],
+            "fpgas": [bool(fpga_mask & (1 << i)) for i in range(8)],
+            "cameras_expected": d[5],
+            "all_present": bool(d[6]),
+        }
 
     # ------------------------------------------------------------------
     # Fan control

--- a/omotion/config.py
+++ b/omotion/config.py
@@ -177,6 +177,7 @@ OW_CTRL_GET_LASER_ODO = 0x27
 # Payload: 1 byte target (0=system, 1=laser, 2=both). Missing payload defaults
 # to both.
 OW_CTRL_RESET_ODO = 0x28
+OW_CTRL_I2C_STATUS = 0x29
 OW_CTRL_FAN_CTL = 0x0A
 
 # Page-by-page direct FPGA programming commands (0x30–0x3C)

--- a/omotion/config.py
+++ b/omotion/config.py
@@ -132,6 +132,7 @@ OW_CMD_NOP = 0x0E
 OW_CMD_RESET = 0x0F
 OW_CMD_I2C_BROADCAST = 0x06
 OW_CMD_DEBUG_FLAGS = 0x0C
+OW_CMD_I2C_STATUS = 0x0B
 
 # Debug flag bits.
 DEBUG_FLAG_USB_PRINTF = 0x01  # Turn on or off USB printf logging

--- a/omotion/utils.py
+++ b/omotion/utils.py
@@ -322,3 +322,25 @@ def list_vcp_with_vid_pid(target_vid, target_pid):
             print(f"Device found: {port.device} - {port.description}")
             devices.append(port.device)
     return devices
+
+
+def log_i2c_health(name, snapshot, logger):
+    """Log the outcome of a device's boot-time I2C health snapshot.
+
+    Shared by MotionSensor / MotionConsole connection handling.
+
+    - ``snapshot is None`` → DEBUG. The query failed or the firmware predates
+      the I2C-status command; treated as "unknown", never an error.
+    - ``all_present`` true → INFO.
+    - otherwise → WARNING, including the snapshot so the missing devices show.
+    """
+    if snapshot is None:
+        logger.debug(
+            "%s: I2C health unavailable (query failed or firmware predates "
+            "the I2C-status command)", name,
+        )
+    elif snapshot.get("all_present"):
+        logger.info("%s: I2C health OK - all expected devices present", name)
+    else:
+        logger.warning("%s: I2C health DEGRADED - not all devices present: %s",
+                       name, snapshot)

--- a/tests/test_i2c_health.py
+++ b/tests/test_i2c_health.py
@@ -1,0 +1,61 @@
+"""Tests for the connection-time I2C health check.
+
+Pure-unit tests cover the shared logging helper. The fixture-based tests
+confirm that connecting a device auto-populates its cached health snapshot
+(runs against hardware, or in demo mode via OPENMOTION_DEMO=1; skips
+otherwise).
+"""
+
+from unittest.mock import Mock
+
+import pytest
+
+from omotion.utils import log_i2c_health
+
+
+# ---------------------------------------------------------------------------
+# log_i2c_health — pure unit, no hardware
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_log_i2c_health_none_is_debug():
+    lg = Mock()
+    log_i2c_health("dev", None, lg)
+    lg.debug.assert_called_once()
+    lg.info.assert_not_called()
+    lg.warning.assert_not_called()
+
+
+@pytest.mark.unit
+def test_log_i2c_health_all_present_is_info():
+    lg = Mock()
+    log_i2c_health("dev", {"all_present": True}, lg)
+    lg.info.assert_called_once()
+    lg.warning.assert_not_called()
+
+
+@pytest.mark.unit
+def test_log_i2c_health_degraded_is_warning():
+    lg = Mock()
+    log_i2c_health("dev", {"all_present": False, "imu": False}, lg)
+    lg.warning.assert_called_once()
+    lg.info.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Connection-time population — requires a connected device (or demo mode)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.console
+def test_console_i2c_health_populated_on_connect(console):
+    # The handle reads and caches its boot-time snapshot during connection.
+    snap = console.i2c_health
+    assert snap is not None, "i2c_health should be populated at connection"
+    assert console.is_i2c_healthy() == bool(snap.get("all_present"))
+
+
+@pytest.mark.sensor
+def test_sensor_i2c_health_populated_on_connect(sensor_left):
+    snap = sensor_left.i2c_health
+    assert snap is not None, "i2c_health should be populated at connection"
+    assert sensor_left.is_i2c_healthy() == bool(snap.get("all_present"))


### PR DESCRIPTION
Fold `next-next` into `next`. Clean fast-forward — `next` is a direct ancestor of `next-next`; these 6 commits sit linearly on top.

### Commits
- feat: `MotionSensor.get_i2c_health()` — boot-time I2C health scan (#83)
- feat: `MotionConsole.get_i2c_health()` — console boot-time I2C scan (#84)
- feat: assess device I2C health at connection time (#85)

No divergence, no conflicts — `next-next` = `next` + these commits.