### PR TITLE
feat: log sensor hardware info as a guarded, side-labeled block

### DIFF
--- a/omotion/MotionInterface.py
+++ b/omotion/MotionInterface.py
@@ -485,7 +485,7 @@ class MotionInterface:
     def log_sensor_info(self, side: str) -> None:
         sensor = self.left if side == "left" else self.right if side == "right" else None
         if sensor and sensor.is_connected():
-            sensor.log_device_info()
+            sensor.log_device_info(label=side)
 
     @staticmethod
     def get_sdk_version() -> str:

--- a/omotion/MotionSensor.py
+++ b/omotion/MotionSensor.py
@@ -1681,24 +1681,39 @@ class MotionSensor(SignalWrapper):
     # Lifecycle
     # ------------------------------------------------------------------
 
-    def log_device_info(self) -> None:
-        """Log sensor firmware version, hardware ID, and cached camera UIDs to the SDK logger."""
+    def log_device_info(self, label: str | None = None) -> None:
+        """Log a ``====``-guarded, side-labeled block with everything we need
+        to identify this sensor: firmware version, hardware ID, serial number,
+        and all 8 camera UIDs.
+
+        ``label`` is the side ("left"/"right") supplied by
+        :meth:`omotion.MotionInterface.log_sensor_info`; it tags the block so
+        the two sensors are distinguishable in the log. The whole block is
+        emitted as a single log record so it stays intact even when both
+        sensors log concurrently (camera UIDs that failed to read are shown
+        as ``<none>`` rather than dropped, so a dead camera stays visible).
+        """
+        title = (label or "sensor").upper()
         try:
             fw_version = self.get_version()
             hw_id      = self.get_cached_hardware_id() or self.get_hardware_id()
-            if self._cached_camera_uids:
-                uid_summary = ", ".join(
-                    f"cam{k}={v}" for k, v in sorted(self._cached_camera_uids.items()) if v
-                )
-            else:
-                uid_summary = "none cached"
-            serial = self.read_serial_number() or "unprogrammed"
-            logger.info(
-                "Sensor: firmware=%s  hw_id=%s  serial=%s  camera_uids=[%s]",
-                fw_version, hw_id, serial, uid_summary,
-            )
+            serial     = self.read_serial_number() or "unprogrammed"
+            uids       = self._cached_camera_uids or {}
+            rule = "=" * 60
+            lines = [
+                rule,
+                f"{title} SENSOR",
+                f"  firmware = {fw_version}",
+                f"  hw_id    = {hw_id}",
+                f"  serial   = {serial}",
+                "  camera UIDs:",
+            ]
+            for cam in range(8):
+                lines.append(f"    cam{cam} = {uids.get(cam) or '<none>'}")
+            lines.append(rule)
+            logger.info("\n".join(lines))
         except Exception as e:
-            logger.warning("Sensor: failed to read device info: %s", e)
+            logger.warning("%s sensor: failed to read device info: %s", title, e)
 
 # Note: graceful disconnect is now driven by ConnectionMonitor via
 # `request_disconnect()` (which submits an EVT_USER_STOP). The old

