### PR TITLE
feat: firmware_update module (version compare, GitHub check, DFU flash orchestration)

### DIFF
--- a/omotion/MotionSensor.py
+++ b/omotion/MotionSensor.py
@@ -1,5 +1,4 @@
 import logging
-import re
 import struct
 import threading
 import time
@@ -84,32 +83,11 @@ logger = logging.getLogger(f"{_log_root}.Sensor" if _log_root else "Sensor")
 _ERROR_TYPES = frozenset({OW_ERROR, OW_BAD_CRC, OW_BAD_PARSE, OW_UNKNOWN})
 
 
-# Matches the leading "MAJOR.MINOR.PATCH" of a firmware version, ignoring any
-# leading "v" and any pre-release / build / git-describe suffix that follows.
-# Examples that match: "v1.5.4", "1.5.4-dev", "1.5.4-dev.0-5-g1234abc-dirty",
-# "1.5.4+build.7". Strings with no leading numeric component (e.g. "unknown")
-# do not match.
-_VERSION_RE = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)")
-
-
-def _parse_firmware_version(version_str: str) -> tuple[int, int, int]:
-    """Parse a sensor firmware version string into a ``(major, minor, patch)`` tuple.
-
-    Tolerates a leading ``v`` and any pre-release / build / git-describe suffix
-    (``-dev``, ``-rc.1``, ``-5-g1234abc``, ``-dirty``, ``+build.7``, etc.) by
-    matching only the leading numeric ``MAJOR.MINOR.PATCH`` segment. Sensor
-    firmware embeds ``git describe --tags --dirty --always`` as its version
-    string, so suffixes like these appear in every non-release build.
-
-    Raises ``ValueError`` if the string has no leading numeric component
-    (e.g. ``"unknown"``).
-    """
-    if version_str is None:
-        raise TypeError("version_str must be a string, got None")
-    m = _VERSION_RE.match(version_str)
-    if not m:
-        raise ValueError(f"unparseable firmware version {version_str!r}")
-    return (int(m.group(1)), int(m.group(2)), int(m.group(3)))
+# Re-exported from the shared module so there is a single source of truth.
+from omotion.firmware_update import (
+    _VERSION_RE,           # noqa: F401  (kept for backward references)
+    parse_version as _parse_firmware_version,
+)
 
 
 class MotionSensor(SignalWrapper):

--- a/omotion/MotionSensor.py
+++ b/omotion/MotionSensor.py
@@ -83,11 +83,7 @@ logger = logging.getLogger(f"{_log_root}.Sensor" if _log_root else "Sensor")
 _ERROR_TYPES = frozenset({OW_ERROR, OW_BAD_CRC, OW_BAD_PARSE, OW_UNKNOWN})
 
 
-# Re-exported from the shared module so there is a single source of truth.
-from omotion.firmware_update import (
-    _VERSION_RE,           # noqa: F401  (kept for backward references)
-    parse_version as _parse_firmware_version,
-)
+from omotion.firmware_update import parse_version as _parse_firmware_version
 
 
 class MotionSensor(SignalWrapper):

--- a/omotion/__init__.py
+++ b/omotion/__init__.py
@@ -59,6 +59,16 @@ from .CalibrationWorkflow import (
     CalibrationThresholds,
 )
 from .connection_state import ConnectionState
+from .firmware_update import (
+    FirmwareKind,
+    FirmwareUpdater,
+    FirmwareUpdateError,
+    LatestInfo,
+    check_latest,
+    download_firmware,
+    is_update_available,
+    parse_version,
+)
 # Top-level handles + interface (deferred until after the leaf modules above
 # so MotionConsole/MotionSensor can do `from omotion import _log_root` during
 # their own module load without hitting the partially-loaded package).
@@ -85,4 +95,12 @@ __all__ = [
     "CalibrationResultRow",
     "CalibrationThresholds",
     "ConnectionState",
+    "FirmwareKind",
+    "FirmwareUpdater",
+    "FirmwareUpdateError",
+    "LatestInfo",
+    "check_latest",
+    "download_firmware",
+    "is_update_available",
+    "parse_version",
 ]

--- a/omotion/firmware_update.py
+++ b/omotion/firmware_update.py
@@ -32,3 +32,65 @@ def is_update_available(installed: str, latest: str) -> bool:
         return parse_version(latest) > parse_version(installed)
     except (ValueError, TypeError):
         return False
