### PR TITLE
feat: add DEBUG_FLAG_SEND_DEFER (bit 7) debug-flag constant

### DIFF
--- a/omotion/MotionSensor.py
+++ b/omotion/MotionSensor.py
@@ -852,6 +852,8 @@ class MotionSensor(SignalWrapper):
         Bit 0 (DEBUG_FLAG_USB_PRINTF) enables firmware printf output over USB.
         Bit 4 (DEBUG_FLAG_COMM_VERBOSE) enables cmd id and "." response prints.
         Bit 5 (DEBUG_FLAG_CMD_VERBOSE) enables printf in command handlers.
+        Bit 7 (DEBUG_FLAG_SEND_DEFER) defers the per-frame histogram send out
+        of the FSIN ISR into the main loop (sensor-fw#68).
         """
         if self.demo_mode:
             return True

--- a/omotion/config.py
+++ b/omotion/config.py
@@ -156,6 +156,7 @@ DEBUG_FLAG_FAKE_DATA = (
 DEBUG_FLAG_HISTO_CMP = 0x40  # Send compressed histogram packets (TYPE_HISTO_CMP)
 DEBUG_FLAG_COMM_VERBOSE = 0x10  # Enable cmd id and "." response prints in uart_comms
 DEBUG_FLAG_CMD_VERBOSE = 0x20  # Enable printf in command handlers (if_commands.c)
+DEBUG_FLAG_SEND_DEFER = 0x80  # Defer per-frame histogram send out of the FSIN ISR into the main loop (sensor-fw#68)
 
 # Controller Commands
 OW_CTRL_I2C_SCAN = 0x10


### PR DESCRIPTION
Names firmware **bit 7 (`0x80`)** as `DEBUG_FLAG_SEND_DEFER` in `omotion/config.py`, and documents it in the `MotionSensor.set_debug_flags` docstring.

## What it does
The firmware bit moves the per-frame histogram **send out of the FSIN ISR into the main loop** — under investigation for the RIGHT-module intermittent 15–30 s histogram stall under laser-on (sensor-fw#68). `set_debug_flags()` already takes a raw int, so callers can now OR in the named constant instead of a magic literal.

## Scope
- Pure additive constant + docstring. No behavior change in the SDK itself.
- Stock firmware ignores bit 7; only the sensor-fw PR-branch firmware (`feature/68-fsin-send-defer-experiment`, sensor-fw#69) acts on it.

## Companion
Consumed by the bloodflow-app `deferHistoSend` config flag (openmotion-bloodflow-app PR, base next-next).

🤖 Generated with [Claude Code](https://claude.com/claude-code)