### PR TITLE
feat: surface console printf; unify console + sensor command transports

### DIFF
--- a/omotion/CommInterface.py
+++ b/omotion/CommInterface.py
@@ -2,7 +2,7 @@
 
 The threading, framing and dispatch live in :class:`omotion.packet_transport.PacketTransport`;
 this class only supplies the USB-specific raw I/O (bulk read/write with libusb
-error handling), interface claim, and a synchronous send path used by tests.
+error handling) and the interface claim.
 """
 import logging
 import time
@@ -10,8 +10,6 @@ import time
 import usb.core
 import usb.util
 
-from omotion.UartPacket import UartPacket
-from omotion.config import OW_ACK, OW_CMD_NOP, OW_END_BYTE
 from omotion.packet_transport import PacketTransport
 from omotion.USBInterfaceBase import USBInterfaceBase
 from omotion import _log_root
@@ -25,11 +23,9 @@ logger = logging.getLogger(
 # Comm Interface (IN + OUT + threads)
 # =========================================
 class CommInterface(PacketTransport, USBInterfaceBase):
-    def __init__(self, dev, interface_index, desc="Comm", async_mode=False):
+    def __init__(self, dev, interface_index, desc="Comm"):
         USBInterfaceBase.__init__(self, dev, interface_index, desc)
-        PacketTransport.__init__(
-            self, desc=desc, async_mode=async_mode, default_timeout=10.0
-        )
+        PacketTransport.__init__(self, desc=desc, default_timeout=10.0)
 
     def claim(self):
         USBInterfaceBase.claim(self)
@@ -93,58 +89,3 @@ class CommInterface(PacketTransport, USBInterfaceBase):
                         except Exception as recovery_err:
                             logger.error("%s: clear_halt recovery failed: %s", self.desc, recovery_err)
                     raise
-
-    def receive(self, length=512, timeout=100):
-        with self._io_lock:
-            data = self.dev.read(self.ep_in.bEndpointAddress, length, timeout=timeout)
-            logger.debug(f"Received {len(data)} bytes.")
-            return data
-
-    # ────────────────────────────────────────────────────────────────────
-    # Send: async path is inherited; sync path (legacy / tested) lives here
-    # because it reads raw USB chunks until the end byte.
-    # ────────────────────────────────────────────────────────────────────
-
-    def send_packet(
-        self,
-        id=None,
-        packetType=OW_ACK,
-        command=OW_CMD_NOP,
-        addr=0,
-        reserved=0,
-        data=None,
-        timeout=10.0,
-        max_retries=0,
-    ) -> UartPacket:
-        if self.async_mode:
-            return super().send_packet(
-                id=id, packetType=packetType, command=command, addr=addr,
-                reserved=reserved, data=data, timeout=timeout, max_retries=max_retries,
-            )
-        # Synchronous path: accumulate raw reads until the END byte. Polls
-        # _transport_down_evt so an in-flight send unblocks if the link drops.
-        with self._send_lock:
-            id, tx = self._build_packet(id, packetType, command, addr, reserved, data)
-            self.write(tx)
-            time.sleep(0.0005)
-            start = time.monotonic()
-            buf = bytearray()
-            with self._io_lock:
-                while time.monotonic() - start < timeout:
-                    if self._transport_down_evt.is_set():
-                        raise ConnectionError(
-                            f"{self.desc}: transport down, packet id 0x{id:04X} "
-                            "not deliverable"
-                        )
-                    try:
-                        resp = self.receive()
-                        time.sleep(0.005)
-                        if resp:
-                            buf.extend(resp)
-                            if buf and buf[-1] == OW_END_BYTE:
-                                return UartPacket(buffer=buf)
-                    except usb.core.USBError:
-                        continue
-            raise TimeoutError(
-                f"{self.desc}: no response (sync) for packet id 0x{id:04X}"
-            )

--- a/omotion/CommInterface.py
+++ b/omotion/CommInterface.py
@@ -1,17 +1,18 @@
+"""Sensor command/response transport — USB-bulk interface 0.
+
+The threading, framing and dispatch live in :class:`omotion.packet_transport.PacketTransport`;
+this class only supplies the USB-specific raw I/O (bulk read/write with libusb
+error handling), interface claim, and a synchronous send path used by tests.
+"""
 import logging
-import omotion.config as config
-from omotion.UartPacket import UartPacket
-from omotion.config import (
-    OW_ACK,
-    OW_CMD_NOP,
-    OW_END_BYTE,
-)
-from omotion.framing import emit_log_packet, extract_frame, is_log_packet
+import time
+
 import usb.core
 import usb.util
-import time
-import threading
-import queue
+
+from omotion.UartPacket import UartPacket
+from omotion.config import OW_ACK, OW_CMD_NOP, OW_END_BYTE
+from omotion.packet_transport import PacketTransport
 from omotion.USBInterfaceBase import USBInterfaceBase
 from omotion import _log_root
 
@@ -19,87 +20,19 @@ logger = logging.getLogger(
     f"{_log_root}.CommInterface" if _log_root else "CommInterface"
 )
 
-_PACKET_TYPE_NAMES = {
-    value: name
-    for name, value in vars(config).items()
-    if name.startswith("OW_") and name.isupper() and isinstance(value, int)
-}
-_CMD_NAMES = {
-    "OW_CMD": {
-        value: name
-        for name, value in vars(config).items()
-        if name.startswith("OW_CMD_")
-    },
-    "OW_CONTROLLER": {
-        value: name
-        for name, value in vars(config).items()
-        if name.startswith("OW_CTRL_")
-    },
-    "OW_FPGA": {
-        value: name
-        for name, value in vars(config).items()
-        if name.startswith("OW_FPGA_")
-    },
-    "OW_CAMERA": {
-        value: name
-        for name, value in vars(config).items()
-        if name.startswith("OW_CAMERA_")
-    },
-    "OW_IMU": {
-        value: name
-        for name, value in vars(config).items()
-        if name.startswith("OW_IMU_")
-    },
-}
-
-
-def _format_named(value: int, name_map: dict[int, str], width: int = 2) -> str:
-    name = name_map.get(value)
-    if name:
-        return f"{name}(0x{value:0{width}X})"
-    return f"0x{value:0{width}X}"
-
 
 # =========================================
 # Comm Interface (IN + OUT + threads)
 # =========================================
-class CommInterface(USBInterfaceBase):
+class CommInterface(PacketTransport, USBInterfaceBase):
     def __init__(self, dev, interface_index, desc="Comm", async_mode=False):
-        super().__init__(dev, interface_index, desc)
-        self.read_thread = None
-        self.stop_event = threading.Event()
-        # Set by the read loop when it exits on a fatal USB error
-        # (ENODEV / EIO / EPIPE / other non-timeout failures). send_packet
-        # polls it inside the wait loops so an in-flight command unblocks
-        # the moment the transport drops, instead of spinning for the full
-        # caller-supplied timeout (60 s for program_fpga, etc.). See
-        # bloodflow-app#130: power-cycle mid-configure left the SDK's
-        # configure worker hung for 60 s, blocking the next scan attempt.
-        self._transport_down_evt = threading.Event()
-        # Contiguous byte buffer: USB reader extends the end, packet parser chops from the front
-        self._read_buffer = bytearray()
-        self._buffer_lock = threading.Lock()
-        self._buffer_condition = threading.Condition(self._buffer_lock)
-        self.packet_count = 0
-        self.async_mode = async_mode
-        # Callback invoked once when the read loop sees a fatal USB error
-        # (e.g. ENODEV, EIO, EPIPE). The owning MotionSensor wires this to
-        # submit an EVT_IO_ERROR to the ConnectionMonitor, which then drives
-        # the handle's state machine. The single-event-queue design means we
-        # don't need the previous _disconnect_notified flag or the daemon-
-        # thread dispatch hack that worked around join-self deadlocks.
-        self.on_io_error = None
-        self._io_lock = threading.RLock()
-        self._send_lock = threading.Lock()
-        if self.async_mode:
-            self.response_queue = queue.Queue()
-            self.response_thread = threading.Thread(
-                target=self._process_responses, daemon=True
-            )
-            self.response_thread.start()
+        USBInterfaceBase.__init__(self, dev, interface_index, desc)
+        PacketTransport.__init__(
+            self, desc=desc, async_mode=async_mode, default_timeout=10.0
+        )
 
     def claim(self):
-        super().claim()
+        USBInterfaceBase.claim(self)
         intf = self.dev.get_active_configuration()[(self.interface_index, 0)]
         self.ep_out = usb.util.find_descriptor(
             intf,
@@ -110,96 +43,23 @@ class CommInterface(USBInterfaceBase):
         if not self.ep_out:
             raise RuntimeError(f"{self.desc}: No OUT endpoint found")
 
-    def send_packet(
-        self,
-        id=None,
-        packetType=OW_ACK,
-        command=OW_CMD_NOP,
-        addr=0,
-        reserved=0,
-        data=None,
-        timeout=10.0,
-        max_retries=0,
-    ) -> UartPacket:
-        with self._send_lock:
-            if id is None:
-                self.packet_count = (self.packet_count + 1) & 0xFFFF or 1
-                id = self.packet_count
+    # ────────────────────────────────────────────────────────────────────
+    # Raw byte I/O for the shared transport engine
+    # ────────────────────────────────────────────────────────────────────
 
-            if data:
-                if not isinstance(data, (bytes, bytearray)):
-                    raise ValueError("Data must be bytes or bytearray")
-                payload = data
-            else:
-                payload = b""
-
-            uart_packet = UartPacket(
-                id=id,
-                packetType=packetType,
-                command=command,
-                addr=addr,
-                reserved=reserved,
-                data=payload,
+    def _raw_read(self) -> bytes:
+        try:
+            data = self.dev.read(
+                self.ep_in.bEndpointAddress, self.ep_in.wMaxPacketSize, timeout=100
             )
+        except usb.core.USBError as e:
+            if e.errno in (110, 10060):  # ETIMEDOUT / WSAETIMEDOUT — idle window
+                return b""
+            raise  # ENODEV / EIO / EPIPE / etc. — fatal, reader loop handles it
+        return bytes(data) if data else b""
 
-            tx_bytes = uart_packet.to_bytes()
-            packet_type_name = _PACKET_TYPE_NAMES.get(packetType)
-            cmd_names = _CMD_NAMES.get(packet_type_name, {})
-            logger.debug(
-                f"{self.desc}: TX id=0x{id:04X} "
-                f"type={_format_named(packetType, _PACKET_TYPE_NAMES)} "
-                f"cmd={_format_named(command, cmd_names)} "
-                f"addr=0x{addr:02X} reserved=0x{reserved:02X} len={len(payload)} data={tx_bytes.hex()}"
-            )
-
-            self.write(tx_bytes)
-            time.sleep(0.0005)
-
-            if not self.async_mode:
-                start = time.monotonic()
-                data = bytearray()
-                with self._io_lock:
-                    while time.monotonic() - start < timeout:
-                        if self._transport_down_evt.is_set():
-                            raise ConnectionError(
-                                f"{self.desc}: transport down, packet id "
-                                f"0x{id:04X} not deliverable"
-                            )
-                        try:
-                            resp = self.receive()
-                            time.sleep(0.005)
-                            if resp:
-                                data.extend(resp)
-                                if data and data[-1] == OW_END_BYTE:
-                                    return UartPacket(buffer=data)
-                        except usb.core.USBError:
-                            continue
-                last_error = TimeoutError("No response")
-            else:
-                start_time = time.monotonic()
-                while time.monotonic() - start_time < timeout:
-                    if self._transport_down_evt.is_set():
-                        raise ConnectionError(
-                            f"{self.desc}: transport down, packet id "
-                            f"0x{id:04X} not deliverable"
-                        )
-                    if self.response_queue.empty():
-                        time.sleep(0.0005)
-                    else:
-                        time.sleep(0.001)
-                        pkt = self.response_queue.get()
-                        if pkt.id != id:
-                            logger.warning(
-                                "%s: discarding stale response id=0x%04X (expected 0x%04X)",
-                                self.desc, pkt.id, id,
-                            )
-                            continue
-                        return pkt
-                raise TimeoutError(f"No response in async mode, packet id 0x{id:04X}")
-
-    def clear_buffer(self):
-        with self._buffer_lock:
-            self._read_buffer.clear()
+    def _raw_write(self, data) -> None:
+        self.write(data)
 
     def write(self, data, timeout=100, _retries=5):
         with self._io_lock:
@@ -224,7 +84,7 @@ class CommInterface(USBInterfaceBase):
                     # A stalled endpoint (EPIPE / broken-pipe) can be recovered by
                     # issuing a CLEAR_HALT control transfer.  Try once; if it works
                     # re-send the original data.  Any other USB error is re-raised
-                    # so callers and _read_loop disconnect logic see it normally.
+                    # so callers and the reader loop disconnect logic see it normally.
                     if e.errno in (32, -9):  # EPIPE on Linux; LIBUSB_ERROR_PIPE cross-platform
                         logger.warning("%s: OUT endpoint stalled, attempting clear_halt", self.desc)
                         try:
@@ -240,101 +100,51 @@ class CommInterface(USBInterfaceBase):
             logger.debug(f"Received {len(data)} bytes.")
             return data
 
-    def start_read_thread(self):
-        if self.read_thread and self.read_thread.is_alive():
-            logger.info(f"{self.desc}: Read thread already running")
-            return
-        self.stop_event.clear()
-        # Fresh read thread implies transport is up again; any prior
-        # transport-down latch from a previous USB error must clear or
-        # subsequent sends would short-circuit on the stale flag.
-        self._transport_down_evt.clear()
-        self.read_thread = threading.Thread(target=self._read_loop, daemon=True)
-        self.read_thread.start()
-        logger.info(f"{self.desc}: Read thread started")
+    # ────────────────────────────────────────────────────────────────────
+    # Send: async path is inherited; sync path (legacy / tested) lives here
+    # because it reads raw USB chunks until the end byte.
+    # ────────────────────────────────────────────────────────────────────
 
-    def stop_read_thread(self):
-        """Signal the read loop to exit and join it (unless we're being
-        called from the read thread itself, in which case the caller is
-        already on its way out)."""
-        self.stop_event.set()
-        rt = self.read_thread
-        if rt is not None and threading.current_thread() is not rt:
-            rt.join(timeout=2.0)
-        logger.info(f"{self.desc}: Read thread stopped")
-
-    def _notify_io_error(self, error):
-        """Invoke the io-error callback exactly once per read-loop exit.
-
-        The state-machine on the owning handle dedups further events that
-        arrive while the handle is already in DISCONNECTING, so we don't
-        need a flag here — the queue serializes everything."""
-        cb = self.on_io_error
-        if cb is None:
-            return
-        errno = getattr(error, "errno", None)
-        try:
-            cb(errno, str(error))
-        except Exception as e:
-            logger.warning("on_io_error callback raised: %s", e)
-
-    def _read_loop(self):
-        while not self.stop_event.is_set():
-            try:
-                data = self.dev.read(
-                    self.ep_in.bEndpointAddress, self.ep_in.wMaxPacketSize, timeout=100
-                )
-                if data:
-                    data_bytes = bytes(data)
-                    with self._buffer_condition:
-                        self._read_buffer.extend(data_bytes)
-                        self._buffer_condition.notify()
-                    logger.debug(f"Read {len(data)} bytes.")
-                time.sleep(0.001)
-            except usb.core.USBError as e:
-                # During an intentional shutdown the read loop will see USB
-                # errors as the transport is closed; suppress them silently.
-                if self.stop_event.is_set():
-                    break
-                if e.errno in (110, 10060):
-                    # Read timeout — no data this window. Keep looping.
-                    continue
-                # errno 32 = EPIPE (stalled/disconnected endpoint)
-                # errno 19 = ENODEV (device unplugged)
-                # errno  5 = EIO (device I/O error)
-                # Any other USB error we treat the same way: notify the
-                # owning handle and exit. The handle's state machine
-                # decides how to react (transition to DISCONNECTING,
-                # release resources). Logging the disconnect once at the
-                # state-machine level avoids the historical duplicate-log
-                # spam from multiple disconnect paths racing.
-                logger.warning(
-                    f"{self.desc}: USB read error (errno={e.errno}); exiting read loop: {e}"
-                )
-                # Latch transport-down BEFORE the io-error callback so any
-                # send_packet that is currently spinning in its wait loop
-                # observes the dead transport on its next tick.
-                self._transport_down_evt.set()
-                self._notify_io_error(e)
-                break
-
-    def _process_responses(self):
-        while not self.stop_event.is_set():
-            with self._buffer_condition:
-                if not self._read_buffer:
-                    self._buffer_condition.wait(timeout=0.1)
-                    continue
-                # Carve one complete frame off the front (resyncs past garbage).
-                frame = extract_frame(self._read_buffer)
-            if frame is None:
-                continue  # partial frame — wait for the reader to add more
-            try:
-                uart_packet = UartPacket(buffer=frame)
-            except ValueError:
-                continue  # bad CRC / malformed — drop it
-            # Unsolicited firmware log packets are surfaced and dropped; only
-            # real command responses go to the queue for send_packet to match.
-            if is_log_packet(uart_packet):
-                emit_log_packet(uart_packet, self.desc)
-            else:
-                self.response_queue.put(uart_packet)
+    def send_packet(
+        self,
+        id=None,
+        packetType=OW_ACK,
+        command=OW_CMD_NOP,
+        addr=0,
+        reserved=0,
+        data=None,
+        timeout=10.0,
+        max_retries=0,
+    ) -> UartPacket:
+        if self.async_mode:
+            return super().send_packet(
+                id=id, packetType=packetType, command=command, addr=addr,
+                reserved=reserved, data=data, timeout=timeout, max_retries=max_retries,
+            )
+        # Synchronous path: accumulate raw reads until the END byte. Polls
+        # _transport_down_evt so an in-flight send unblocks if the link drops.
+        with self._send_lock:
+            id, tx = self._build_packet(id, packetType, command, addr, reserved, data)
+            self.write(tx)
+            time.sleep(0.0005)
+            start = time.monotonic()
+            buf = bytearray()
+            with self._io_lock:
+                while time.monotonic() - start < timeout:
+                    if self._transport_down_evt.is_set():
+                        raise ConnectionError(
+                            f"{self.desc}: transport down, packet id 0x{id:04X} "
+                            "not deliverable"
+                        )
+                    try:
+                        resp = self.receive()
+                        time.sleep(0.005)
+                        if resp:
+                            buf.extend(resp)
+                            if buf and buf[-1] == OW_END_BYTE:
+                                return UartPacket(buffer=buf)
+                    except usb.core.USBError:
+                        continue
+            raise TimeoutError(
+                f"{self.desc}: no response (sync) for packet id 0x{id:04X}"
+            )

--- a/omotion/CommInterface.py
+++ b/omotion/CommInterface.py
@@ -5,10 +5,8 @@ from omotion.config import (
     OW_ACK,
     OW_CMD_NOP,
     OW_END_BYTE,
-    OW_START_BYTE,
-    OW_DATA,
-    OW_CMD_ECHO,
 )
+from omotion.framing import emit_log_packet, extract_frame, is_log_packet
 import usb.core
 import usb.util
 import time
@@ -17,15 +15,9 @@ import queue
 from omotion.USBInterfaceBase import USBInterfaceBase
 from omotion import _log_root
 
-# Max data_len we accept (sanity check to avoid runaway buffer)
-OW_MAX_PACKET_DATA_LEN = 4096 * 2
-
 logger = logging.getLogger(
     f"{_log_root}.CommInterface" if _log_root else "CommInterface"
 )
-
-# Max data_len we accept (sanity check to avoid runaway buffer)
-OW_MAX_PACKET_DATA_LEN = 4096 * 2
 
 _PACKET_TYPE_NAMES = {
     value: name
@@ -332,49 +324,17 @@ class CommInterface(USBInterfaceBase):
                 if not self._read_buffer:
                     self._buffer_condition.wait(timeout=0.1)
                     continue
-                buf = self._read_buffer
-                # Align to start of packet: discard leading bytes until OW_START_BYTE
-                if buf[0] != OW_START_BYTE:
-                    try:
-                        start_idx = buf.index(OW_START_BYTE)
-                    except ValueError:
-                        start_idx = len(buf)
-                    del self._read_buffer[:start_idx]
-                    if start_idx == len(buf):
-                        continue
-                    buf = self._read_buffer
-                # Need at least 9 bytes to read data_len (bytes 7:9)
-                if len(buf) < 9:
-                    continue
-                data_len = int.from_bytes(buf[7:9], "big")
-                if data_len > OW_MAX_PACKET_DATA_LEN:
-                    del self._read_buffer[:1]
-                    continue
-                packet_len = 12 + data_len  # header(11) + data + crc(2) + end(1)
-                if len(buf) < packet_len:
-                    continue
-                if buf[packet_len - 1] != OW_END_BYTE:
-                    del self._read_buffer[:1]
-                    continue
-                packet_bytes = bytes(buf[:packet_len])
-                del self._read_buffer[:packet_len]
+                # Carve one complete frame off the front (resyncs past garbage).
+                frame = extract_frame(self._read_buffer)
+            if frame is None:
+                continue  # partial frame — wait for the reader to add more
             try:
-                uart_packet = UartPacket(buffer=packet_bytes)
+                uart_packet = UartPacket(buffer=frame)
             except ValueError:
-                continue
-            if (
-                uart_packet.id == 0
-                and uart_packet.packetType == OW_DATA
-                and uart_packet.command == OW_CMD_ECHO
-            ):
-                _raw = bytes(uart_packet.data[:uart_packet.data_len]) if uart_packet.data_len > 0 else b""
-                try:
-                    _text = _raw.decode("utf-8", errors="replace").rstrip("\x00").strip()
-                except Exception:
-                    _text = ""
-                if _text:
-                    logger.warning("[%s PRINTF] %s", self.desc, _text)
-                else:
-                    logger.warning("[%s] MCU echo: data=%s", self.desc, _raw.hex() if _raw else "")
+                continue  # bad CRC / malformed — drop it
+            # Unsolicited firmware log packets are surfaced and dropped; only
+            # real command responses go to the queue for send_packet to match.
+            if is_log_packet(uart_packet):
+                emit_log_packet(uart_packet, self.desc)
             else:
                 self.response_queue.put(uart_packet)

--- a/omotion/MotionComposite.py
+++ b/omotion/MotionComposite.py
@@ -40,9 +40,7 @@ class MotionComposite:
         self.demo_mode = False
         self.on_io_error = on_io_error
 
-        self.comm = CommInterface(
-            dev, 0, desc=f"{desc}-COMM", async_mode=True
-        )
+        self.comm = CommInterface(dev, 0, desc=f"{desc}-COMM")
         self.histo = StreamInterface(dev, 1, desc=f"{desc}-HISTO")
         self.imu = StreamInterface(dev, 2, desc=f"{desc}-IMU")
         self.comm.on_io_error = self._forward_io_error
@@ -60,18 +58,15 @@ class MotionComposite:
         self.comm.claim()
         self.histo.claim()
         self.imu.claim()
-        if self.comm.async_mode:
-            self.comm.start_read_thread()
+        self.comm.start_read_thread()
         logger.info(f"{self.desc}: opened")
 
     def close(self) -> None:
         """Release all three interfaces and free USB resources. Idempotent.
         Each step runs regardless of whether earlier steps fail — failures
         are logged with enough context to diagnose without aborting cleanup."""
-        steps = []
-        if getattr(self.comm, "async_mode", False):
-            steps.append(("stop comm read thread", self.comm.stop_read_thread))
-        steps += [
+        steps = [
+            ("stop comm read thread", self.comm.stop_read_thread),
             ("stop histo streaming", self.histo.stop_streaming),
             ("stop imu streaming", self.imu.stop_streaming),
             ("release comm", self.comm.release),

--- a/omotion/MotionConsole.py
+++ b/omotion/MotionConsole.py
@@ -33,6 +33,8 @@ from omotion.config import (
     OW_CMD,
     OW_CMD_SERIAL,
     OW_CMD_DFU,
+    OW_CMD_DEBUG_FLAGS,
+    DEBUG_FLAG_USB_PRINTF,
     is_valid_serial,
     OW_FPGA_PROG,
     OW_CMD_ECHO,
@@ -530,6 +532,96 @@ class MotionConsole(SignalWrapper):
         except Exception as e:
             self._log_command_error("echo", e)
             raise  # Re-raise the exception for the caller to handle
+
+    def set_debug_flags(self, flags: int) -> bool:
+        """Set the firmware debug-flag bitmask (32-bit, RAM-only on the MCU).
+
+        Bit 0 (``DEBUG_FLAG_USB_PRINTF``) mirrors firmware ``printf()`` to this
+        USB CDC link; the SDK surfaces those log lines automatically as they
+        arrive (see :mod:`omotion.framing`). Mirrors
+        ``MotionSensor.set_debug_flags``. Returns True on success.
+        """
+        try:
+            if self.uart.demo_mode:
+                return True
+
+            if not self.is_connected():
+                raise ValueError("Console Device not connected")
+
+            r = self.uart.send_packet(
+                id=None,
+                packetType=OW_CMD,
+                command=OW_CMD_DEBUG_FLAGS,
+                reserved=1,  # reserved bit0 = SET
+                data=struct.pack("<I", flags & 0xFFFFFFFF),
+            )
+            self.uart.clear_buffer()
+
+            if r.packetType == OW_ERROR:
+                logger.error("Error setting debug flags")
+                return False
+
+            if r.data_len == 4:
+                logger.info(
+                    "Debug flags set to: 0x%08X", struct.unpack("<I", r.data)[0]
+                )
+            return True
+
+        except ValueError as v:
+            logger.error("ValueError: %s", v)
+            raise  # Re-raise the exception for the caller to handle
+        except Exception as e:
+            self._log_command_error("set_debug_flags", e)
+            raise  # Re-raise the exception for the caller to handle
+
+    def get_debug_flags(self) -> int:
+        """Return the current firmware debug-flag bitmask, or 0 on error."""
+        try:
+            if self.uart.demo_mode:
+                return 0
+
+            if not self.is_connected():
+                raise ValueError("Console Device not connected")
+
+            r = self.uart.send_packet(
+                id=None,
+                packetType=OW_CMD,
+                command=OW_CMD_DEBUG_FLAGS,
+                reserved=0,  # reserved bit0 = GET
+            )
+            self.uart.clear_buffer()
+
+            if r.packetType == OW_ERROR or r.data_len != 4:
+                logger.error("Error reading debug flags")
+                return 0
+
+            flags = struct.unpack("<I", r.data)[0]
+            logger.info("Debug flags: 0x%08X", flags)
+            return flags
+
+        except ValueError as v:
+            logger.error("ValueError: %s", v)
+            raise  # Re-raise the exception for the caller to handle
+        except Exception as e:
+            self._log_command_error("get_debug_flags", e)
+            raise  # Re-raise the exception for the caller to handle
+
+    def enable_usb_printf(self, enable: bool = True) -> bool:
+        """Enable/disable mirroring of firmware ``printf()`` to this USB link.
+
+        Convenience read-modify-write of the ``DEBUG_FLAG_USB_PRINTF`` bit.
+        When enabled, firmware log lines arrive as unsolicited packets that the
+        SDK logs automatically (see :func:`omotion.framing.emit_log_packet`).
+        Returns True on success.
+        """
+        if self.uart.demo_mode:
+            return True
+        flags = self.get_debug_flags()
+        if enable:
+            flags |= DEBUG_FLAG_USB_PRINTF
+        else:
+            flags &= ~DEBUG_FLAG_USB_PRINTF
+        return self.set_debug_flags(flags)
 
     def toggle_led(self) -> bool:
         """