+
+
+# ---------------------------------------------------------------------------
+# Task 3: FirmwareKind, LatestInfo, check_latest
+# ---------------------------------------------------------------------------
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+from omotion.GitHubReleases import GitHubReleases
+
+
+class FirmwareKind(Enum):
+    CONSOLE = "console"
+    SENSOR = "sensor"
+
+
+_REPO = {
+    FirmwareKind.CONSOLE: ("OpenwaterHealth", "openmotion-console-fw"),
+    FirmwareKind.SENSOR: ("OpenwaterHealth", "openmotion-sensor-fw"),
+}
+_ASSET = {
+    FirmwareKind.CONSOLE: "motion-console-fw.bin",
+    FirmwareKind.SENSOR: "motion-sensor-fw.bin",
+}
+
+
+@dataclass(frozen=True)
+class LatestInfo:
+    kind: FirmwareKind
+    tag: str
+    asset_name: str
+    published_at: Optional[str] = None
+
+
+def check_latest(
+    kind: FirmwareKind,
+    *,
+    include_prerelease: bool = False,
+    releases: GitHubReleases | None = None,
+) -> Optional[LatestInfo]:
+    """Newest release of ``kind``'s firmware repo, or ``None`` on any
+    network/parse failure or if no matching ``.bin`` asset exists. Never raises:
+    callers treat ``None`` as "couldn't determine, show nothing"."""
+    owner, repo = _REPO[kind]
+    gh = releases or GitHubReleases(owner, repo)
+    try:
+        rel = gh.get_latest_release(include_prerelease=include_prerelease)
+        tag = rel.get("tag_name")
+        if not tag:
+            return None
+        names = [a.get("name", "") for a in gh.get_asset_list(release=rel, extension=".bin")]
+        if _ASSET[kind] in names:
+            asset_name = _ASSET[kind]
+        elif names:
+            asset_name = names[0]
+        else:
+            return None
+        return LatestInfo(kind=kind, tag=tag, asset_name=asset_name,
+                          published_at=rel.get("published_at"))
+    except Exception:
+        return None

