### PR TITLE
fix: reject non-monotonic frame ids in unwrapper (#172)

### DIFF
--- a/omotion/pipeline/stages/classify.py
+++ b/omotion/pipeline/stages/classify.py
@@ -24,7 +24,25 @@ _FRAME_ROLLOVER_THRESHOLD = 128
 
 
 class _FrameUnwrapper:
-    """8-bit rolling → monotonic. One instance per (side, cam_id)."""
+    """8-bit rolling → monotonic. One instance per (side, cam_id).
+
+    Robust against a non-monotonic frame stream. The sensor occasionally
+    emits stale/garbage frames — leftover buffer contents at scan start
+    (e.g. raw 1, 255, 173, 4, 5 …) or a mid-scan counter blip — when its
+    histogram DMA buffer isn't flushed. The old unwrapper trusted every
+    frame after the first, so a backward-looking value (255 after 1) was
+    read as a huge forward jump and the next real frame (4) tripped the
+    rollover test, injecting a permanent +256 epoch offset that shifted the
+    whole positional dark/warmup schedule for the rest of the scan.
+
+    Now each frame is gated by its *signed* 8-bit step from the last
+    accepted frame: only forward steps (1..127) advance state; a backward
+    or duplicate step (<= 0) is rejected as stale and does NOT advance the
+    counter, so isolated garbage frames can't corrupt the epoch. The 8-bit
+    counter can't disambiguate a genuine forward gap > 127 frames (a >3.2 s
+    intra-scan dropout) from a backward step; such ambiguous frames are
+    rejected — that data is already lost in a gap that large.
+    """
 
     __slots__ = ("epoch", "last_raw", "seen_first", "first_was_stale")
 
@@ -34,18 +52,30 @@ class _FrameUnwrapper:
         self.seen_first = False
         self.first_was_stale = False
 
-    def unwrap(self, raw_frame_id: int) -> int:
+    def unwrap(self, raw_frame_id: int) -> tuple[int, bool]:
+        """Return (abs_frame_id, accepted).
+
+        accepted=False marks a stale/non-monotonic frame: the abs_id is
+        advisory only and the unwrapper state is left untouched so the
+        next genuine frame resumes the sequence cleanly.
+        """
         if not self.seen_first:
             self.seen_first = True
             self.first_was_stale = (raw_frame_id != 1)
             self.last_raw = raw_frame_id
-            return raw_frame_id
+            return raw_frame_id, True
 
-        delta = (raw_frame_id - self.last_raw) & 0xFF
-        if delta <= _FRAME_ROLLOVER_THRESHOLD and raw_frame_id < self.last_raw:
+        # Signed step in [-128, 127]: positive = forward, <= 0 = backward
+        # (stale leftover) or duplicate.
+        step = ((raw_frame_id - self.last_raw + 128) & 0xFF) - 128
+        if step <= 0:
+            return self.epoch * _FRAME_ID_MODULUS + raw_frame_id, False
+
+        # Forward step (1..127). A wrap shows up as raw <= last_raw.
+        if raw_frame_id <= self.last_raw:
             self.epoch += 1
         self.last_raw = raw_frame_id
-        return self.epoch * _FRAME_ID_MODULUS + raw_frame_id
+        return self.epoch * _FRAME_ID_MODULUS + raw_frame_id, True
 
 
 class FrameClassificationStage:
@@ -75,10 +105,15 @@ class FrameClassificationStage:
                 unwrapper = _FrameUnwrapper()
                 self._unwrappers[key] = unwrapper
 
-            abs_id = unwrapper.unwrap(raw_id)
+            abs_id, accepted = unwrapper.unwrap(raw_id)
             abs_ids[i] = abs_id
 
-            if unwrapper.first_was_stale and abs_id == raw_id:
+            if not accepted:
+                # Non-monotonic / stale leftover frame (e.g. unflushed
+                # histogram buffer at scan start or a mid-scan counter blip).
+                # Excluded downstream so it can't poison dark/timestamp align.
+                types[i] = "stale"
+            elif unwrapper.first_was_stale and abs_id == raw_id:
                 types[i] = "stale"
             elif abs_id <= self.discard_count:
                 types[i] = "warmup"

--- a/tests/test_pipeline/test_classify_stage.py
+++ b/tests/test_pipeline/test_classify_stage.py
@@ -71,6 +71,42 @@ def test_unwrap_handles_8bit_rollover():
     np.testing.assert_array_equal(batch.abs_frame_ids, expected_abs)
 
 
+def test_stale_leftover_frames_at_start_are_rejected_not_offsetting_epoch():
+    """Reproduces the Varun-unit left-sensor capture (issue #172): an unflushed
+    histogram buffer emits stale frames (raw 255, 173) after the real first
+    frame, then the real sequence resumes (4, 5, 6 …). The old unwrapper read
+    255 as a forward jump and 4 as a rollover, injecting a permanent +256
+    epoch offset that shifted the entire dark/warmup schedule. The stale frames
+    must be rejected without advancing the counter."""
+    raw_ids = [1, 255, 173, 4, 5, 6, 7, 8, 9, 10, 11]
+    batch = _batch_with_raw_ids({(0, 0): raw_ids})
+    FrameClassificationStage(discard_count=9, dark_interval=600).process(batch)
+    # 255 and 173 rejected as stale; real frames keep their true abs_id (no +256).
+    np.testing.assert_array_equal(
+        batch.frame_type,
+        ["warmup", "stale", "stale", "warmup", "warmup", "warmup",
+         "warmup", "warmup", "warmup", "dark", "light"],
+    )
+    np.testing.assert_array_equal(
+        batch.abs_frame_ids, [1, 255, 173, 4, 5, 6, 7, 8, 9, 10, 11]
+    )
+
+
+def test_midscan_counter_blip_is_rejected_and_sequence_resumes():
+    """A mid-scan counter glitch (…3, 4, [2, 3], 5 …) must not reset the epoch:
+    the spurious backward 2,3 are rejected and 5 continues the run."""
+    raw_ids = [1, 2, 3, 4, 2, 3, 5, 6]
+    batch = _batch_with_raw_ids({(0, 0): raw_ids})
+    FrameClassificationStage(discard_count=9, dark_interval=600).process(batch)
+    # backward 2,3 rejected; the real run 1..6 keeps monotonic abs ids.
+    assert list(batch.frame_type) == [
+        "warmup", "warmup", "warmup", "warmup",
+        "stale", "stale", "warmup", "warmup"]
+    np.testing.assert_array_equal(
+        batch.abs_frame_ids, [1, 2, 3, 4, 2, 3, 5, 6]
+    )
+
+
 def test_zero_filled_row_keeps_source_assigned_side():
     """A row whose raw_histogram is all zeros (e.g. firmware-dropped frame)
     must still be routed to its source-assigned side.


### PR DESCRIPTION
## Problem
A stale/leftover frame stream from the sensor (e.g. raw `1, 255, 173, 4, 5 …` at scan start, plus a mid-scan counter blip — see OpenwaterHealth/openmotion-bloodflow-app#172 / OpenwaterHealth/openmotion-bloodflow-app#183) corrupted the pipeline. The frame-id unwrapper only sanity-checked the **first** frame (`raw==1`); after that it trusted everything, so a backward-looking value (`255` after `1`) was read as a huge forward jump and the next real frame tripped the rollover test — injecting a permanent **+256 epoch offset** that shifted the entire positional dark/warmup schedule for the rest of the scan. Result: dark labels landed on laser-on frames, dark correction was poisoned, warmup collapsed (9→1), and per-side t0 normalization produced negative timestamps.

## Fix
Gate each frame by its **signed 8-bit step** from the last accepted frame: forward steps (1..127) advance state; backward/duplicate steps (≤0) are rejected as `stale` without advancing the epoch, so isolated stale frames can't corrupt the counter. An ambiguous forward gap >127 frames (a >3.2 s intra-scan dropout) is also rejected — that data is already lost in a gap that large.

## Verification
Replayed the **actual captured corrupt left-sensor scan** (`191626_varun_unit_timestamp`) through old vs new:

| metric | before | after |
|---|---|---|
| `dark`-labeled-but-bright frames | 10 | **0** |
| warmup frames | 1 | **7** |
| frame 4 → abs_id | 260 (+256) | **4** |
| dark-frame u1 | 277 (contaminated) | **128 (pedestal)** |

Adds two regression tests; full classify/dark suite (69) green. This makes the host robust to a corrupt frame stream regardless of which unit/firmware produced it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
