### PR TITLE
feat: Download Beta Firmware — prerelease-aware update check

### DIFF
--- a/omotion/firmware_update.py
+++ b/omotion/firmware_update.py
@@ -36,10 +36,38 @@ def parse_version(version_str: str) -> tuple[int, int, int]:
     return (int(m.group(1)), int(m.group(2)), int(m.group(3)))
 
 
-def is_update_available(installed: str, latest: str) -> bool:
-    """True iff ``latest`` parses to a strictly greater (maj, min, patch) than
-    ``installed``. Pre-release suffixes are ignored. Returns ``False`` if either
-    string is empty/unparseable (fail-safe: never offer an unreasoned update)."""
+_GIT_DESCRIBE_TAIL = re.compile(r"-\d+-g[0-9a-f]+$", re.IGNORECASE)
+
+
+def _release_tag(version: str) -> str:
+    """Reduce a version/tag to its base release tag: strip a leading 'v', a
+    trailing '-dirty', and a git-describe tail ('-<N>-g<sha>'). Used by the
+    beta (most-recently-published) update check, which compares release
+    identity rather than semver precedence."""
+    if not version:
+        return ""
+    v = version.strip()
+    if v[:1] in ("v", "V"):
+        v = v[1:]
+    if v.endswith("-dirty"):
+        v = v[: -len("-dirty")]
+    return _GIT_DESCRIBE_TAIL.sub("", v)
+
+
+def is_update_available(installed: str, latest: str, *, prerelease: bool = False) -> bool:
+    """Whether ``latest`` should be offered over ``installed``.
+
+    prerelease=False (stable): True iff ``latest``'s (major, minor, patch) is
+    strictly greater than ``installed``'s. prerelease=True (beta): True iff the
+    device's base release tag differs from ``latest``'s — i.e. the device is
+    not already on the most-recently-published release. Fail-safe ``False`` on
+    empty/unparseable input."""
+    if prerelease:
+        inst = _release_tag(installed)
+        lat = _release_tag(latest)
+        if not inst or not lat:
+            return False
+        return inst != lat
     try:
         return parse_version(latest) > parse_version(installed)
     except (ValueError, TypeError):

--- a/omotion/firmware_update.py
+++ b/omotion/firmware_update.py
@@ -51,6 +51,9 @@ def _release_tag(version: str) -> str:
         v = v[1:]
     if v.endswith("-dirty"):
         v = v[: -len("-dirty")]
+    # Assumes real release tags never end in the git-describe pattern
+    # '-<N>-g<sha>'; that suffix only appears in describe output for commits
+    # AFTER a tag, so stripping it here recovers the base release tag.
     return _GIT_DESCRIBE_TAIL.sub("", v)
 
 