--- a/omotion/firmware_update.py
+++ b/omotion/firmware_update.py
@@ -3,9 +3,21 @@ download, and a thin DFU flash orchestrator. UI-agnostic (no Qt)."""
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Callable
+
+from omotion.GitHubReleases import GitHubReleases
+from omotion.DFUProgrammer import DFUProgrammer, DFUProgress, DFUResult
+
+# ---------------------------------------------------------------------------
+# Version parsing
+# ---------------------------------------------------------------------------
 
 # Matches a leading MAJOR.MINOR.PATCH, tolerating a leading "v" and any
-# pre-release/build/git-describe suffix. Mirrors MotionSensor._VERSION_RE.
+# pre-release/build/git-describe suffix. Shared with MotionSensor (which
+# re-imports parse_version).
 _VERSION_RE = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)")
 
 
@@ -35,14 +47,8 @@ def is_update_available(installed: str, latest: str) -> bool:
 
 
 # ---------------------------------------------------------------------------
-# Task 3: FirmwareKind, LatestInfo, check_latest
+# FirmwareKind, LatestInfo, check_latest
 # ---------------------------------------------------------------------------
-from dataclasses import dataclass
-from enum import Enum
-from typing import Optional
-
-from omotion.GitHubReleases import GitHubReleases
-
 
 class FirmwareKind(Enum):
     CONSOLE = "console"
@@ -64,7 +70,7 @@ class LatestInfo:
     kind: FirmwareKind
     tag: str
     asset_name: str
-    published_at: Optional[str] = None
+    published_at: str | None = None
 
 
 def check_latest(
@@ -72,7 +78,7 @@ def check_latest(
     *,
     include_prerelease: bool = False,
     releases: GitHubReleases | None = None,
-) -> Optional[LatestInfo]:
+) -> LatestInfo | None:
     """Newest release of ``kind``'s firmware repo, or ``None`` on any
     network/parse failure or if no matching ``.bin`` asset exists. Never raises:
     callers treat ``None`` as "couldn't determine, show nothing"."""
@@ -97,12 +103,8 @@ def check_latest(
 
 
 # ---------------------------------------------------------------------------
-# Task 4: download_firmware + FirmwareUpdater
+# download_firmware + FirmwareUpdater
 # ---------------------------------------------------------------------------
-from pathlib import Path
-from typing import Callable
-
-from omotion.DFUProgrammer import DFUProgrammer, DFUProgress, DFUResult
 
 _STM32_DFU_VIDPID = "0483:df11"
 

--- a/omotion/firmware_update.py
+++ b/omotion/firmware_update.py
@@ -1,0 +1,34 @@
+"""Firmware update helpers: version comparison, GitHub "latest" lookup,
+download, and a thin DFU flash orchestrator. UI-agnostic (no Qt)."""
+from __future__ import annotations
+
+import re
+
+# Matches a leading MAJOR.MINOR.PATCH, tolerating a leading "v" and any
+# pre-release/build/git-describe suffix. Mirrors MotionSensor._VERSION_RE.
+_VERSION_RE = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)")
+
+
+def parse_version(version_str: str) -> tuple[int, int, int]:
+    """Parse a firmware version into ``(major, minor, patch)``.
+
+    Tolerates a leading ``v`` and any pre-release/build suffix. Raises
+    ``TypeError`` for ``None`` and ``ValueError`` for a string with no leading
+    numeric ``MAJOR.MINOR.PATCH`` component.
+    """
+    if version_str is None:
+        raise TypeError("version_str must be a string, got None")
+    m = _VERSION_RE.match(version_str)
+    if not m:
+        raise ValueError(f"unparseable firmware version {version_str!r}")
+    return (int(m.group(1)), int(m.group(2)), int(m.group(3)))
+
+
+def is_update_available(installed: str, latest: str) -> bool:
+    """True iff ``latest`` parses to a strictly greater (maj, min, patch) than
+    ``installed``. Pre-release suffixes are ignored. Returns ``False`` if either
+    string is empty/unparseable (fail-safe: never offer an unreasoned update)."""
+    try:
+        return parse_version(latest) > parse_version(installed)
+    except (ValueError, TypeError):
+        return False

--- a/omotion/firmware_update.py
+++ b/omotion/firmware_update.py
@@ -94,3 +94,61 @@ def check_latest(
                           published_at=rel.get("published_at"))
     except Exception:
         return None
+
+
+# ---------------------------------------------------------------------------
+# Task 4: download_firmware + FirmwareUpdater
+# ---------------------------------------------------------------------------
+from pathlib import Path
+from typing import Callable
+
+from omotion.DFUProgrammer import DFUProgrammer, DFUProgress, DFUResult
+
+_STM32_DFU_VIDPID = "0483:df11"
+
+
+class FirmwareUpdateError(RuntimeError):
+    """Raised when a firmware flash cannot proceed (DFU entry/enumeration)."""
+
+
+def download_firmware(
+    info: LatestInfo,
+    dest_dir: Path,
+    *,
+    releases: GitHubReleases | None = None,
+) -> Path:
+    """Download ``info``'s ``.bin`` asset into ``dest_dir``; returns the path."""
+    owner, repo = _REPO[info.kind]
+    gh = releases or GitHubReleases(owner, repo)
+    rel = gh.get_release_by_tag(info.tag)
+    return gh.download_asset(rel, info.asset_name, output_dir=Path(dest_dir))
+
+
+class FirmwareUpdater:
+    """Flash one STM32 firmware ``.bin`` onto a handle that supports ``enter_dfu``.
+
+    Pure SDK: enters DFU, waits for the ROM bootloader (PID df11) to
+    re-enumerate, and flashes with the bundled dfu-util. Does NOT manage any
+    connection monitor — the caller pauses reconnection logic around this call.
+    """
+
+    def __init__(
+        self,
+        *,
+        programmer: DFUProgrammer | None = None,
+        dfu_wait_timeout_s: float = 30.0,
+    ):
+        self._dfu = programmer or DFUProgrammer(vidpid=_STM32_DFU_VIDPID)
+        self._wait_timeout_s = dfu_wait_timeout_s
+
+    def update(
+        self,
+        handle,
+        bin_path: Path,
+        progress_cb: Callable[[DFUProgress], None] | None = None,
+    ) -> DFUResult:
+        if not handle.enter_dfu():
+            raise FirmwareUpdateError("device did not accept enter_dfu()")
+        if not self._dfu.wait_for_dfu_device(timeout_s=self._wait_timeout_s):
+            raise FirmwareUpdateError("DFU device did not appear after enter_dfu()")
+        return self._dfu.flash_bin(Path(bin_path), progress=progress_cb)

--- a/tests/test_firmware_update.py
+++ b/tests/test_firmware_update.py
@@ -39,3 +39,45 @@ def test_parse_version_none_raises_typeerror():
 ])
 def test_is_update_available(installed, latest, expected):
     assert is_update_available(installed, latest) is expected