--- a/omotion/MotionUart.py
+++ b/omotion/MotionUart.py
@@ -14,7 +14,6 @@ machine can transition out of CONNECTED.
 from __future__ import annotations
 
 import logging
-import time
 from typing import Callable, Optional
 
 import serial
@@ -34,12 +33,6 @@ logger = logging.getLogger(f"{_log_root}.UART" if _log_root else "UART")
 _READER_TIMEOUT_S = 0.1
 # Default per-command response timeout for the console (preserves prior behavior).
 _CONSOLE_CMD_TIMEOUT_S = 20.0
-# Minimum gap between the previous response and the next command. The console
-# firmware re-arms its CDC OUT reception only after sending each response, so a
-# command that arrives in the ~10 ms window before that is silently dropped.
-# Pacing here (rather than retrying) avoids re-applying non-idempotent commands.
-# The old synchronous reader paced this implicitly via its ~100 ms read loop.
-_MIN_CMD_INTERVAL_S = 0.015
 
 
 class MotionUart(PacketTransport):
@@ -67,7 +60,6 @@ class MotionUart(PacketTransport):
         self.demo_mode = demo_mode
         self.descriptor = desc
         self.serial: Optional[serial.Serial] = None
-        self._last_cmd_ts = 0.0
 
     # ────────────────────────────────────────────────────────────────────
     # Lifecycle (driven by MotionConsole state machine)
