### PR TITLE
fix: detect read-only scan DB before scan start (#213)

### DIFF
--- a/omotion/ScanDatabase.py
+++ b/omotion/ScanDatabase.py
@@ -170,6 +170,27 @@ class ScanDatabase:
             raise RuntimeError("Database connection is closed")
         return self._conn
 
+    def assert_writable(self) -> None:
+        """Force SQLite to attempt a write so a read-only file fails *here*.
+
+        Opening a read-only SQLite file succeeds — the error
+        (``sqlite3.OperationalError: attempt to write a readonly database``)
+        only surfaces on the first write. So ``__init__`` alone cannot detect
+        a read-only database file, and in WAL mode neither can a bare
+        ``BEGIN IMMEDIATE`` (its write is deferred to the ``-wal``). Callers
+        that must fail before a side effect — e.g. firing the laser at scan
+        start — call this to provoke the write up front.
+
+        Rewrites ``PRAGMA user_version`` to its current value: a header write
+        that fails on a read-only DB but is a semantic no-op when it succeeds,
+        so nothing is persisted. Raises ``sqlite3.OperationalError`` (or other
+        ``sqlite3.Error``) when the database is not writable; returns ``None``
+        otherwise.
+        """
+        conn = self._connection()
+        version = int(conn.execute("PRAGMA user_version").fetchone()[0])
+        conn.execute(f"PRAGMA user_version = {version}")
+
     # ------------------------------------------------------------------
     # Sessions
     # ------------------------------------------------------------------

--- a/omotion/ScanWorkflow.py
+++ b/omotion/ScanWorkflow.py
@@ -139,6 +139,13 @@ class ScanRequest:
     # resolved default (DEFAULT_TRIGGER_CONFIG ⊕ constructor override). A dict
     # here is shallow-merged on top (e.g. {"TriggerFrequencyHz": 20}).
     trigger_config: dict | None = None
+    # Called (with the exception) when the scan worker thread aborts AFTER
+    # start_scan returned True — e.g. a critical sink failing in on_scan_start
+    # because the scan DB became unwritable in the race window past the
+    # synchronous preflight. Lets the caller surface a failure that a return
+    # value can no longer carry. Fires on the worker thread, so the handler
+    # must be thread-safe. See bloodflow-app issue #213.
+    on_error: Callable[[BaseException], None] | None = None
 
 
 @dataclass
@@ -486,7 +493,17 @@ class ScanWorkflow:
                 # if the DB dies between this check and the worker start.)
                 try:
                     from omotion.ScanDatabase import ScanDatabase
-                    ScanDatabase(db_path=scan_db_path).close()
+                    _preflight_db = ScanDatabase(db_path=scan_db_path)
+                    try:
+                        # Opening a read-only DB succeeds (open never writes),
+                        # so probe a real write here — otherwise a read-only
+                        # file/dir slips through and the failure only surfaces
+                        # asynchronously on the first INSERT in the worker
+                        # thread, after the laser has fired. See bloodflow-app
+                        # issue #213.
+                        _preflight_db.assert_writable()
+                    finally:
+                        _preflight_db.close()
                 except Exception as exc:
                     logger.exception(
                         "start_scan: scan database pre-flight failed (%s) — "
@@ -710,6 +727,14 @@ class ScanWorkflow:
             except Exception as e:
                 logger.exception("ScanWorkflow worker raised")
                 self._last_scan_error = str(e) or type(e).__name__
+                # Notify the caller of an async start failure (start_scan
+                # already returned True, so the failure can't ride the return
+                # value). Guarded so a faulty handler can't break teardown.
+                if request.on_error is not None:
+                    try:
+                        request.on_error(e)
+                    except Exception:
+                        logger.exception("ScanRequest.on_error handler raised")
             finally:
                 if telemetry_writer is not None:
                     telemetry_writer.close()

--- a/tests/test_scan_database.py
+++ b/tests/test_scan_database.py
@@ -2,6 +2,8 @@
 
 import json
 import os
+import sqlite3
+import stat
 import sys
 from pathlib import Path
 
@@ -74,3 +76,45 @@ def test_session_meta_survives_unicode_and_none(tmp_db: ScanDatabase) -> None:
     )
     session = tmp_db.get_session(sid)
     assert session["session_meta"] == meta
+
+
+# ---------------------------------------------------------------------------
+# assert_writable — write-probe so a read-only DB fails the scan preflight
+# synchronously (before the laser fires) instead of asynchronously on the
+# first INSERT inside the scan worker thread. See bloodflow-app issue #213.
+# ---------------------------------------------------------------------------
+
+def test_assert_writable_raises_on_readonly_db(tmp_path: Path) -> None:
+    """A read-only DB file opens fine (open never writes) but a write fails.
+    assert_writable must force that write and surface the OperationalError."""
+    p = tmp_path / "ro.db"
+    ScanDatabase(db_path=str(p)).close()  # create + schema while writable
+    os.chmod(p, stat.S_IREAD)             # Windows read-only attribute
+    db = ScanDatabase(db_path=str(p))     # reopen: succeeds, no write yet
+    try:
+        with pytest.raises(sqlite3.OperationalError):
+            db.assert_writable()
+    finally:
+        db.close()
+        os.chmod(p, stat.S_IWRITE)
+
+
+def test_assert_writable_noop_on_writable_db(tmp_db: ScanDatabase) -> None:
+    """On a writable DB the probe returns None and persists nothing."""
+    settings_before = tmp_db._connection().execute(
+        "SELECT COUNT(*) FROM database_settings"
+    ).fetchone()[0]
+    version_before = tmp_db._connection().execute(
+        "PRAGMA user_version"
+    ).fetchone()[0]
+
+    assert tmp_db.assert_writable() is None
+
+    settings_after = tmp_db._connection().execute(
+        "SELECT COUNT(*) FROM database_settings"
+    ).fetchone()[0]
+    version_after = tmp_db._connection().execute(
+        "PRAGMA user_version"
+    ).fetchone()[0]
+    assert settings_after == settings_before
+    assert version_after == version_before

--- a/tests/test_scan_workflow.py
+++ b/tests/test_scan_workflow.py
@@ -1,6 +1,8 @@
 """Tests for ScanWorkflow and ScanRequest."""
 
 import dataclasses
+import os
+import stat
 import threading
 import time
 from unittest import mock
@@ -389,6 +391,75 @@ def test_start_scan_sends_trigger_config_before_start_trigger():
         "set_trigger_json must be sent before start_trigger"
     sent = next(payload for kind, payload in calls if kind == "set")
     assert sent == expected_cfg
+
+
+def test_start_scan_aborts_synchronously_when_scan_db_readonly(tmp_path):
+    """Issue #213: a read-only scan DB must abort the scan in the synchronous
+    preflight — start_scan returns False (so the worker that fires the laser is
+    never spawned) and records last_scan_error. The old preflight only *opened*
+    the DB, which succeeds on a read-only file because opening never writes; the
+    write-probe forces the failure to surface here instead of asynchronously on
+    the first INSERT in the worker thread."""
+    db_path = tmp_path / "scans.db"
+    from omotion.ScanDatabase import ScanDatabase
+    ScanDatabase(db_path=str(db_path)).close()  # create while writable
+    os.chmod(db_path, stat.S_IREAD)             # then mark read-only
+    try:
+        motion = _build_motion_with_data_dir(str(tmp_path), scan_db_path=str(db_path))
+        request = ScanRequest(
+            subject_id="x", duration_sec=1,
+            left_camera_mask=0xFF, right_camera_mask=0, reduced_mode=False,
+        )
+        started = motion.scan_workflow.start_scan(request)
+
+        assert started is False
+        # No worker thread spawned -> the laser path is never reached.
+        assert motion.scan_workflow._thread is None
+        err = motion.scan_workflow.last_scan_error
+        assert err is not None
+        assert "readonly" in err.lower()
+    finally:
+        os.chmod(db_path, stat.S_IWRITE)
+
+
+def test_worker_invokes_on_error_when_scan_aborts(tmp_path):
+    """A scan failure that surfaces only in the worker thread (e.g. the scan DB
+    becoming unwritable in the race window after the synchronous preflight
+    passed) must notify the caller via ScanRequest.on_error — start_scan already
+    returned True, so a return value can't carry the failure. Without this the
+    worker dies silently and the app shows no error. See bloodflow-app #213."""
+    motion = _build_motion_with_data_dir(None)
+
+    errors = []
+    done = threading.Event()
+
+    def on_error(exc):
+        errors.append(exc)
+        done.set()
+
+    class _ExplodingCriticalSink:
+        critical = True
+        channels: set = set()
+
+        def on_scan_start(self, meta):
+            raise RuntimeError("db vanished mid-scan")
+
+        def consume(self, channel, payload):
+            pass
+
+        def on_complete(self):
+            pass
+
+    request = ScanRequest(
+        subject_id="x", duration_sec=1,
+        left_camera_mask=0xFF, right_camera_mask=0, reduced_mode=False,
+        sinks=[_ExplodingCriticalSink()], skip_default_storage=True,
+        on_error=on_error,
+    )
+    assert motion.scan_workflow.start_scan(request) is True
+    assert done.wait(timeout=5.0), "on_error was never invoked"
+    assert isinstance(errors[0], BaseException)
+    assert "db vanished mid-scan" in str(errors[0])
 
 
 def test_start_scan_trigger_config_override_is_merged():


### PR DESCRIPTION
## Summary
Fixes the SDK half of bloodflow-app issue [#213](https://github.com/OpenwaterHealth/openmotion-bloodflow-app/issues/213): a read-only scan database let the scan *appear* to start (laser fired), then died asynchronously in the worker thread with no error surfaced.

- **`ScanDatabase.assert_writable()`** — probes a real write (`PRAGMA user_version` rewrite) so a read-only DB raises `sqlite3.OperationalError` immediately. Opening a read-only SQLite file succeeds (open never writes), and a WAL-deferred `BEGIN IMMEDIATE` doesn't hit the read-only main file either — only an actual write does.
- **`start_scan` preflight** now calls `assert_writable()`, so the read-only case aborts **synchronously, before the laser fires**, returning `False` with `last_scan_error` set (the app maps that to E-301).
- **`ScanRequest.on_error`** — invoked from the worker thread when a scan aborts *after* `start_scan` returned `True` (the race window past the preflight, where a return value can no longer carry the failure).

## Test Plan
- [x] `tests/test_scan_database.py` — `assert_writable` raises on a read-only DB, no-ops (persists nothing) on a writable one
- [x] `tests/test_scan_workflow.py` — `start_scan` aborts synchronously (no worker spawned) with `last_scan_error` set on a read-only DB; `on_error` fires when the worker aborts after start
- [x] Full `test_scan_workflow.py` + `test_scan_database.py` + `test_scan_db_sink_empty.py` green (24 passed); pipeline suite collects clean (259)

## Cross-repo
Pairs with bloodflow-app PR (consumes `on_error` + relies on the preflight). The app installs this SDK editable, so both must land together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)