+
+
+# ---------------------------------------------------------------------------
+# Task 3: FirmwareKind + check_latest
+# ---------------------------------------------------------------------------
+from unittest.mock import MagicMock
+
+from omotion.firmware_update import FirmwareKind, LatestInfo, check_latest
+
+
+def _fake_gh(latest_release=None, raises=False):
+    gh = MagicMock()
+    if raises:
+        gh.get_latest_release.side_effect = RuntimeError("network down")
+    else:
+        gh.get_latest_release.return_value = latest_release
+        gh.get_asset_list.return_value = [{"name": "motion-sensor-fw.bin"}]
+    return gh
+
+
+def test_check_latest_returns_info():
+    gh = _fake_gh({"tag_name": "1.4.0", "published_at": "2026-01-01"})
+    info = check_latest(FirmwareKind.SENSOR, releases=gh)
+    assert info == LatestInfo(
+        kind=FirmwareKind.SENSOR, tag="1.4.0",
+        asset_name="motion-sensor-fw.bin", published_at="2026-01-01",
+    )
+
+
+def test_check_latest_none_on_network_error():
+    assert check_latest(FirmwareKind.SENSOR, releases=_fake_gh(raises=True)) is None
+
+
+def test_check_latest_none_when_no_bin_asset():
+    gh = _fake_gh({"tag_name": "1.4.0"})
+    gh.get_asset_list.return_value = []
+    assert check_latest(FirmwareKind.SENSOR, releases=gh) is None
+
+
+def test_check_latest_none_when_no_tag():
+    gh = _fake_gh({"published_at": "x"})  # no tag_name
+    assert check_latest(FirmwareKind.CONSOLE, releases=gh) is None

--- a/tests/test_firmware_update.py
+++ b/tests/test_firmware_update.py
@@ -83,6 +83,14 @@ def test_check_latest_none_when_no_tag():
     assert check_latest(FirmwareKind.CONSOLE, releases=gh) is None
 
 
+def test_check_latest_falls_back_to_first_bin_when_canonical_missing():
+    gh = _fake_gh({"tag_name": "1.4.0", "published_at": "2026-01-01"})
+    gh.get_asset_list.return_value = [{"name": "motion-sensor-fw-v1.4.0.bin"}]
+    info = check_latest(FirmwareKind.SENSOR, releases=gh)
+    assert info is not None
+    assert info.asset_name == "motion-sensor-fw-v1.4.0.bin"
+
+
 # ---------------------------------------------------------------------------
 # Task 4: download_firmware + FirmwareUpdater
 # ---------------------------------------------------------------------------

--- a/tests/test_firmware_update.py
+++ b/tests/test_firmware_update.py
@@ -81,3 +81,60 @@ def test_check_latest_none_when_no_bin_asset():
 def test_check_latest_none_when_no_tag():
     gh = _fake_gh({"published_at": "x"})  # no tag_name
     assert check_latest(FirmwareKind.CONSOLE, releases=gh) is None
+
+
+# ---------------------------------------------------------------------------
+# Task 4: download_firmware + FirmwareUpdater
+# ---------------------------------------------------------------------------
+from pathlib import Path
+
+from omotion.firmware_update import (
+    FirmwareUpdateError, FirmwareUpdater, download_firmware,
+)
+
+
+def test_download_firmware_uses_release_by_tag(tmp_path):
+    gh = MagicMock()
+    gh.get_release_by_tag.return_value = {"tag_name": "1.4.0"}
+    gh.download_asset.return_value = tmp_path / "motion-sensor-fw.bin"
+    info = LatestInfo(FirmwareKind.SENSOR, "1.4.0", "motion-sensor-fw.bin")
+
+    out = download_firmware(info, tmp_path, releases=gh)
+
+    gh.get_release_by_tag.assert_called_once_with("1.4.0")
+    gh.download_asset.assert_called_once_with(
+        {"tag_name": "1.4.0"}, "motion-sensor-fw.bin", output_dir=tmp_path)
+    assert out == tmp_path / "motion-sensor-fw.bin"
+
+
+def test_updater_happy_path(tmp_path):
+    handle = MagicMock()
+    handle.enter_dfu.return_value = True
+    dfu = MagicMock()
+    dfu.wait_for_dfu_device.return_value = True
+    dfu.flash_bin.return_value = MagicMock(success=True)
+
+    updater = FirmwareUpdater(programmer=dfu)
+    result = updater.update(handle, tmp_path / "fw.bin")
+
+    assert result.success is True
+    handle.enter_dfu.assert_called_once()
+    dfu.flash_bin.assert_called_once()
+
+
+def test_updater_raises_if_enter_dfu_rejected(tmp_path):
+    handle = MagicMock()
+    handle.enter_dfu.return_value = False
+    updater = FirmwareUpdater(programmer=MagicMock())
+    with pytest.raises(FirmwareUpdateError):
+        updater.update(handle, tmp_path / "fw.bin")
+
+
+def test_updater_raises_if_dfu_never_appears(tmp_path):
+    handle = MagicMock()
+    handle.enter_dfu.return_value = True
+    dfu = MagicMock()
+    dfu.wait_for_dfu_device.return_value = False
+    updater = FirmwareUpdater(programmer=dfu)
+    with pytest.raises(FirmwareUpdateError):
+        updater.update(handle, tmp_path / "fw.bin")