@@ -119,8 +122,10 @@ def check_latest(
                 return None
             # Most recently PUBLISHED wins (timestamp), even if its version is
             # "lower" semver — a dev released after an rc is the one to flash.
-            # published_at is ISO-8601, so lexicographic max == chronological;
-            # a missing value sorts oldest, falling back to API newest-first.
+            # published_at is ISO-8601, so lexicographic max == chronological.
+            # On a tie / missing published_at, Python's max keeps the FIRST
+            # maximal element and GitHub returns releases newest-first, so the
+            # API-newest release wins.
             rel = max(rels, key=lambda r: (r.get("published_at") or ""))
         else:
             rel = gh.get_latest_release(include_prerelease=False)

--- a/omotion/firmware_update.py
+++ b/omotion/firmware_update.py
@@ -113,7 +113,17 @@ def check_latest(
     owner, repo = _REPO[kind]
     gh = releases or GitHubReleases(owner, repo)
     try:
-        rel = gh.get_latest_release(include_prerelease=include_prerelease)
+        if include_prerelease:
+            rels = gh.get_all_releases(include_prerelease=True)
+            if not rels:
+                return None
+            # Most recently PUBLISHED wins (timestamp), even if its version is
+            # "lower" semver — a dev released after an rc is the one to flash.
+            # published_at is ISO-8601, so lexicographic max == chronological;
+            # a missing value sorts oldest, falling back to API newest-first.
+            rel = max(rels, key=lambda r: (r.get("published_at") or ""))
+        else:
+            rel = gh.get_latest_release(include_prerelease=False)
         tag = rel.get("tag_name")
         if not tag:
             return None

--- a/tests/test_firmware_update.py
+++ b/tests/test_firmware_update.py
@@ -180,7 +180,7 @@ def test_is_update_available_prerelease(installed, latest, expected):
     assert is_update_available(installed, latest, prerelease=True) is expected
 
 
-def test_is_update_available_stable_unchanged():
+def test_is_update_available_stable():
     assert is_update_available("1.8.0", "1.8.1") is True
     assert is_update_available("1.8.1-rc.0", "1.8.1") is False   # same M.M.P
     assert is_update_available("1.8.0", "1.8.0") is False
@@ -202,6 +202,17 @@ def test_check_latest_beta_picks_max_published_at():
     assert info is not None
     assert info.tag == "1.8.1-dev.5"            # newest published, though "lower" semver
     gh.get_all_releases.assert_called_once_with(include_prerelease=True)
+
+
+def test_check_latest_beta_timestamped_beats_missing():
+    gh = MagicMock()
+    gh.get_all_releases.return_value = [
+        {"tag_name": "1.8.1-rc.0", "published_at": "2026-02-01T00:00:00Z"},
+        {"tag_name": "1.8.1-dev.5", "published_at": None},  # no timestamp
+    ]
+    gh.get_asset_list.return_value = [{"name": "motion-sensor-fw.bin"}]
+    info = check_latest(FirmwareKind.SENSOR, include_prerelease=True, releases=gh)
+    assert info.tag == "1.8.1-rc.0"  # a real timestamp beats a missing one
 
 
 def test_check_latest_beta_none_when_empty():

--- a/tests/test_firmware_update.py
+++ b/tests/test_firmware_update.py
@@ -146,3 +146,41 @@ def test_updater_raises_if_dfu_never_appears(tmp_path):
     updater = FirmwareUpdater(programmer=dfu)
     with pytest.raises(FirmwareUpdateError):
         updater.update(handle, tmp_path / "fw.bin")
+
+
+# ---------------------------------------------------------------------------
+# Task 1: _release_tag + prerelease-aware is_update_available
+# ---------------------------------------------------------------------------
+from omotion.firmware_update import _release_tag
+
+
+@pytest.mark.parametrize("v,expected", [
+    ("1.8.0", "1.8.0"),
+    ("v1.8.0", "1.8.0"),
+    ("1.8.1-rc.0", "1.8.1-rc.0"),
+    ("1.8.1-dev.5", "1.8.1-dev.5"),
+    ("1.8.1-rc.0-2-gf09e8dc", "1.8.1-rc.0"),
+    ("1.8.1-rc.0-2-gf09e8dc-dirty", "1.8.1-rc.0"),
+    ("1.8.0-dirty", "1.8.0"),
+    ("", ""),
+])
+def test_release_tag(v, expected):
+    assert _release_tag(v) == expected
+
+
+@pytest.mark.parametrize("installed,latest,expected", [
+    ("1.8.1-rc.0-2-gf09e8dc-dirty", "1.8.1-rc.0", False),  # device on/ahead of latest
+    ("1.8.1-rc.0", "1.8.1-dev.5", True),                   # newer-published dev wins
+    ("1.8.0", "1.8.1-dev.0", True),
+    ("1.8.1-dev.5", "1.8.1-dev.5", False),                 # already on it
+    ("v1.8.0", "1.8.0", False),                            # equal after normalize
+    ("", "1.8.1-rc.0", False),                             # empty installed -> no update
+])
+def test_is_update_available_prerelease(installed, latest, expected):
+    assert is_update_available(installed, latest, prerelease=True) is expected
+
+
+def test_is_update_available_stable_unchanged():
+    assert is_update_available("1.8.0", "1.8.1") is True
+    assert is_update_available("1.8.1-rc.0", "1.8.1") is False   # same M.M.P
+    assert is_update_available("1.8.0", "1.8.0") is False

--- a/tests/test_firmware_update.py
+++ b/tests/test_firmware_update.py
@@ -184,3 +184,36 @@ def test_is_update_available_stable_unchanged():
     assert is_update_available("1.8.0", "1.8.1") is True
     assert is_update_available("1.8.1-rc.0", "1.8.1") is False   # same M.M.P
     assert is_update_available("1.8.0", "1.8.0") is False
+
+
+# ---------------------------------------------------------------------------
+# Task 2: check_latest real prerelease path (max published_at)
+# ---------------------------------------------------------------------------
+
+def test_check_latest_beta_picks_max_published_at():
+    gh = MagicMock()
+    gh.get_all_releases.return_value = [
+        {"tag_name": "1.8.1-dev.5", "published_at": "2026-02-10T00:00:00Z"},
+        {"tag_name": "1.8.1-rc.0", "published_at": "2026-02-01T00:00:00Z"},
+        {"tag_name": "1.8.0", "published_at": "2026-01-15T00:00:00Z"},
+    ]
+    gh.get_asset_list.return_value = [{"name": "motion-sensor-fw.bin"}]
+    info = check_latest(FirmwareKind.SENSOR, include_prerelease=True, releases=gh)
+    assert info is not None
+    assert info.tag == "1.8.1-dev.5"            # newest published, though "lower" semver
+    gh.get_all_releases.assert_called_once_with(include_prerelease=True)
+
+
+def test_check_latest_beta_none_when_empty():
+    gh = MagicMock()
+    gh.get_all_releases.return_value = []
+    assert check_latest(FirmwareKind.SENSOR, include_prerelease=True, releases=gh) is None
+
+
+def test_check_latest_stable_uses_get_latest_release():
+    gh = MagicMock()
+    gh.get_latest_release.return_value = {"tag_name": "1.8.0", "published_at": "2026-01-15T00:00:00Z"}
+    gh.get_asset_list.return_value = [{"name": "motion-sensor-fw.bin"}]
+    info = check_latest(FirmwareKind.SENSOR, include_prerelease=False, releases=gh)
+    assert info.tag == "1.8.0"
+    gh.get_latest_release.assert_called_once_with(include_prerelease=False)


### PR DESCRIPTION
Adds a **beta (pre-release) path** to `omotion/firmware_update.py` so the bloodflow-app firmware autoupdater can target dev/rc builds, not just full releases.

## This feature's changes (the 3 commits that matter)
- `960c72f` — `_release_tag(version)` (strip leading `v`, trailing `-dirty`, and a git-describe tail `-<N>-g<sha>`) + `is_update_available(installed, latest, *, prerelease=False)`. `prerelease=False` keeps the existing semver `(major,minor,patch)` compare; `prerelease=True` uses **release-tag identity** — available iff the device's base tag differs from `latest`'s.
- `93d5e6f` — `check_latest(kind, include_prerelease=True)` now returns the **most-recently-published** release (`max(get_all_releases(...), key=published_at)`), including dev/rc. Fixes the prior bug where `include_prerelease=True` hit GitHub `/releases/latest`, which excludes pre-releases.
- `5d0a146` — test for the missing-`published_at` tie-break + comment clarifications.

Stable mode (`include_prerelease=False`) is **unchanged**. 48 unit tests pass; verified live against GitHub (`check_latest(SENSOR, include_prerelease=True)` → `1.8.1-rc.0` vs stable `1.8.0`).

## ⚠️ Branch base note — read before merging
This branch was cut from **local `next-next` (`5348575`)**, which is **ahead of `origin/next-next` (`707e04d`)** by 4 commits that are **NOT part of this feature** — they're your existing async-transport **reverts**:
```
5348575 Revert "feat: surface console firmware printf over USB CDC"
886ad0c Revert "refactor: unify console + sensor command transports on one async engine"
2e297b7 Revert "refactor: drop CommInterface sync mode — command transports are async-only"
e589a73 Revert "refactor: drop console command pacing — firmware now re-arms CDC RX up front"
```
Because `origin/next-next` doesn't have them yet, this PR's diff includes them on top of the 3 beta commits. Handle them as you prefer before merge (e.g. push local `next-next` first, then this PR rebases to beta-only).

## Cross-repo
Consumed by the openmotion-bloodflow-app "Download Beta Firmware toggle" PR.

Draft for hand-testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
