### PR TITLE
feat: log converted TEC engineering units in per-scan telemetry CSV

### DIFF
--- a/omotion/ScanWorkflow.py
+++ b/omotion/ScanWorkflow.py
@@ -12,6 +12,11 @@ from typing import Callable, Optional, TYPE_CHECKING
 
 from omotion import _log_root
 from omotion.connection_state import ConnectionState
+from omotion.console_telemetry_conversions import (
+    tec_thermistor_voltage_to_celsius,
+    tec_current_to_amps,
+    tec_voltage_to_volts,
+)
 from omotion.MotionProcessing import (
     CorrectedBatch,
     HISTO_SIZE_WORDS,
@@ -38,6 +43,9 @@ _TELEMETRY_HEADERS: list[str] = [
     "timestamp",
     "tcm", "tcl", "pdc",
     "tec_v_raw", "tec_set_raw", "tec_curr_raw", "tec_volt_raw", "tec_good",
+    # Converted engineering units (°C / A / V) alongside the raw ADC values, so
+    # the TEC temperature is human-readable in the log. See bloodflow-app#244.
+    "tec_temp_c", "tec_set_c", "tec_curr_a", "tec_volt_v",
     *[f"pdu_raw_{i}" for i in range(16)],
     *[f"pdu_volt_{i}" for i in range(16)],
     "safety_se", "safety_so", "safety_ok",
@@ -52,6 +60,13 @@ def _snap_to_row(snap) -> list:
         snap.tcm, snap.tcl, snap.pdc,
         snap.tec_v_raw, snap.tec_set_raw, snap.tec_curr_raw, snap.tec_volt_raw,
         int(snap.tec_good),
+        # Converted engineering units, rounded to match the live display
+        # (temps 2 dp, current/voltage 3 dp). A missing RT table yields NaN,
+        # which is written through as-is.
+        round(tec_thermistor_voltage_to_celsius(snap.tec_v_raw), 2),
+        round(tec_thermistor_voltage_to_celsius(snap.tec_set_raw), 2),
+        round(tec_current_to_amps(snap.tec_curr_raw), 3),
+        round(tec_voltage_to_volts(snap.tec_volt_raw), 3),
     ]
     pdu_raws = snap.pdu_raws or []
     pdu_volts = snap.pdu_volts or []

--- a/tests/test_scan_workflow.py
+++ b/tests/test_scan_workflow.py
@@ -480,3 +480,46 @@ def test_start_scan_trigger_config_override_is_merged():
     # untouched keys fall through to the resolved default
     assert sent["LaserPulseSkipInterval"] == \
         motion.resolve_trigger_config(None)["LaserPulseSkipInterval"]
+
+
+def test_telemetry_csv_logs_converted_tec_engineering_units():
+    """The per-scan telemetry CSV records converted TEC engineering units
+    (measured/setpoint temperature in °C, current in A, voltage in V) alongside
+    the existing raw ADC values, so the TEC temperature is human-readable in the
+    log -- e.g. while watching the console cool down during power-off.
+    See OpenwaterHealth/openmotion-bloodflow-app#244.
+    """
+    from omotion.ScanWorkflow import _TELEMETRY_HEADERS, _snap_to_row
+    from omotion.ConsoleTelemetry import ConsoleTelemetry
+    from omotion.console_telemetry_conversions import (
+        tec_thermistor_voltage_to_celsius,
+        tec_current_to_amps,
+        tec_voltage_to_volts,
+    )
+
+    # Real device readings (~25 °C bench idle), distinct per field so the test
+    # also pins which raw column feeds which converted column.
+    snap = ConsoleTelemetry(
+        tec_v_raw=1.194286,
+        tec_set_raw=1.190256,
+        tec_curr_raw=1.504542,
+        tec_volt_raw=1.544029,
+        tec_good=True,
+    )
+
+    # The 4 converted columns sit immediately after tec_good, keeping the raw
+    # columns (and every column after) in place for header-based consumers.
+    gi = _TELEMETRY_HEADERS.index("tec_good")
+    assert _TELEMETRY_HEADERS[gi + 1:gi + 5] == [
+        "tec_temp_c", "tec_set_c", "tec_curr_a", "tec_volt_v",
+    ]
+
+    row = _snap_to_row(snap)
+    assert len(row) == len(_TELEMETRY_HEADERS)
+
+    # Each converted value is wired to the correct raw field and rounded to the
+    # same precision the live display uses (temps 2 dp, current/voltage 3 dp).
+    assert row[gi + 1] == round(tec_thermistor_voltage_to_celsius(snap.tec_v_raw), 2)
+    assert row[gi + 2] == round(tec_thermistor_voltage_to_celsius(snap.tec_set_raw), 2)
+    assert row[gi + 3] == round(tec_current_to_amps(snap.tec_curr_raw), 3)
+    assert row[gi + 4] == round(tec_voltage_to_volts(snap.tec_volt_raw), 3)


### PR DESCRIPTION
## Summary
The per-scan telemetry CSV logged only **raw** TEC ADC values (`tec_v_raw`, `tec_set_raw`, `tec_curr_raw`, `tec_volt_raw`), so the TEC temperature was never human-readable in the log. This adds four **converted** engineering-unit columns immediately after `tec_good`:

| New column | Source raw | Conversion | Units |
|---|---|---|---|
| `tec_temp_c` | `tec_v_raw` | `tec_thermistor_voltage_to_celsius` | °C (measured) |
| `tec_set_c` | `tec_set_raw` | `tec_thermistor_voltage_to_celsius` | °C (setpoint) |
| `tec_curr_a` | `tec_curr_raw` | `tec_current_to_amps` | A |
| `tec_volt_v` | `tec_volt_raw` | `tec_voltage_to_volts` | V |

- Conversions reuse `omotion.console_telemetry_conversions` — the same math the live app display uses — rounded to match it (temps 2 dp, current/voltage 3 dp). A missing RT table yields `NaN`, written through as-is.
- Raw columns are unchanged; the new columns are **inserted** (not appended). Safe for the header-based `scripts/plot_telemetry.py` consumer, which selects columns by name.

Addresses OpenwaterHealth/openmotion-bloodflow-app#244 — the TEC temperature now appears directly in the log (e.g. while watching the console cool down during power-off).

## Test Plan
- [x] New unit test `test_telemetry_csv_logs_converted_tec_engineering_units` (pins column names, positions, row-length consistency, and that each converted column is wired to the correct raw field at the right rounding). Run: `pytest tests/test_scan_workflow.py`
- [x] Full `tests/test_scan_workflow.py` — 16 passed
- [x] Verified the only failures in the pure-software subset (`test_diagnostics_sink.py`, `test_scan_db_sink.py`) pre-exist on `origin/next` and are unrelated to this change

## Out of scope
- A temperature subplot in `plot_telemetry.py` (nice follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)