--- a/tests/test_firmware_update.py
+++ b/tests/test_firmware_update.py
@@ -1,0 +1,41 @@
+import pytest
+
+from omotion.firmware_update import parse_version, is_update_available
+
+
+@pytest.mark.parametrize("s,expected", [
+    ("1.2.3", (1, 2, 3)),
+    ("v1.2.3", (1, 2, 3)),
+    ("1.5.4-dev.1", (1, 5, 4)),
+    ("v2.0.0-rc.2", (2, 0, 0)),
+    ("1.5.4+build.7", (1, 5, 4)),
+    ("1.2.3-5-g1234abc-dirty", (1, 2, 3)),
+])
+def test_parse_version_ok(s, expected):
+    assert parse_version(s) == expected
+
+
+@pytest.mark.parametrize("s", ["", "unknown", "vX.Y.Z", "1.2"])
+def test_parse_version_rejects(s):
+    with pytest.raises(ValueError):
+        parse_version(s)
+
+
+def test_parse_version_none_raises_typeerror():
+    with pytest.raises(TypeError):
+        parse_version(None)
+
+
+@pytest.mark.parametrize("installed,latest,expected", [
+    ("1.2.3", "1.2.4", True),
+    ("1.2.3", "1.3.0", True),
+    ("1.2.3", "2.0.0", True),
+    ("1.2.3", "1.2.3", False),
+    ("1.2.4", "1.2.3", False),
+    ("v1.2.3", "v1.2.4", True),
+    ("1.2.3-dev.1", "1.2.3", False),   # suffixes ignored: same core, not newer
+    ("", "1.2.3", False),               # unparseable installed -> no update
+    ("1.2.3", "garbage", False),        # unparseable latest -> no update
+])
+def test_is_update_available(installed, latest, expected):
+    assert is_update_available(installed, latest) is expected


### PR DESCRIPTION
Adds `omotion/firmware_update.py` — a UI-agnostic helper module that powers the bloodflow-app firmware autoupdater.

## What it adds
- `parse_version` / `is_update_available` — semver `(major, minor, patch)` compare. Pre-release/build suffixes are ignored; returns `False` (never raises) on empty/unparseable input, so an unreasoned update is never offered.
- `FirmwareKind` enum + `check_latest(kind, include_prerelease=False)` — newest **stable** GitHub release for the console/sensor firmware repo. **Fail-soft**: returns `None` on any network/parse error or when no `.bin` asset exists (no banner, never blocks).
- `download_firmware(info, dest_dir)` — fetch the release `.bin`.
- `FirmwareUpdater.update(handle, bin_path)` — `enter_dfu()` → `wait_for_dfu_device()` → bundled-`dfu-util` `flash_bin()`. No Qt, no connection-monitor coupling; the caller owns lifecycle.
- `MotionSensor._parse_firmware_version` now delegates to the shared `parse_version` (single source of truth).
- Re-exports the public symbols from `omotion/__init__.py`.

## Tests
29 unit tests in `tests/test_firmware_update.py` (parse/compare table, `check_latest` success + all None paths, download, updater raise paths). The existing `tests/test_pedestal_height.py` is the regression guard for the parser delegation and stays 100% green.

## Hardware-validated finding (informs consumers)
dfu-util's `leave`/`-R` does **not** reliably reset the STM32 — after a successful write the device hangs non-enumerating until a **power-cycle**, then boots the new image. Verified on both a sensor and the console. Consumers must await a power-cycle + poll for reconnect (~30 s), not assume auto-reboot.

## Cross-repo
Consumed by the openmotion-bloodflow-app "firmware autoupdater" PR. That app PR needs this merged to `next-next` so the app's editable-installed `omotion` exposes `omotion.firmware_update`.

Draft for hand-testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