@@ -158,17 +150,6 @@ class MotionUart(PacketTransport):
                 id=0, packetType=OW_ERROR, command=0, addr=0, reserved=0, data=[]
             )
         return super().send_packet(*args, **kwargs)
-
-    # Throttle hooks (called by PacketTransport.send_packet holding the send
-    # lock) — keep at least _MIN_CMD_INTERVAL_S between the previous response
-    # and the next command so the firmware's CDC RX has re-armed.
-    def _pace_before_send(self) -> None:
-        wait = self._last_cmd_ts + _MIN_CMD_INTERVAL_S - time.monotonic()
-        if wait > 0:
-            time.sleep(wait)
-
-    def _mark_send_done(self) -> None:
-        self._last_cmd_ts = time.monotonic()
 
     def print(self) -> None:
         logger.info("    Serial Port: %s", self.port)

--- a/omotion/MotionUart.py
+++ b/omotion/MotionUart.py
@@ -24,6 +24,7 @@ from omotion.config import (
     OW_ERROR,
     OW_START_BYTE,
 )
+from omotion.framing import emit_log_packet, extract_frame, is_log_packet
 from omotion.utils import util_crc16
 from omotion import _log_root
 from omotion.CommandError import CommandError
@@ -54,6 +55,10 @@ class MotionUart:
         self.descriptor = desc
         self.serial: Optional[serial.Serial] = None
         self._io_lock = threading.RLock()
+        # Bytes read from the port but not yet consumed as a complete frame.
+        # Lets read_packet reassemble fragmented frames and skip interleaved
+        # firmware log packets without losing trailing response bytes.
+        self._rx_buf = bytearray()
         self.on_io_error = on_io_error
 
     # ────────────────────────────────────────────────────────────────────
@@ -138,7 +143,15 @@ class MotionUart:
             raise
 
     def read_packet(self, timeout: int = 20) -> UartPacket:
