### PR TITLE
test: align ScanDBSink session_meta tests with empty-session deletion (#82)

### DIFF
--- a/tests/test_pipeline/test_diagnostics_sink.py
+++ b/tests/test_pipeline/test_diagnostics_sink.py
@@ -10,6 +10,7 @@ TerminalDarkResult) are excluded from the integrity record.
 import json
 import logging
 import sqlite3
+from types import SimpleNamespace
 
 from omotion.pipeline.batch import (
     DarkIntegrityWarning,
@@ -33,6 +34,18 @@ def _dark_warning(abs_id=42):
         side="left", cam_id=0, abs_frame_id=abs_id,
         u1=90.0, pedestal=64.0, threshold=5.0,
     )
+
+
+def _final_interval():
+    """One corrected frame so the session persists as a real scan. Empty scans
+    (no corrected rows) are deleted by ScanDBSink — that path is covered by
+    test_scan_db_sink_empty.py; these tests exercise the session_meta /
+    diagnostics summary on a scan that actually produced rows."""
+    frame = SimpleNamespace(
+        cam_id=0, side="left", abs_frame_id=1, t=0.1,
+        bfi=1.0, bvi=2.0, mean=3.0, contrast=0.4, quality="ok",
+    )
+    return SimpleNamespace(frames=[frame])
 
 
 def test_log_sink_warns_on_integrity_events(caplog):
@@ -66,6 +79,7 @@ def test_scan_db_sink_writes_diagnostics_summary_to_session_meta(tmp_path):
     db_path = str(tmp_path / "scan.db")
     sink = ScanDBSink(db_path=db_path)
     sink.on_scan_start(_meta())
+    sink.consume("final", _final_interval())
     sink.consume("diagnostics", _dark_warning(abs_id=10))
     sink.consume("diagnostics", _dark_warning(abs_id=610))
     sink.consume("diagnostics", TerminalDarkResult(
@@ -92,6 +106,7 @@ def test_scan_db_sink_meta_has_no_diagnostics_key_when_clean(tmp_path):
     db_path = str(tmp_path / "scan.db")
     sink = ScanDBSink(db_path=db_path)
     sink.on_scan_start(_meta())
+    sink.consume("final", _final_interval())
     sink.on_complete()
 
     conn = sqlite3.connect(db_path)

--- a/tests/test_pipeline/test_scan_db_sink.py
+++ b/tests/test_pipeline/test_scan_db_sink.py
@@ -71,6 +71,9 @@ def test_scan_db_sink_stamps_session_meta(tmp_path):
     db_path = str(tmp_path / "scan.db")
     sink = ScanDBSink(db_path=db_path)
     sink.on_scan_start(_meta_reduced())
+    # One side-average row so the session persists (empty scans are deleted —
+    # see test_scan_db_sink_empty.py). Reduced mode keeps only cam_id=-1 rows.
+    sink.consume("final", _interval([_frame(42, side="right", cam_id=-1)]))
     sink.on_complete()
 
     conn = sqlite3.connect(db_path)


### PR DESCRIPTION
## Summary
Three pure-software tests have been failing on `next` since #82 merged (Jun 15):

- `test_pipeline/test_scan_db_sink.py::test_scan_db_sink_stamps_session_meta`
- `test_pipeline/test_diagnostics_sink.py::test_scan_db_sink_writes_diagnostics_summary_to_session_meta`
- `test_pipeline/test_diagnostics_sink.py::test_scan_db_sink_meta_has_no_diagnostics_key_when_clean`

**Root cause:** #82 (`b0eb37a`) made `ScanDBSink.on_complete()` **delete** the session row when zero corrected `final` rows were persisted — so an interrupted scan never appears as a viewable scan in History. It added `tests/test_scan_db_sink_empty.py` for the new behavior but didn't update these three pre-existing tests, which feed **no** `final` rows and then query the `sessions` table. They now hit the delete path and fail with `TypeError: 'NoneType' object is not subscriptable` (the `SELECT … FROM sessions` returns no rows → `fetchone()[0]`).

This is **stale tests, not a code bug** — `test_scan_db_sink_empty.py` asserts the new contract (`test_empty_scan_session_is_deleted`) is intended.

**Fix:** feed one corrected row in each test so the session is a real (non-orphan) scan, then keep the original `session_meta` / diagnostics-summary assertions. Reduced-mode test uses a `cam_id=-1` side-average frame; normal-mode tests use a `cam_id=0` frame. Test-only change.

## Test Plan
- [x] The 3 named tests now pass
- [x] `pytest tests/test_pipeline/` → 233 passed, 30 skipped, **0 failed** (was 3 failed)
- [x] `test_scan_db_sink_empty.py` still passes (empty-session deletion contract intact)

## Note (not addressed here)
Under #82, a scan that emitted integrity diagnostics but produced no corrected rows is deleted *with its diagnostics*. If post-mortem diagnostics for failed/empty scans are ever wanted, that's a separate behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)