--- a/tests/test_sensor_device_info_log.py
+++ b/tests/test_sensor_device_info_log.py
@@ -1,0 +1,84 @@
+"""Unit tests for MotionSensor.log_device_info block formatting.
+
+These construct a MotionSensor without USB enumeration and mock the
+identity reads, so they run with no hardware. The point of the block is
+that every piece of hardware info we need (firmware, hw_id, serial, and
+all 8 camera UIDs) is logged, inside a ``====``-guarded, side-labeled
+region emitted as a single log record.
+"""
+import logging
+
+from unittest.mock import MagicMock
+
+from omotion.MotionSensor import MotionSensor
+from omotion.MotionSensor import logger as sensor_logger
+
+
+def _make_sensor(uids):
+    s = MotionSensor.__new__(MotionSensor)
+    s.get_version = MagicMock(return_value="1.7.0")
+    s.get_cached_hardware_id = MagicMock(return_value="DEADBEEF")
+    s.get_hardware_id = MagicMock(return_value="DEADBEEF")
+    s.read_serial_number = MagicMock(return_value="OW-SN-001")
+    s._cached_camera_uids = uids
+    return s
+
+
+def _block(caplog):
+    """The single log record emitted by log_device_info."""
+    assert len(caplog.records) == 1, [r.getMessage() for r in caplog.records]
+    return caplog.records[0].getMessage()
+
+
+def test_block_is_single_guarded_record(caplog):
+    sensor = _make_sensor({i: f"0x{i:012X}" for i in range(8)})
+    with caplog.at_level(logging.INFO, logger=sensor_logger.name):
+        sensor.log_device_info(label="left")
+    msg = _block(caplog)
+    lines = msg.splitlines()
+    # Guarded top and bottom with a ==== rule.
+    assert set(lines[0]) == {"="}
+    assert set(lines[-1]) == {"="}
+    assert len(lines[0]) >= 4
+
+
+def test_block_carries_label_and_all_identity_fields(caplog):
+    sensor = _make_sensor({i: f"0x{i:012X}" for i in range(8)})
+    with caplog.at_level(logging.INFO, logger=sensor_logger.name):
+        sensor.log_device_info(label="right")
+    msg = _block(caplog)
+    assert "RIGHT" in msg                # side label, uppercased
+    assert "1.7.0" in msg                # firmware version
+    assert "DEADBEEF" in msg             # hardware id
+    assert "OW-SN-001" in msg            # serial number
+
+
+def test_block_logs_all_eight_camera_uids(caplog):
+    uids = {i: f"0x{i:012X}" for i in range(8)}
+    sensor = _make_sensor(uids)
+    with caplog.at_level(logging.INFO, logger=sensor_logger.name):
+        sensor.log_device_info(label="left")
+    msg = _block(caplog)
+    for i in range(8):
+        assert f"cam{i}" in msg
+        assert uids[i] in msg
+
+
+def test_missing_camera_uid_is_shown_not_dropped(caplog):
+    # Camera 3 failed to read (empty string); it must still appear so a
+    # dead camera is visible in the log rather than silently omitted.
+    uids = {i: (f"0x{i:012X}" if i != 3 else "") for i in range(8)}
+    sensor = _make_sensor(uids)
+    with caplog.at_level(logging.INFO, logger=sensor_logger.name):
+        sensor.log_device_info(label="left")
+    msg = _block(caplog)
+    assert "cam3" in msg
+    assert "<none>" in msg
+
+
+def test_no_label_defaults_to_sensor(caplog):
+    sensor = _make_sensor({i: f"0x{i:012X}" for i in range(8)})
+    with caplog.at_level(logging.INFO, logger=sensor_logger.name):
+        sensor.log_device_info()
+    msg = _block(caplog)
+    assert "SENSOR" in msg


### PR DESCRIPTION
Reformats `MotionSensor.log_device_info()` so all the hardware identity we need is logged in one clearly-delimited, side-labeled block.

### Before
```
Sensor: firmware=1.7.0  hw_id=A1B2C3D4E5F6  serial=OW-LEFT-0007  camera_uids=[cam0=0x..., cam1=0x...]
```
One line; empty/failed camera UIDs were silently dropped; no side label.

### After
```
============================================================
LEFT SENSOR
  firmware = 1.7.0
  hw_id    = A1B2C3D4E5F6
  serial   = OW-LEFT-0007
  camera UIDs:
    cam0 = 0x000000000000
    cam1 = 0x000000000001
    cam2 = 0x000000000002
    cam3 = <none>
    cam4 = 0x000000000004
    cam5 = 0x000000000005
    cam6 = 0x000000000006
    cam7 = 0x000000000007
============================================================
```

### Changes
- `MotionSensor.log_device_info(label=None)` emits a `====`-guarded block carrying firmware, hw_id, serial, and **all 8** camera UIDs.
- `MotionInterface.log_sensor_info(side)` passes the side through as the label, so the left and right blocks are distinguishable in the log.
- A camera UID that failed to read shows as `<none>` instead of being dropped — a dead camera stays visible.
- The whole block is a single log record (newline-joined), so it can't interleave with the other sensor's block when both log concurrently.

### Tests
- New `tests/test_sensor_device_info_log.py` (5 cases, pure-software, no hardware): single guarded record, side label + all identity fields present, all 8 UIDs logged, missing UID shown not dropped, default label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