-        """Block until a packet arrives or `timeout` seconds elapse."""
+        """Block until a command response arrives or `timeout` seconds elapse.
+
+        Unsolicited firmware log packets (printf mirrored over the link when
+        DEBUG_FLAG_USB_PRINTF is set — id=0 / OW_DATA / OW_CMD_ECHO) share this
+        link with command responses, so they are demuxed out here: each one is
+        surfaced via the logger and skipped, and reading continues until a real
+        response frame arrives. Malformed/bad-CRC frames are dropped the same
+        way. Raises ValueError if nothing valid arrives within the timeout.
+        """
         if self.demo_mode:
             return UartPacket(
                 id=0, packetType=OW_ERROR, command=0, addr=0, reserved=0, data=[]
@@ -147,24 +160,30 @@ class MotionUart:
             raise CommandError("UART not open")
         with self._io_lock:
             start_time = time.monotonic()
-            raw_data = b""
-            count = 0
-
             while timeout == -1 or time.monotonic() - start_time < timeout:
-                time.sleep(0.05)
                 try:
-                    raw_data += self.serial.read_all()
+                    chunk = self.serial.read_all()
                 except serial.SerialException as se:
                     self._notify_io_error(getattr(se, "errno", None), str(se))
                     raise
-                if raw_data:
-                    count += 1
-                    if count > 1:
-                        break
+                if chunk:
+                    self._rx_buf.extend(chunk)
+                    # Dispatch every complete frame currently buffered.
+                    while True:
+                        frame = extract_frame(self._rx_buf)
+                        if frame is None:
+                            break
+                        try:
+                            packet = UartPacket(buffer=frame)
+                        except ValueError:
+                            continue  # bad CRC / malformed — drop and resync
+                        if is_log_packet(packet):
+                            emit_log_packet(packet, self.descriptor)
+                            continue
+                        return packet
+                time.sleep(0.005)
 
-        if not raw_data:
-            raise ValueError("No data received from UART within timeout")
-        return UartPacket(buffer=raw_data)
+        raise ValueError("No data received from UART within timeout")
 
     def send_packet(
         self,
@@ -240,6 +259,9 @@ class MotionUart:
             raise
 
     def clear_buffer(self) -> None:
+        # Drop any partial frame we were holding so it can't bleed into the
+        # next command's response, then flush the OS input buffer.
+        self._rx_buf.clear()
         if self.demo_mode or self.serial is None:
             return
         try:

--- a/omotion/MotionUart.py
+++ b/omotion/MotionUart.py
@@ -1,15 +1,19 @@
-"""Pure UART transport (synchronous request/response).
+"""Console command/response transport — serial VCP.
 
-`MotionUart` no longer owns connection lifecycle — the owning handle
-(`MotionConsole`) drives `open(port)` / `close()` from its state machine.
-On a fatal serial error during reads or writes, the transport invokes the
-`on_io_error(errno, message)` callback; the handle's state machine is
-expected to react by transitioning out of CONNECTED.
+Same async engine as the sensor's USB link: :class:`omotion.packet_transport.PacketTransport`
+runs the reader/dispatch threads and matches responses by id; this class only
+supplies serial-specific raw I/O and lifecycle (open/close/discovery). A
+continuous reader is what lets unsolicited firmware printf packets share the
+command channel without colliding with responses.
+
+`MotionUart` does not own connection lifecycle — the owning `MotionConsole`
+drives `open(port)` / `close()` from its state machine. On a fatal serial error
+the transport invokes the `on_io_error(errno, message)` callback so the state
+machine can transition out of CONNECTED.
 """
 from __future__ import annotations
 
 import logging
-import threading
 import time
 from typing import Callable, Optional
 
@@ -17,22 +21,28 @@ import serial
 import serial.tools.list_ports
 
 from omotion.UartPacket import UartPacket
-from omotion.config import (
-    OW_ACK,
-    OW_CMD_NOP,
-    OW_END_BYTE,
-    OW_ERROR,
-    OW_START_BYTE,
-)
-from omotion.framing import emit_log_packet, extract_frame, is_log_packet
-from omotion.utils import util_crc16
-from omotion import _log_root
+from omotion.config import OW_END_BYTE, OW_ERROR
+from omotion.packet_transport import PacketTransport
 from omotion.CommandError import CommandError
+from omotion import _log_root
 
 logger = logging.getLogger(f"{_log_root}.UART" if _log_root else "UART")
 
+# Short blocking read timeout for the reader thread — keeps it responsive to
+# incoming bytes and to shutdown without a busy-spin. The per-command timeout is
+# separate (PacketTransport.send_packet / default_timeout).
+_READER_TIMEOUT_S = 0.1
+# Default per-command response timeout for the console (preserves prior behavior).
+_CONSOLE_CMD_TIMEOUT_S = 20.0
+# Minimum gap between the previous response and the next command. The console
+# firmware re-arms its CDC OUT reception only after sending each response, so a
+# command that arrives in the ~10 ms window before that is silently dropped.
+# Pacing here (rather than retrying) avoids re-applying non-idempotent commands.
+# The old synchronous reader paced this implicitly via its ~100 ms read loop.
+_MIN_CMD_INTERVAL_S = 0.015
 
-class MotionUart:
+
+class MotionUart(PacketTransport):
     def __init__(
         self,
         vid: int,
@@ -44,43 +54,44 @@ class MotionUart:
         desc: str = "VCP",
         on_io_error: Optional[Callable[[Optional[int], str], None]] = None,
     ):
+        PacketTransport.__init__(
+            self, desc=desc, async_mode=True,
+            default_timeout=_CONSOLE_CMD_TIMEOUT_S, on_io_error=on_io_error,
+        )
         self.vid = vid
         self.pid = pid
         self.port: Optional[str] = None
         self.baudrate = baudrate
-        self.timeout = timeout
+        self.timeout = timeout  # retained for API compat; reader uses _READER_TIMEOUT_S
         self.align = align
-        self.packet_count = 0
         self.demo_mode = demo_mode
         self.descriptor = desc
         self.serial: Optional[serial.Serial] = None
-        self._io_lock = threading.RLock()
-        # Bytes read from the port but not yet consumed as a complete frame.
-        # Lets read_packet reassemble fragmented frames and skip interleaved
-        # firmware log packets without losing trailing response bytes.
-        self._rx_buf = bytearray()
-        self.on_io_error = on_io_error
+        self._last_cmd_ts = 0.0
 
     # ────────────────────────────────────────────────────────────────────
     # Lifecycle (driven by MotionConsole state machine)
     # ────────────────────────────────────────────────────────────────────
 
     def open(self, port: str) -> None:
-        """Open the serial port. Raises serial.SerialException on failure."""
+        """Open the serial port and start the reader. Raises serial.SerialException
+        on failure."""
         if self.demo_mode:
             self.port = port or "DEMO"
             return
         self.serial = serial.Serial(
-            port=port, baudrate=self.baudrate, timeout=self.timeout
+            port=port, baudrate=self.baudrate, timeout=_READER_TIMEOUT_S
         )
         self.port = port
+        self.start_read_thread()
         logger.info("UART %s opened on %s", self.descriptor, port)
 
     def close(self) -> None:
-        """Close the serial port. Idempotent."""
+        """Stop the reader and close the serial port. Idempotent."""
         if self.demo_mode:
             self.port = None
             return
+        self.stop_read_thread()
         s = self.serial
         self.serial = None
         if s is not None:
@@ -98,10 +109,6 @@ class MotionUart:
             return self.port is not None
         return self.serial is not None and self.serial.is_open
 
-    # ────────────────────────────────────────────────────────────────────
-    # VID/PID discovery
-    # ────────────────────────────────────────────────────────────────────
-
     def find_port(self) -> Optional[str]:
         """Return the COM/tty device path that matches our VID/PID, or None."""
         for p in serial.tools.list_ports.comports():
@@ -113,161 +120,55 @@ class MotionUart:
         return None
 
     # ────────────────────────────────────────────────────────────────────
-    # I/O
+    # Raw byte I/O for the shared transport engine
     # ────────────────────────────────────────────────────────────────────
 
-    def _notify_io_error(self, errno: Optional[int], message: str) -> None:
-        cb = self.on_io_error
-        if cb is None:
-            return
-        try:
-            cb(errno, message)
-        except Exception as e:
-            logger.warning("on_io_error callback raised: %s", e)
-
-    def _tx(self, data: bytes) -> None:
-        if self.demo_mode:
-            logger.debug("Demo mode TX: %s", data.hex())
-            return
-        if self.serial is None or not self.serial.is_open:
+    def _raw_read(self) -> bytes:
+        s = self.serial
+        if s is None:
             raise CommandError("UART not open")
+        # read(1) blocks up to the (short) serial timeout, then drain whatever
+        # else arrived. Returns b"" on an idle window. SerialException → fatal.
+        first = s.read(1)
+        if not first:
+            return b""
+        rest = s.read_all()
+        return first + (rest or b"")
+
+    def _raw_write(self, data: bytes) -> None:
+        if self.demo_mode:
+            logger.debug("Demo mode TX: %s", bytes(data).hex())
+            return
+        s = self.serial
+        if s is None or not s.is_open:
+            raise CommandError("UART not open")
+        if self.align > 0:
+            data = bytes(data)
+            while len(data) % self.align != 0:
+                data += bytes([OW_END_BYTE])
         try:
-            with self._io_lock:
-                if self.align > 0:
-                    while len(data) % self.align != 0:
-                        data += bytes([OW_END_BYTE])
-                self.serial.write(data)
+            s.write(data)
         except serial.SerialException as se:
-            errno = getattr(se, "errno", None)
-            self._notify_io_error(errno, str(se))
+            self._notify_io_error(se)
             raise
 
-    def read_packet(self, timeout: int = 20) -> UartPacket:
-        """Block until a command response arrives or `timeout` seconds elapse.
-
-        Unsolicited firmware log packets (printf mirrored over the link when
-        DEBUG_FLAG_USB_PRINTF is set — id=0 / OW_DATA / OW_CMD_ECHO) share this
-        link with command responses, so they are demuxed out here: each one is
-        surfaced via the logger and skipped, and reading continues until a real
-        response frame arrives. Malformed/bad-CRC frames are dropped the same
-        way. Raises ValueError if nothing valid arrives within the timeout.
-        """
+    def send_packet(self, *args, **kwargs):
         if self.demo_mode:
             return UartPacket(
                 id=0, packetType=OW_ERROR, command=0, addr=0, reserved=0, data=[]
             )
-        if self.serial is None:
-            raise CommandError("UART not open")
-        with self._io_lock:
-            start_time = time.monotonic()
-            while timeout == -1 or time.monotonic() - start_time < timeout:
-                try:
-                    chunk = self.serial.read_all()
-                except serial.SerialException as se:
-                    self._notify_io_error(getattr(se, "errno", None), str(se))
-                    raise
-                if chunk:
-                    self._rx_buf.extend(chunk)
-                    # Dispatch every complete frame currently buffered.
-                    while True:
-                        frame = extract_frame(self._rx_buf)
-                        if frame is None:
-                            break
-                        try:
-                            packet = UartPacket(buffer=frame)
-                        except ValueError:
-                            continue  # bad CRC / malformed — drop and resync
-                        if is_log_packet(packet):
-                            emit_log_packet(packet, self.descriptor)
-                            continue
-                        return packet
-                time.sleep(0.005)
+        return super().send_packet(*args, **kwargs)
 
-        raise ValueError("No data received from UART within timeout")
+    # Throttle hooks (called by PacketTransport.send_packet holding the send
+    # lock) — keep at least _MIN_CMD_INTERVAL_S between the previous response
+    # and the next command so the firmware's CDC RX has re-armed.
+    def _pace_before_send(self) -> None:
+        wait = self._last_cmd_ts + _MIN_CMD_INTERVAL_S - time.monotonic()
+        if wait > 0:
+            time.sleep(wait)
 
-    def send_packet(
-        self,
-        id=None,
-        packetType=OW_ACK,
-        command=OW_CMD_NOP,
-        addr: int = 0,
-        reserved: int = 0,
-        data=None,
-        timeout: int = 20,
-    ) -> Optional[UartPacket]:
-        """Send a command packet and return the matching response.
-
-        Returns None only when the transport is closed (caller should treat
-        as a connection error). Raises `CommandError` on validation errors
-        and re-raises `serial.SerialException` after notifying the I/O
-        error callback so the handle can transition out of CONNECTED.
-        """
-        try:
-            if not self.demo_mode and (
-                self.serial is None or not self.serial.is_open
-            ):
-                logger.error("Cannot send packet. UART not open.")
-                return None
-
-            if id is None:
-                self.packet_count += 1
-                if self.packet_count >= 0xFFFF:
-                    self.packet_count = 1
-                id = self.packet_count
-
-            if data:
-                if not isinstance(data, (bytes, bytearray)):
-                    raise ValueError("Data must be bytes or bytearray")
-                payload = data
-                payload_length = len(payload)
-            else:
-                payload_length = 0
-                payload = b""
-
-            packet = bytearray()
-            packet.append(OW_START_BYTE)
-            packet.extend(id.to_bytes(2, "big"))
-            packet.append(packetType)
-            packet.append(command)
-            packet.append(addr)
-            packet.append(reserved)
-            packet.extend(payload_length.to_bytes(2, "big"))
-            if payload_length > 0:
-                packet.extend(payload)
-
-            crc_value = util_crc16(packet[1:])  # exclude start byte
-            packet.extend(crc_value.to_bytes(2, "big"))
-            packet.append(OW_END_BYTE)
-
-            with self._io_lock:
-                self._tx(packet)
-                time.sleep(0.0005)
-                ret_packet = self.read_packet(timeout=timeout)
-                time.sleep(0.0005)
-                return ret_packet
-
-        except ValueError as ve:
-            logger.error("Validation error in send_packet: %s", ve)
-            raise CommandError(str(ve)) from ve
-        except serial.SerialException as se:
-            # Already notified on_io_error from _tx/read_packet — the
-            # handle's state machine logs the disconnect at INFO. Logging
-            # here at DEBUG keeps in-flight commands from spamming ERROR
-            # during the disconnect window. The exception is still
-            # re-raised so callers can react.
-            logger.debug("Serial error in send_packet: %s", se)
-            raise
-
-    def clear_buffer(self) -> None:
-        # Drop any partial frame we were holding so it can't bleed into the
-        # next command's response, then flush the OS input buffer.
-        self._rx_buf.clear()
-        if self.demo_mode or self.serial is None:
-            return
-        try:
-            self.serial.reset_input_buffer()
-        except Exception:
-            pass
+    def _mark_send_done(self) -> None:
+        self._last_cmd_ts = time.monotonic()
 
     def print(self) -> None:
         logger.info("    Serial Port: %s", self.port)

--- a/omotion/MotionUart.py
+++ b/omotion/MotionUart.py
@@ -55,7 +55,7 @@ class MotionUart(PacketTransport):
         on_io_error: Optional[Callable[[Optional[int], str], None]] = None,
     ):
         PacketTransport.__init__(
-            self, desc=desc, async_mode=True,
+            self, desc=desc,
             default_timeout=_CONSOLE_CMD_TIMEOUT_S, on_io_error=on_io_error,
         )
         self.vid = vid

--- a/omotion/framing.py
+++ b/omotion/framing.py
@@ -1,0 +1,115 @@
+"""Shared wire-framing helpers for the OpenMotion packet protocol.
+
+Both host transports speak the same framed protocol and receive the same kind
+of unsolicited firmware log packets, so the framing and log-demux logic lives
+here once instead of being copied into each transport:
+
+  * the console's synchronous serial link (:class:`omotion.MotionUart`), and
+  * the sensor's asynchronous USB-bulk link (:class:`omotion.CommInterface`).
+
+Frame layout (matches the firmware ``common.h``)::
+
+    [0xAA][id:2][type:1][cmd:1][addr:1][rsvd:1][len:2][payload:N][crc16:2][0xDD]
+
+Firmware mirrors ``printf()`` over the same link as an *unsolicited* packet with
+``id == 0``, ``packetType == OW_DATA`` and ``command == OW_CMD_ECHO`` (see the
+``DEBUG_FLAG_USB_PRINTF`` debug flag). Because those packets share the link with
+command responses, every receiver has to recognise and skip them — that is what
+:func:`is_log_packet` / :func:`emit_log_packet` are for.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from omotion import _log_root
+from omotion.UartPacket import UartPacket
+from omotion.config import (
+    OW_CMD_ECHO,
+    OW_DATA,
+    OW_END_BYTE,
+    OW_START_BYTE,
+)
+
+logger = logging.getLogger(f"{_log_root}.framing" if _log_root else "framing")
+
+# Bytes before the payload: start(1)+id(2)+type(1)+cmd(1)+addr(1)+rsvd(1)+len(2)
+_HEADER_LEN = 9
+# Bytes after the payload: crc(2)+end(1)
+_TRAILER_LEN = 3
+# Total framing overhead around the payload.
+FRAME_OVERHEAD = _HEADER_LEN + _TRAILER_LEN  # 12
+
+# Sanity ceiling on the length field used only to reject a garbled stream while
+# resynchronising. Set to the larger of the two firmwares' limits (sensor =
+# 8192) so this is safe for both transports; it is not a protocol max.
+MAX_FRAME_DATA_LEN = 8192
+
+
+def extract_frame(buf: bytearray) -> Optional[bytes]:
+    """Pop one complete framed packet from the front of ``buf``.
+
+    Skips leading garbage and resynchronises past false start bytes (a 0xAA
+    whose declared length doesn't land an 0xDD where expected). Returns the raw
+    frame bytes (including the 0xAA/0xDD) and removes them from ``buf``, or
+    returns ``None`` when no complete frame is available yet — in which case the
+    caller should read more bytes and try again. Mutates ``buf`` in place.
+
+    CRC is **not** validated here; construct a :class:`UartPacket` from the
+    returned bytes to validate it.
+    """
+    while True:
+        if not buf:
+            return None
+        if buf[0] != OW_START_BYTE:
+            idx = buf.find(OW_START_BYTE)
+            if idx == -1:
+                buf.clear()  # no frame start anywhere — drop it all
+                return None
+            del buf[:idx]
+        if len(buf) < _HEADER_LEN:
+            return None  # not enough yet to read the length field
+        data_len = int.from_bytes(buf[7:9], "big")
+        if data_len > MAX_FRAME_DATA_LEN:
+            del buf[:1]  # implausible length: this 0xAA wasn't a real start
+            continue
+        frame_len = FRAME_OVERHEAD + data_len
+        if len(buf) < frame_len:
+            return None  # whole frame hasn't arrived yet
+        if buf[frame_len - 1] != OW_END_BYTE:
+            del buf[:1]  # end byte not where the length said: false start
+            continue
+        frame = bytes(buf[:frame_len])
+        del buf[:frame_len]
+        return frame
+
+
+def is_log_packet(pkt: UartPacket) -> bool:
+    """True if ``pkt`` is an unsolicited firmware log/printf packet rather than
+    a command response.
+
+    Firmware mirrors ``printf()`` as ``id == 0`` / ``OW_DATA`` / ``OW_CMD_ECHO``
+    on the same link that carries responses (``DEBUG_FLAG_USB_PRINTF``).
+    """
+    return (
+        pkt.id == 0
+        and pkt.packetType == OW_DATA
+        and pkt.command == OW_CMD_ECHO
+    )
+
+
+def emit_log_packet(pkt: UartPacket, desc: str) -> None:
+    """Surface a firmware log packet (see :func:`is_log_packet`) via the logger.
+
+    The payload is the firmware ``printf`` text; decode it leniently so a
+    partial/garbled line never raises.
+    """
+    raw = bytes(pkt.data[: pkt.data_len]) if pkt.data_len > 0 else b""
+    try:
+        text = raw.decode("utf-8", errors="replace").rstrip("\x00").strip()
+    except Exception:
+        text = ""
+    if text:
+        logger.warning("[%s PRINTF] %s", desc, text)
+    else:
+        logger.warning("[%s] MCU echo: data=%s", desc, raw.hex() if raw else "")

--- a/omotion/packet_transport.py
+++ b/omotion/packet_transport.py
@@ -1,0 +1,287 @@
+"""Shared async framed-packet transport for the OpenMotion command links.
+
+Both command transports — the console's serial VCP (:class:`omotion.MotionUart`)
+and the sensor's USB-bulk interface 0 (:class:`omotion.CommInterface`) — speak
+the same framed protocol and both receive unsolicited firmware log packets
+interleaved with command responses. They differ only in the raw byte I/O and
+lifecycle, so the threading / framing / dispatch logic lives here once:
+
+  * a **reader thread** continuously drains the link (``_raw_read``),
+  * a **dispatch thread** carves frames (:mod:`omotion.framing`) off the stream
+    and routes them — firmware log packets are surfaced via the logger, command
+    responses go on a queue,
+  * :meth:`send_packet` writes a request and waits for the response with the
+    matching id, unblocking promptly if the transport drops.
+
+A continuous reader is what lets unsolicited log packets share the command
+channel without colliding with responses — the reason the sensor tolerated
+firmware printf long before the console did.
+
+Subclasses implement ``_raw_read()`` / ``_raw_write()`` plus their own
+open/close, and may override :meth:`send_packet` to add a synchronous path.
+"""
+from __future__ import annotations
+
+import logging
+import queue
+import threading
+import time
+from typing import Callable, Optional
+
+import omotion.config as config
+from omotion import _log_root
+from omotion.UartPacket import UartPacket
+from omotion.config import OW_ACK, OW_CMD_NOP
+from omotion.framing import emit_log_packet, extract_frame, is_log_packet
+
+logger = logging.getLogger(f"{_log_root}.transport" if _log_root else "transport")
+
+
+# Pretty names for TX debug logging, derived from the config enums.
+_PACKET_TYPE_NAMES = {
+    value: name
+    for name, value in vars(config).items()
+    if name.startswith("OW_") and name.isupper() and isinstance(value, int)
+}
+_CMD_NAMES = {
+    "OW_CMD": {v: n for n, v in vars(config).items() if n.startswith("OW_CMD_")},
+    "OW_CONTROLLER": {v: n for n, v in vars(config).items() if n.startswith("OW_CTRL_")},
+    "OW_FPGA": {v: n for n, v in vars(config).items() if n.startswith("OW_FPGA_")},
+    "OW_CAMERA": {v: n for n, v in vars(config).items() if n.startswith("OW_CAMERA_")},
+    "OW_IMU": {v: n for n, v in vars(config).items() if n.startswith("OW_IMU_")},
+}
+
+
+def _format_named(value: int, name_map: dict, width: int = 2) -> str:
+    name = name_map.get(value)
+    return f"{name}(0x{value:0{width}X})" if name else f"0x{value:0{width}X}"
+
+
+class PacketTransport:
+    """Transport-agnostic async command/response engine. See module docstring."""
+
+    def __init__(
+        self,
+        desc: str = "XPORT",
+        async_mode: bool = True,
+        default_timeout: float = 10.0,
+        on_io_error: Optional[Callable[[Optional[int], str], None]] = None,
+    ):
+        self.desc = desc
+        self.async_mode = async_mode
+        self.default_timeout = default_timeout
+        self.on_io_error = on_io_error
+        self.packet_count = 0
+
+        self.stop_event = threading.Event()
+        # Latched when the reader exits on a fatal transport error so an
+        # in-flight send_packet unblocks immediately instead of waiting out
+        # its full timeout (root cause of bloodflow-app#130 on the sensor).
+        self._transport_down_evt = threading.Event()
+
+        # Reader appends raw bytes; the dispatcher carves frames off the front.
+        self._read_buffer = bytearray()
+        self._buffer_lock = threading.Lock()
+        self._buffer_condition = threading.Condition(self._buffer_lock)
+
+        self._io_lock = threading.RLock()
+        self._send_lock = threading.Lock()
+
+        self.read_thread: Optional[threading.Thread] = None
+        self.response_thread: Optional[threading.Thread] = None
+        self.response_queue: Optional[queue.Queue] = (
+            queue.Queue() if async_mode else None
+        )
+
+    # ────────────────────────────────────────────────────────────────────
+    # Raw byte I/O — subclass provides
+    # ────────────────────────────────────────────────────────────────────
+
+    def _raw_read(self) -> bytes:
+        """Return bytes read from the link (``b""`` on idle/timeout). Raise on a
+        fatal/disconnect error — the reader loop treats that as transport-down."""
+        raise NotImplementedError
+
+    def _raw_write(self, data: bytes) -> None:
+        """Write raw bytes to the link. Raise on a fatal error."""
+        raise NotImplementedError
+
+    # ────────────────────────────────────────────────────────────────────
+    # Thread lifecycle
+    # ────────────────────────────────────────────────────────────────────
+
+    def start_read_thread(self) -> None:
+        # A fresh reader implies the transport is up again; clear any stale
+        # transport-down latch so subsequent sends aren't poisoned.
+        self.stop_event.clear()
+        self._transport_down_evt.clear()
+        if self.async_mode:
+            if self.response_queue is None:
+                self.response_queue = queue.Queue()
+            if self.response_thread is None or not self.response_thread.is_alive():
+                self.response_thread = threading.Thread(
+                    target=self._process_responses, daemon=True
+                )
+                self.response_thread.start()
+        if self.read_thread is not None and self.read_thread.is_alive():
+            logger.info("%s: read thread already running", self.desc)
+            return
+        self.read_thread = threading.Thread(target=self._read_loop, daemon=True)
+        self.read_thread.start()
+        logger.info("%s: read thread started", self.desc)
+
+    def stop_read_thread(self) -> None:
+        """Signal both worker threads to exit and join them (unless called from
+        one of them, in which case that thread is already on its way out)."""
+        self.stop_event.set()
+        with self._buffer_condition:
+            self._buffer_condition.notify_all()
+        for t in (self.read_thread, self.response_thread):
+            if t is not None and threading.current_thread() is not t:
+                t.join(timeout=2.0)
+        logger.info("%s: read thread stopped", self.desc)
+
+    # ────────────────────────────────────────────────────────────────────
+    # Core loops
+    # ────────────────────────────────────────────────────────────────────
+
+    def _read_loop(self) -> None:
+        while not self.stop_event.is_set():
+            try:
+                data = self._raw_read()
+            except Exception as e:  # noqa: BLE001 — any read failure is fatal here
+                if self.stop_event.is_set():
+                    break
+                logger.warning("%s: read error; exiting read loop: %s", self.desc, e)
+                # Latch transport-down BEFORE the callback so any send_packet
+                # spinning in its wait loop observes the dead transport next tick.
+                self._transport_down_evt.set()
+                self._notify_io_error(e)
+                break
+            if data:
+                with self._buffer_condition:
+                    self._read_buffer.extend(data)
+                    self._buffer_condition.notify()
+
+    def _process_responses(self) -> None:
+        while not self.stop_event.is_set():
+            with self._buffer_condition:
+                if not self._read_buffer:
+                    self._buffer_condition.wait(timeout=0.1)
+                    continue
+                # Carve one complete frame off the front (resyncs past garbage).
+                frame = extract_frame(self._read_buffer)
+            if frame is None:
+                continue  # partial frame — wait for the reader to add more
+            try:
+                pkt = UartPacket(buffer=frame)
+            except ValueError:
+                continue  # bad CRC / malformed — drop it
+            # Unsolicited firmware log packets are surfaced and dropped; only
+            # real command responses go to the queue for send_packet to match.
+            if is_log_packet(pkt):
+                emit_log_packet(pkt, self.desc)
+            elif self.response_queue is not None:
+                self.response_queue.put(pkt)
+
+    # ────────────────────────────────────────────────────────────────────
+    # Send
+    # ────────────────────────────────────────────────────────────────────
+
+    def _build_packet(self, id, packetType, command, addr, reserved, data):
+        """Resolve the id (auto-increment when None), build the frame bytes, and
+        log the TX. Call inside ``_send_lock`` (it bumps ``packet_count``)."""
+        if id is None:
+            self.packet_count = (self.packet_count + 1) & 0xFFFF or 1
+            id = self.packet_count
+        if data:
+            if not isinstance(data, (bytes, bytearray)):
+                raise ValueError("Data must be bytes or bytearray")
+            payload = data
+        else:
+            payload = b""
+        pkt = UartPacket(
+            id=id, packetType=packetType, command=command,
+            addr=addr, reserved=reserved, data=payload,
+        )
+        tx = pkt.to_bytes()
+        cmd_names = _CMD_NAMES.get(_PACKET_TYPE_NAMES.get(packetType), {})
+        logger.debug(
+            "%s: TX id=0x%04X type=%s cmd=%s addr=0x%02X reserved=0x%02X len=%d",
+            self.desc, id, _format_named(packetType, _PACKET_TYPE_NAMES),
+            _format_named(command, cmd_names), addr, reserved, len(payload),
+        )
+        return id, tx
+
+    def send_packet(
+        self,
+        id=None,
+        packetType=OW_ACK,
+        command=OW_CMD_NOP,
+        addr=0,
+        reserved=0,
+        data=None,
+        timeout=None,
+        max_retries=0,
+    ) -> UartPacket:
+        """Write a command and return the response with the matching id.
+
+        Raises ``ConnectionError`` if the transport drops mid-wait, ``TimeoutError``
+        if no matching response arrives within ``timeout`` (defaults to
+        ``self.default_timeout``), and ``ValueError`` on bad arguments.
+        """
+        timeout = self.default_timeout if timeout is None else timeout
+        with self._send_lock:
+            self._pace_before_send()
+            try:
+                id, tx = self._build_packet(id, packetType, command, addr, reserved, data)
+                self._raw_write(tx)
+                time.sleep(0.0005)
+                start = time.monotonic()
+                while time.monotonic() - start < timeout:
+                    if self._transport_down_evt.is_set():
+                        raise ConnectionError(
+                            f"{self.desc}: transport down, packet id 0x{id:04X} "
+                            "not deliverable"
+                        )
+                    try:
+                        resp = self.response_queue.get(timeout=0.02)
+                    except queue.Empty:
+                        continue
+                    if resp.id != id:
+                        logger.warning(
+                            "%s: discarding stale response id=0x%04X (expected 0x%04X)",
+                            self.desc, resp.id, id,
+                        )
+                        continue
+                    return resp
+                raise TimeoutError(
+                    f"{self.desc}: no response for packet id 0x{id:04X}"
+                )
+            finally:
+                self._mark_send_done()
+
+    def _pace_before_send(self) -> None:
+        """Hook (called holding the send lock): subclasses may throttle the
+        command rate. Default: no throttling."""
+
+    def _mark_send_done(self) -> None:
+        """Hook (called holding the send lock): subclasses may record the
+        send-completion time for rate throttling. Default: no-op."""
+
+    def clear_buffer(self) -> None:
+        """Drop any partially-received frame. Safe to call from any thread —
+        the reader thread is the only other toucher and it locks the same
+        condition."""
+        with self._buffer_condition:
+            self._read_buffer.clear()
+
+    def _notify_io_error(self, error) -> None:
+        cb = self.on_io_error
+        if cb is None:
+            return
+        errno = getattr(error, "errno", None)
+        try:
+            cb(errno, str(error))
+        except Exception as e:
+            logger.warning("on_io_error callback raised: %s", e)

--- a/omotion/packet_transport.py
+++ b/omotion/packet_transport.py
@@ -18,7 +18,7 @@ channel without colliding with responses — the reason the sensor tolerated
 firmware printf long before the console did.
 
 Subclasses implement ``_raw_read()`` / ``_raw_write()`` plus their own
-open/close, and may override the throttle hooks to pace commands.
+open/close.
 """
 from __future__ import annotations
 
@@ -225,42 +225,30 @@ class PacketTransport:
         """
         timeout = self.default_timeout if timeout is None else timeout
         with self._send_lock:
-            self._pace_before_send()
-            try:
-                id, tx = self._build_packet(id, packetType, command, addr, reserved, data)
-                self._raw_write(tx)
-                time.sleep(0.0005)
-                start = time.monotonic()
-                while time.monotonic() - start < timeout:
-                    if self._transport_down_evt.is_set():
-                        raise ConnectionError(
-                            f"{self.desc}: transport down, packet id 0x{id:04X} "
-                            "not deliverable"
-                        )
-                    try:
-                        resp = self.response_queue.get(timeout=0.02)
-                    except queue.Empty:
-                        continue
-                    if resp.id != id:
-                        logger.warning(
-                            "%s: discarding stale response id=0x%04X (expected 0x%04X)",
-                            self.desc, resp.id, id,
-                        )
-                        continue
-                    return resp
-                raise TimeoutError(
-                    f"{self.desc}: no response for packet id 0x{id:04X}"
-                )
-            finally:
-                self._mark_send_done()
-
-    def _pace_before_send(self) -> None:
-        """Hook (called holding the send lock): subclasses may throttle the
-        command rate. Default: no throttling."""
-
-    def _mark_send_done(self) -> None:
-        """Hook (called holding the send lock): subclasses may record the
-        send-completion time for rate throttling. Default: no-op."""
+            id, tx = self._build_packet(id, packetType, command, addr, reserved, data)
+            self._raw_write(tx)
+            time.sleep(0.0005)
+            start = time.monotonic()
+            while time.monotonic() - start < timeout:
+                if self._transport_down_evt.is_set():
+                    raise ConnectionError(
+                        f"{self.desc}: transport down, packet id 0x{id:04X} "
+                        "not deliverable"
+                    )
+                try:
+                    resp = self.response_queue.get(timeout=0.02)
+                except queue.Empty:
+                    continue
+                if resp.id != id:
+                    logger.warning(
+                        "%s: discarding stale response id=0x%04X (expected 0x%04X)",
+                        self.desc, resp.id, id,
+                    )
+                    continue
+                return resp
+            raise TimeoutError(
+                f"{self.desc}: no response for packet id 0x{id:04X}"
+            )
 
     def clear_buffer(self) -> None:
         """Drop any partially-received frame. Safe to call from any thread —

--- a/omotion/packet_transport.py
+++ b/omotion/packet_transport.py
@@ -18,7 +18,7 @@ channel without colliding with responses — the reason the sensor tolerated
 firmware printf long before the console did.
 
 Subclasses implement ``_raw_read()`` / ``_raw_write()`` plus their own
-open/close, and may override :meth:`send_packet` to add a synchronous path.
+open/close, and may override the throttle hooks to pace commands.
 """
 from __future__ import annotations
 
@@ -63,12 +63,10 @@ class PacketTransport:
     def __init__(
         self,
         desc: str = "XPORT",
-        async_mode: bool = True,
         default_timeout: float = 10.0,
         on_io_error: Optional[Callable[[Optional[int], str], None]] = None,
     ):
         self.desc = desc
-        self.async_mode = async_mode
         self.default_timeout = default_timeout
         self.on_io_error = on_io_error
         self.packet_count = 0
@@ -89,9 +87,7 @@ class PacketTransport:
 
         self.read_thread: Optional[threading.Thread] = None
         self.response_thread: Optional[threading.Thread] = None
-        self.response_queue: Optional[queue.Queue] = (
-            queue.Queue() if async_mode else None
-        )
+        self.response_queue: queue.Queue = queue.Queue()
 
     # ────────────────────────────────────────────────────────────────────
     # Raw byte I/O — subclass provides
@@ -115,14 +111,11 @@ class PacketTransport:
         # transport-down latch so subsequent sends aren't poisoned.
         self.stop_event.clear()
         self._transport_down_evt.clear()
-        if self.async_mode:
-            if self.response_queue is None:
-                self.response_queue = queue.Queue()
-            if self.response_thread is None or not self.response_thread.is_alive():
-                self.response_thread = threading.Thread(
-                    target=self._process_responses, daemon=True
-                )
-                self.response_thread.start()
+        if self.response_thread is None or not self.response_thread.is_alive():
+            self.response_thread = threading.Thread(
+                target=self._process_responses, daemon=True
+            )
+            self.response_thread.start()
         if self.read_thread is not None and self.read_thread.is_alive():
             logger.info("%s: read thread already running", self.desc)
             return
@@ -181,7 +174,7 @@ class PacketTransport:
             # real command responses go to the queue for send_packet to match.
             if is_log_packet(pkt):
                 emit_log_packet(pkt, self.desc)
-            elif self.response_queue is not None:
+            else:
                 self.response_queue.put(pkt)
 
     # ────────────────────────────────────────────────────────────────────

--- a/tests/test_comm_transport_down.py
+++ b/tests/test_comm_transport_down.py
@@ -1,48 +1,43 @@
-"""Unit tests for CommInterface transport-down cancellation.
+"""Unit tests for transport-down cancellation (via CommInterface / PacketTransport).
 
-Verifies that when the USB read loop signals the transport is down
-(via the new ``_transport_down_evt``), any in-flight ``send_packet``
-call unblocks immediately instead of spinning for the full ``timeout``
-(which is 60 s for ``program_fpga`` / ``camera_configure_registers``
-and was the root cause of bloodflow-app#130 — power-cycle during a
-scan left the SDK's configure worker hung for 60 s, blocking the next
-scan attempt).
+Verifies that when the read loop signals the transport is down (via
+``_transport_down_evt``), any in-flight ``send_packet`` call unblocks
+immediately instead of spinning for the full ``timeout`` (which is 60 s for
+``program_fpga`` / ``camera_configure_registers`` and was the root cause of
+bloodflow-app#130 — power-cycle during a scan left the SDK's configure worker
+hung for 60 s, blocking the next scan attempt).
 """
 
 import threading
 import time
 from unittest.mock import MagicMock
 
-import pytest
-
 from omotion.CommInterface import CommInterface
 from omotion.config import OW_CMD, OW_CMD_NOP
 
 
-def _make_comm(*, async_mode: bool) -> CommInterface:
+def _make_comm() -> CommInterface:
     """Build a CommInterface bypassing claim() — dev is a MagicMock so
     write() succeeds silently and the response stays absent."""
     dev = MagicMock()
     dev.write.return_value = 12
-    ci = CommInterface(dev, interface_index=0, desc="TEST", async_mode=async_mode)
+    ci = CommInterface(dev, interface_index=0, desc="TEST")
     ci.ep_out = MagicMock(bEndpointAddress=0x01)
     ci.ep_in = MagicMock(bEndpointAddress=0x81, wMaxPacketSize=64)
     return ci
 
 
-def test_async_send_unblocks_on_transport_down():
-    """A pending async send must raise within a few ms of the transport
-    flag being set, not wait for the full 60 s timeout."""
-    ci = _make_comm(async_mode=True)
+def test_send_unblocks_on_transport_down():
+    """A pending send must raise within a few ms of the transport flag being
+    set, not wait for the full 60 s timeout."""
+    ci = _make_comm()
 
     box: dict = {}
 
     def _do_send():
         t0 = time.monotonic()
         try:
-            ci.send_packet(
-                packetType=OW_CMD, command=OW_CMD_NOP, timeout=60,
-            )
+            ci.send_packet(packetType=OW_CMD, command=OW_CMD_NOP, timeout=60)
             box["result"] = "returned"
         except ConnectionError as e:
             box["err"] = e
@@ -64,52 +59,18 @@ def test_async_send_unblocks_on_transport_down():
     )
 
 
-def test_sync_send_unblocks_on_transport_down():
-    """Same guarantee for sync (non-async) mode."""
-    ci = _make_comm(async_mode=False)
-    ci.receive = MagicMock(return_value=b"")  # no data arriving
-
-    box: dict = {}
-
-    def _do_send():
-        t0 = time.monotonic()
-        try:
-            ci.send_packet(
-                packetType=OW_CMD, command=OW_CMD_NOP, timeout=60,
-            )
-            box["result"] = "returned"
-        except ConnectionError as e:
-            box["err"] = e
-        box["elapsed"] = time.monotonic() - t0
-
-    t = threading.Thread(target=_do_send, daemon=True)
-    t.start()
-
-    time.sleep(0.05)
-    ci._transport_down_evt.set()
-
-    t.join(timeout=2.0)
-    assert not t.is_alive(), "sync send_packet did not unblock on transport_down"
-    assert "err" in box, f"expected ConnectionError, got: {box}"
-    assert box["elapsed"] < 1.0, (
-        f"sync send_packet took {box['elapsed']:.2f}s — should have unblocked "
-        "promptly on transport_down"
-    )
-
-
 def test_start_read_thread_clears_transport_down():
     """Restarting the read thread (e.g. after reconnect) must clear the
     transport-down flag so subsequent sends are not poisoned."""
-    ci = _make_comm(async_mode=True)
+    ci = _make_comm()
     ci._transport_down_evt.set()
 
-    # Avoid spawning a real read thread (no real dev to read from); patch
-    # the loop to exit immediately so start_read_thread just runs the
-    # bookkeeping (clearing stop_event + transport_down_evt).
+    # Avoid spawning a real read thread (no real dev to read from); patch the
+    # loop to exit immediately so start_read_thread just runs the bookkeeping
+    # (clearing stop_event + transport_down_evt).
     ci._read_loop = lambda: None
     ci.start_read_thread()
 
-    # Let the (no-op) read thread finish before we assert.
     if ci.read_thread is not None:
         ci.read_thread.join(timeout=1.0)
     assert not ci._transport_down_evt.is_set(), (

--- a/tests/test_framing.py
+++ b/tests/test_framing.py
@@ -1,8 +1,10 @@
-"""Pure-software tests for omotion.framing and the MotionUart printf demux.
-
-No hardware: runs under ``pytest -m "not console and not sensor and not destructive"``.
+"""Pure-software tests for omotion.framing and the unified async transport
+(MotionUart over a fake serial). No hardware: runs under
+``pytest -m "not console and not sensor and not destructive"``.
 """
 import logging
+import threading
+import time
 
 import pytest
 
@@ -15,6 +17,7 @@ from omotion.framing import (
     is_log_packet,
 )
 from omotion.config import (
+    OW_CMD,
     OW_CMD_ECHO,
     OW_CMD_PING,
     OW_DATA,
@@ -41,8 +44,7 @@ def make_log_frame(text=b"hello\n"):
 def test_extract_single_frame():
     frame = make_frame(b"abc")
     buf = bytearray(frame)
-    out = extract_frame(buf)
-    assert out == frame
+    assert extract_frame(buf) == frame
     assert len(buf) == 0
 
 
@@ -59,8 +61,8 @@ def test_extract_multiple_frames_back_to_back():
 def test_extract_partial_frame_returns_none_then_completes():
     frame = make_frame(b"payload")
     buf = bytearray(frame[:6])
-    assert extract_frame(buf) is None       # not enough bytes yet
-    assert bytes(buf) == frame[:6]          # held intact for next read
+    assert extract_frame(buf) is None
+    assert bytes(buf) == frame[:6]
     buf.extend(frame[6:])
     assert extract_frame(buf) == frame
 
@@ -73,8 +75,6 @@ def test_extract_skips_leading_garbage():
 
 
 def test_extract_resyncs_past_false_start():
-    # A 0xAA whose declared length is implausible (0xFFFF > MAX) must be
-    # discarded so the real frame that follows is still found.
     false_start = bytes([OW_START_BYTE, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF])
     frame = make_frame(b"real")
     buf = bytearray(false_start + frame)
@@ -83,19 +83,16 @@ def test_extract_resyncs_past_false_start():
 
 
 def test_extract_empty_buffer():
-    buf = bytearray()
-    assert extract_frame(buf) is None
+    assert extract_frame(bytearray()) is None
 
 
 def test_extract_all_garbage_is_dropped():
     buf = bytearray(b"\x01\x02\x03\x04")
     assert extract_frame(buf) is None
-    assert len(buf) == 0  # nothing salvageable — buffer cleared
+    assert len(buf) == 0
 
 
 def test_max_frame_data_len_is_generous():
-    # Must cover both firmwares (sensor up to 8192) so the shared extractor is
-    # safe for the async path too.
     assert MAX_FRAME_DATA_LEN >= 8192
 
 
@@ -104,16 +101,15 @@ def test_max_frame_data_len_is_generous():
 # --------------------------------------------------------------------------- #
 
 def test_is_log_packet_true_for_printf():
-    pkt = UartPacket(buffer=make_log_frame(b"hi"))
-    assert is_log_packet(pkt) is True
+    assert is_log_packet(UartPacket(buffer=make_log_frame(b"hi"))) is True
 
 
 @pytest.mark.parametrize(
     "frame",
     [
-        make_frame(b"hi", id=1, ptype=OW_DATA, cmd=OW_CMD_ECHO),   # id != 0
-        make_frame(b"hi", id=0, ptype=OW_RESP, cmd=OW_CMD_ECHO),   # wrong type
-        make_frame(b"hi", id=0, ptype=OW_DATA, cmd=OW_CMD_PING),   # wrong cmd
+        make_frame(b"hi", id=1, ptype=OW_DATA, cmd=OW_CMD_ECHO),
+        make_frame(b"hi", id=0, ptype=OW_RESP, cmd=OW_CMD_ECHO),
+        make_frame(b"hi", id=0, ptype=OW_DATA, cmd=OW_CMD_PING),
     ],
 )
 def test_is_log_packet_false_for_responses(frame):
@@ -124,64 +120,129 @@ def test_emit_log_packet_logs_text(caplog):
     pkt = UartPacket(buffer=make_log_frame(b"boot complete\r\n"))
     with caplog.at_level(logging.WARNING):
         emit_log_packet(pkt, "console")
-    msgs = [r.getMessage() for r in caplog.records]
-    assert any("PRINTF" in m and "boot complete" in m for m in msgs)
+    assert any(
+        "PRINTF" in r.getMessage() and "boot complete" in r.getMessage()
+        for r in caplog.records
+    )
 
 
 # --------------------------------------------------------------------------- #
-# MotionUart.read_packet — demuxes log packets out of the response stream
+# Unified async transport (MotionUart) over a fake serial
 # --------------------------------------------------------------------------- #
 
 class FakeSerial:
-    """Minimal serial stand-in: read_all() drains queued chunks."""
+    """Threadsafe serial stand-in: read(1)/read_all() drain queued chunks."""
 
-    def __init__(self, chunks):
-        self._chunks = list(chunks)
+    def __init__(self, chunks=()):
+        self._chunks = [bytes(c) for c in chunks]
+        self._lock = threading.Lock()
         self.is_open = True
 
+    def feed(self, data):
+        with self._lock:
+            self._chunks.append(bytes(data))
+
+    def read(self, n=1):
+        with self._lock:
+            if self._chunks:
+                return self._chunks.pop(0)
+        time.sleep(0.005)
+        return b""
+
     def read_all(self):
-        return self._chunks.pop(0) if self._chunks else b""
+        with self._lock:
+            if not self._chunks:
+                return b""
+            data = b"".join(self._chunks)
+            self._chunks.clear()
+            return data
+
+    def write(self, data):
+        return len(data)
 
     def reset_input_buffer(self):
-        pass
+        with self._lock:
+            self._chunks.clear()
+
+    def close(self):
+        self.is_open = False
 
 
-def make_uart(chunks):
+def make_async_uart(chunks=()):
     u = MotionUart(vid=0, pid=0, demo_mode=False)
     u.serial = FakeSerial(chunks)
+    u.port = "FAKE"
+    u.start_read_thread()
     return u
 
 
-def test_read_packet_skips_log_and_returns_response(caplog):
-    log = make_log_frame(b"some printf\n")
-    resp = make_frame(b"OK", id=7, cmd=OW_CMD_PING)
-    uart = make_uart([log + resp])
-    with caplog.at_level(logging.WARNING):
-        pkt = uart.read_packet(timeout=2)
-    assert pkt.id == 7
-    assert bytes(pkt.data) == b"OK"
-    assert any("PRINTF" in r.getMessage() for r in caplog.records)
+def test_transport_demuxes_log_and_returns_response(caplog):
+    resp = make_frame(b"OK", id=42, cmd=OW_CMD_PING)
+    log = make_log_frame(b"hello from fw\n")
+    u = make_async_uart([log + resp])
+    try:
+        with caplog.at_level(logging.WARNING):
+            r = u.send_packet(id=42, packetType=OW_CMD, command=OW_CMD_PING, timeout=2)
+        assert r.id == 42
+        assert bytes(r.data) == b"OK"
+        assert any("PRINTF" in rec.getMessage() for rec in caplog.records)
+    finally:
+        u.stop_read_thread()
 
 
-def test_read_packet_reassembles_fragments():
-    resp = make_frame(b"payload-across-reads", id=3)
-    uart = make_uart([resp[:5], resp[5:]])
-    pkt = uart.read_packet(timeout=2)
-    assert pkt.id == 3
-    assert bytes(pkt.data) == b"payload-across-reads"
+def test_transport_reassembles_fragments():
+    resp = make_frame(b"payload-across-reads", id=7)
+    u = make_async_uart([resp[:5]])
+    try:
+        u.serial.feed(resp[5:])
+        r = u.send_packet(id=7, packetType=OW_CMD, command=OW_CMD_PING, timeout=2)
+        assert r.id == 7
+        assert bytes(r.data) == b"payload-across-reads"
+    finally:
+        u.stop_read_thread()
 
 
-def test_read_packet_times_out_with_no_data():
-    uart = make_uart([])  # read_all always returns b""
-    with pytest.raises(ValueError):
-        uart.read_packet(timeout=0.2)
-
-
-def test_read_packet_drops_bad_crc_then_returns_good():
+def test_transport_drops_bad_crc_then_returns_good():
     bad = bytearray(make_frame(b"bad", id=1))
-    bad[10] ^= 0xFF  # corrupt a CRC byte
+    bad[10] ^= 0xFF  # corrupt the payload so CRC fails
     good = make_frame(b"good", id=2)
-    uart = make_uart([bytes(bad) + good])
-    pkt = uart.read_packet(timeout=2)
-    assert pkt.id == 2
-    assert bytes(pkt.data) == b"good"
+    u = make_async_uart([bytes(bad) + good])
+    try:
+        r = u.send_packet(id=2, packetType=OW_CMD, command=OW_CMD_PING, timeout=2)
+        assert r.id == 2
+        assert bytes(r.data) == b"good"
+    finally:
+        u.stop_read_thread()
+
+
+def test_transport_ignores_stale_id_and_times_out():
+    # A response with the wrong id must not satisfy a different request.
+    other = make_frame(b"x", id=99)
+    u = make_async_uart([other])
+    try:
+        with pytest.raises(TimeoutError):
+            u.send_packet(id=1, packetType=OW_CMD, command=OW_CMD_PING, timeout=0.4)
+    finally:
+        u.stop_read_thread()
+
+
+def test_transport_send_unblocks_on_transport_down():
+    u = make_async_uart([])
+    try:
+        def trip():
+            time.sleep(0.05)
+            u._transport_down_evt.set()
+
+        threading.Thread(target=trip, daemon=True).start()
+        t0 = time.monotonic()
+        with pytest.raises(ConnectionError):
+            u.send_packet(id=1, packetType=OW_CMD, command=OW_CMD_PING, timeout=5)
+        assert time.monotonic() - t0 < 1.0
+    finally:
+        u.stop_read_thread()
+
+
+def test_demo_mode_send_returns_without_serial():
+    u = MotionUart(vid=0, pid=0, demo_mode=True)
+    r = u.send_packet(packetType=OW_CMD, command=OW_CMD_PING)
+    assert r is not None  # demo short-circuit, never touches a port

--- a/tests/test_framing.py
+++ b/tests/test_framing.py
@@ -1,0 +1,187 @@
+"""Pure-software tests for omotion.framing and the MotionUart printf demux.
+
+No hardware: runs under ``pytest -m "not console and not sensor and not destructive"``.
+"""
+import logging
+
+import pytest
+
+from omotion.UartPacket import UartPacket
+from omotion.MotionUart import MotionUart
+from omotion.framing import (
+    MAX_FRAME_DATA_LEN,
+    emit_log_packet,
+    extract_frame,
+    is_log_packet,
+)
+from omotion.config import (
+    OW_CMD_ECHO,
+    OW_CMD_PING,
+    OW_DATA,
+    OW_RESP,
+    OW_START_BYTE,
+)
+
+
+def make_frame(data=b"", id=1, ptype=OW_RESP, cmd=OW_CMD_PING, addr=0, reserved=0):
+    return UartPacket(
+        id=id, packetType=ptype, command=cmd, addr=addr, reserved=reserved, data=data
+    ).to_bytes()
+
+
+def make_log_frame(text=b"hello\n"):
+    """A firmware printf packet: id=0, OW_DATA, OW_CMD_ECHO."""
+    return make_frame(data=text, id=0, ptype=OW_DATA, cmd=OW_CMD_ECHO)
+
+
+# --------------------------------------------------------------------------- #
+# extract_frame
+# --------------------------------------------------------------------------- #
+
+def test_extract_single_frame():
+    frame = make_frame(b"abc")
+    buf = bytearray(frame)
+    out = extract_frame(buf)
+    assert out == frame
+    assert len(buf) == 0
+
+
+def test_extract_multiple_frames_back_to_back():
+    f1 = make_frame(b"one", id=1)
+    f2 = make_frame(b"two", id=2)
+    buf = bytearray(f1 + f2)
+    assert extract_frame(buf) == f1
+    assert extract_frame(buf) == f2
+    assert extract_frame(buf) is None
+    assert len(buf) == 0
+
+
+def test_extract_partial_frame_returns_none_then_completes():
+    frame = make_frame(b"payload")
+    buf = bytearray(frame[:6])
+    assert extract_frame(buf) is None       # not enough bytes yet
+    assert bytes(buf) == frame[:6]          # held intact for next read
+    buf.extend(frame[6:])
+    assert extract_frame(buf) == frame
+
+
+def test_extract_skips_leading_garbage():
+    frame = make_frame(b"x")
+    buf = bytearray(b"\x00\x11\x22" + frame)
+    assert extract_frame(buf) == frame
+    assert len(buf) == 0
+
+
+def test_extract_resyncs_past_false_start():
+    # A 0xAA whose declared length is implausible (0xFFFF > MAX) must be
+    # discarded so the real frame that follows is still found.
+    false_start = bytes([OW_START_BYTE, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF])
+    frame = make_frame(b"real")
+    buf = bytearray(false_start + frame)
+    assert extract_frame(buf) == frame
+    assert len(buf) == 0
+
+
+def test_extract_empty_buffer():
+    buf = bytearray()
+    assert extract_frame(buf) is None
+
+
+def test_extract_all_garbage_is_dropped():
+    buf = bytearray(b"\x01\x02\x03\x04")
+    assert extract_frame(buf) is None
+    assert len(buf) == 0  # nothing salvageable — buffer cleared
+
+
+def test_max_frame_data_len_is_generous():
+    # Must cover both firmwares (sensor up to 8192) so the shared extractor is
+    # safe for the async path too.
+    assert MAX_FRAME_DATA_LEN >= 8192
+
+
+# --------------------------------------------------------------------------- #
+# is_log_packet / emit_log_packet
+# --------------------------------------------------------------------------- #
+
+def test_is_log_packet_true_for_printf():
+    pkt = UartPacket(buffer=make_log_frame(b"hi"))
+    assert is_log_packet(pkt) is True
+
+
+@pytest.mark.parametrize(
+    "frame",
+    [
+        make_frame(b"hi", id=1, ptype=OW_DATA, cmd=OW_CMD_ECHO),   # id != 0
+        make_frame(b"hi", id=0, ptype=OW_RESP, cmd=OW_CMD_ECHO),   # wrong type
+        make_frame(b"hi", id=0, ptype=OW_DATA, cmd=OW_CMD_PING),   # wrong cmd
+    ],
+)
+def test_is_log_packet_false_for_responses(frame):
+    assert is_log_packet(UartPacket(buffer=frame)) is False
+
+
+def test_emit_log_packet_logs_text(caplog):
+    pkt = UartPacket(buffer=make_log_frame(b"boot complete\r\n"))
+    with caplog.at_level(logging.WARNING):
+        emit_log_packet(pkt, "console")
+    msgs = [r.getMessage() for r in caplog.records]
+    assert any("PRINTF" in m and "boot complete" in m for m in msgs)
+
+
+# --------------------------------------------------------------------------- #
+# MotionUart.read_packet — demuxes log packets out of the response stream
+# --------------------------------------------------------------------------- #
+
+class FakeSerial:
+    """Minimal serial stand-in: read_all() drains queued chunks."""
+
+    def __init__(self, chunks):
+        self._chunks = list(chunks)
+        self.is_open = True
+
+    def read_all(self):
+        return self._chunks.pop(0) if self._chunks else b""
+
+    def reset_input_buffer(self):
+        pass
+
+
+def make_uart(chunks):
+    u = MotionUart(vid=0, pid=0, demo_mode=False)
+    u.serial = FakeSerial(chunks)
+    return u
+
+
+def test_read_packet_skips_log_and_returns_response(caplog):
+    log = make_log_frame(b"some printf\n")
+    resp = make_frame(b"OK", id=7, cmd=OW_CMD_PING)
+    uart = make_uart([log + resp])
+    with caplog.at_level(logging.WARNING):
+        pkt = uart.read_packet(timeout=2)
+    assert pkt.id == 7
+    assert bytes(pkt.data) == b"OK"
+    assert any("PRINTF" in r.getMessage() for r in caplog.records)
+
+
+def test_read_packet_reassembles_fragments():
+    resp = make_frame(b"payload-across-reads", id=3)
+    uart = make_uart([resp[:5], resp[5:]])
+    pkt = uart.read_packet(timeout=2)
+    assert pkt.id == 3
+    assert bytes(pkt.data) == b"payload-across-reads"
+
+
+def test_read_packet_times_out_with_no_data():
+    uart = make_uart([])  # read_all always returns b""
+    with pytest.raises(ValueError):
+        uart.read_packet(timeout=0.2)
+
+
+def test_read_packet_drops_bad_crc_then_returns_good():
+    bad = bytearray(make_frame(b"bad", id=1))
+    bad[10] ^= 0xFF  # corrupt a CRC byte
+    good = make_frame(b"good", id=2)
+    uart = make_uart([bytes(bad) + good])
+    pkt = uart.read_packet(timeout=2)
+    assert pkt.id == 2
+    assert bytes(pkt.data) == b"good"


### PR DESCRIPTION
Refs #122.

## What

Host-side support for console firmware printf-over-USB, plus a transport cleanup: the console and sensor command links now share one async engine.

### Commits
- **feat: surface console firmware printf over USB CDC** — new `omotion/framing.py` (shared frame extraction + log-packet demux); `MotionConsole.set_debug_flags` / `get_debug_flags` / `enable_usb_printf`; firmware `printf` packets (`OW_DATA`/`OW_CMD_ECHO`/id=0) are demuxed from responses and surfaced via the logger.
- **refactor: unify console + sensor command transports** — extract the sensor's proven async engine into `omotion/packet_transport.py::PacketTransport` (reader thread + frame dispatch + id-matched send + transport-down cancellation). `CommInterface` (USB bulk) and `MotionUart` (serial VCP) both subclass it; the console gains a continuous reader so printf packets never collide with responses. Net **−228 lines**.
- **refactor: drop CommInterface sync mode** — async-only; the sync path was dead in production.
- **refactor: drop console command pacing** — the console firmware now re-arms its CDC RX up front, so the host no longer needs the inter-command pace.

## Compatibility
This SDK assumes console firmware with the CDC-RX re-arm fix (OpenwaterHealth/openmotion-console-fw#39). Against older console firmware, rapid back-to-back console commands could be dropped.

## Testing
- Pure-software suite green (485 passed; 3 pre-existing unrelated ScanDB-sink failures). `CommInterface` transport-down contract preserved.
- Hardware: console printf surfaces to host; **40 rapid back-to-back pings, 0 failures, no pacing**; telemetry + both sensors (ping/echo) healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
