### PR TITLE
Release: SDK next → main (1.8.1)

### DIFF
--- a/omotion/ScanDatabase.py
+++ b/omotion/ScanDatabase.py
@@ -170,6 +170,27 @@ class ScanDatabase:
             raise RuntimeError("Database connection is closed")
         return self._conn
 
+    def assert_writable(self) -> None:
+        """Force SQLite to attempt a write so a read-only file fails *here*.
+
+        Opening a read-only SQLite file succeeds — the error
+        (``sqlite3.OperationalError: attempt to write a readonly database``)
+        only surfaces on the first write. So ``__init__`` alone cannot detect
+        a read-only database file, and in WAL mode neither can a bare
+        ``BEGIN IMMEDIATE`` (its write is deferred to the ``-wal``). Callers
+        that must fail before a side effect — e.g. firing the laser at scan
+        start — call this to provoke the write up front.
+
+        Rewrites ``PRAGMA user_version`` to its current value: a header write
+        that fails on a read-only DB but is a semantic no-op when it succeeds,
+        so nothing is persisted. Raises ``sqlite3.OperationalError`` (or other
+        ``sqlite3.Error``) when the database is not writable; returns ``None``
+        otherwise.
+        """
+        conn = self._connection()
+        version = int(conn.execute("PRAGMA user_version").fetchone()[0])
+        conn.execute(f"PRAGMA user_version = {version}")
+
     # ------------------------------------------------------------------
     # Sessions
     # ------------------------------------------------------------------

--- a/omotion/ScanWorkflow.py
+++ b/omotion/ScanWorkflow.py
@@ -12,6 +12,11 @@ from typing import Callable, Optional, TYPE_CHECKING
 
 from omotion import _log_root
 from omotion.connection_state import ConnectionState
+from omotion.console_telemetry_conversions import (
+    tec_thermistor_voltage_to_celsius,
+    tec_current_to_amps,
+    tec_voltage_to_volts,
+)
 from omotion.MotionProcessing import (
     CorrectedBatch,
     HISTO_SIZE_WORDS,
@@ -38,6 +43,9 @@ _TELEMETRY_HEADERS: list[str] = [
     "timestamp",
     "tcm", "tcl", "pdc",
     "tec_v_raw", "tec_set_raw", "tec_curr_raw", "tec_volt_raw", "tec_good",
+    # Converted engineering units (°C / A / V) alongside the raw ADC values, so
+    # the TEC temperature is human-readable in the log. See bloodflow-app#244.
+    "tec_temp_c", "tec_set_c", "tec_curr_a", "tec_volt_v",
     *[f"pdu_raw_{i}" for i in range(16)],
     *[f"pdu_volt_{i}" for i in range(16)],
     "safety_se", "safety_so", "safety_ok",
@@ -52,6 +60,13 @@ def _snap_to_row(snap) -> list:
         snap.tcm, snap.tcl, snap.pdc,
         snap.tec_v_raw, snap.tec_set_raw, snap.tec_curr_raw, snap.tec_volt_raw,
         int(snap.tec_good),
+        # Converted engineering units, rounded to match the live display
+        # (temps 2 dp, current/voltage 3 dp). A missing RT table yields NaN,
+        # which is written through as-is.
+        round(tec_thermistor_voltage_to_celsius(snap.tec_v_raw), 2),
+        round(tec_thermistor_voltage_to_celsius(snap.tec_set_raw), 2),
+        round(tec_current_to_amps(snap.tec_curr_raw), 3),
+        round(tec_voltage_to_volts(snap.tec_volt_raw), 3),
     ]
     pdu_raws = snap.pdu_raws or []
     pdu_volts = snap.pdu_volts or []

--- a/omotion/ScanWorkflow.py
+++ b/omotion/ScanWorkflow.py
@@ -139,6 +139,13 @@ class ScanRequest:
     # resolved default (DEFAULT_TRIGGER_CONFIG ⊕ constructor override). A dict
     # here is shallow-merged on top (e.g. {"TriggerFrequencyHz": 20}).
     trigger_config: dict | None = None
+    # Called (with the exception) when the scan worker thread aborts AFTER
+    # start_scan returned True — e.g. a critical sink failing in on_scan_start
+    # because the scan DB became unwritable in the race window past the
+    # synchronous preflight. Lets the caller surface a failure that a return
+    # value can no longer carry. Fires on the worker thread, so the handler
+    # must be thread-safe. See bloodflow-app issue #213.
+    on_error: Callable[[BaseException], None] | None = None
 
 
 @dataclass
@@ -486,7 +493,17 @@ class ScanWorkflow:
                 # if the DB dies between this check and the worker start.)
                 try:
                     from omotion.ScanDatabase import ScanDatabase
-                    ScanDatabase(db_path=scan_db_path).close()
+                    _preflight_db = ScanDatabase(db_path=scan_db_path)
+                    try:
+                        # Opening a read-only DB succeeds (open never writes),
+                        # so probe a real write here — otherwise a read-only
+                        # file/dir slips through and the failure only surfaces
+                        # asynchronously on the first INSERT in the worker
+                        # thread, after the laser has fired. See bloodflow-app
+                        # issue #213.
+                        _preflight_db.assert_writable()
+                    finally:
+                        _preflight_db.close()
                 except Exception as exc:
                     logger.exception(
                         "start_scan: scan database pre-flight failed (%s) — "
@@ -710,6 +727,14 @@ class ScanWorkflow:
             except Exception as e:
                 logger.exception("ScanWorkflow worker raised")
                 self._last_scan_error = str(e) or type(e).__name__
+                # Notify the caller of an async start failure (start_scan
+                # already returned True, so the failure can't ride the return
+                # value). Guarded so a faulty handler can't break teardown.
+                if request.on_error is not None:
+                    try:
+                        request.on_error(e)
+                    except Exception:
+                        logger.exception("ScanRequest.on_error handler raised")
             finally:
                 if telemetry_writer is not None:
                     telemetry_writer.close()

--- a/omotion/pipeline/stages/classify.py
+++ b/omotion/pipeline/stages/classify.py
@@ -24,7 +24,25 @@ _FRAME_ROLLOVER_THRESHOLD = 128
 
 
 class _FrameUnwrapper:
-    """8-bit rolling → monotonic. One instance per (side, cam_id)."""
+    """8-bit rolling → monotonic. One instance per (side, cam_id).
+
+    Robust against a non-monotonic frame stream. The sensor occasionally
+    emits stale/garbage frames — leftover buffer contents at scan start
+    (e.g. raw 1, 255, 173, 4, 5 …) or a mid-scan counter blip — when its
+    histogram DMA buffer isn't flushed. The old unwrapper trusted every
+    frame after the first, so a backward-looking value (255 after 1) was
+    read as a huge forward jump and the next real frame (4) tripped the
+    rollover test, injecting a permanent +256 epoch offset that shifted the
+    whole positional dark/warmup schedule for the rest of the scan.
+
+    Now each frame is gated by its *signed* 8-bit step from the last
+    accepted frame: only forward steps (1..127) advance state; a backward
+    or duplicate step (<= 0) is rejected as stale and does NOT advance the
+    counter, so isolated garbage frames can't corrupt the epoch. The 8-bit
+    counter can't disambiguate a genuine forward gap > 127 frames (a >3.2 s
+    intra-scan dropout) from a backward step; such ambiguous frames are
+    rejected — that data is already lost in a gap that large.
+    """
 
     __slots__ = ("epoch", "last_raw", "seen_first", "first_was_stale")
 
@@ -34,18 +52,30 @@ class _FrameUnwrapper:
         self.seen_first = False
         self.first_was_stale = False
 
-    def unwrap(self, raw_frame_id: int) -> int:
+    def unwrap(self, raw_frame_id: int) -> tuple[int, bool]:
+        """Return (abs_frame_id, accepted).
+
+        accepted=False marks a stale/non-monotonic frame: the abs_id is
+        advisory only and the unwrapper state is left untouched so the
+        next genuine frame resumes the sequence cleanly.
+        """
         if not self.seen_first:
             self.seen_first = True
             self.first_was_stale = (raw_frame_id != 1)
             self.last_raw = raw_frame_id
-            return raw_frame_id
+            return raw_frame_id, True
 
-        delta = (raw_frame_id - self.last_raw) & 0xFF
-        if delta <= _FRAME_ROLLOVER_THRESHOLD and raw_frame_id < self.last_raw:
+        # Signed step in [-128, 127]: positive = forward, <= 0 = backward
+        # (stale leftover) or duplicate.
+        step = ((raw_frame_id - self.last_raw + 128) & 0xFF) - 128
+        if step <= 0:
+            return self.epoch * _FRAME_ID_MODULUS + raw_frame_id, False
+
+        # Forward step (1..127). A wrap shows up as raw <= last_raw.
+        if raw_frame_id <= self.last_raw:
             self.epoch += 1
         self.last_raw = raw_frame_id
-        return self.epoch * _FRAME_ID_MODULUS + raw_frame_id
+        return self.epoch * _FRAME_ID_MODULUS + raw_frame_id, True
 
 
 class FrameClassificationStage:
@@ -75,10 +105,15 @@ class FrameClassificationStage:
                 unwrapper = _FrameUnwrapper()
                 self._unwrappers[key] = unwrapper
 
-            abs_id = unwrapper.unwrap(raw_id)
+            abs_id, accepted = unwrapper.unwrap(raw_id)
             abs_ids[i] = abs_id
 
-            if unwrapper.first_was_stale and abs_id == raw_id:
+            if not accepted:
+                # Non-monotonic / stale leftover frame (e.g. unflushed
+                # histogram buffer at scan start or a mid-scan counter blip).
+                # Excluded downstream so it can't poison dark/timestamp align.
+                types[i] = "stale"
+            elif unwrapper.first_was_stale and abs_id == raw_id:
                 types[i] = "stale"
             elif abs_id <= self.discard_count:
                 types[i] = "warmup"

--- a/omotion/pipeline/stages/classify.py
+++ b/omotion/pipeline/stages/classify.py
@@ -14,10 +14,14 @@ See docs/SciencePipeline.md §3 (unwrapping) and §4 (classification).
 
 from __future__ import annotations
 
+import logging
+
 import numpy as np
 
 from ..batch import FrameBatch
 
+
+logger = logging.getLogger("openmotion.sdk.pipeline.stages.frame_classification")
 
 _FRAME_ID_MODULUS = 256
 _FRAME_ROLLOVER_THRESHOLD = 128
@@ -85,6 +89,13 @@ class FrameClassificationStage:
         self.discard_count = int(discard_count)
         self.dark_interval = int(dark_interval)
         self._unwrappers: dict[tuple[int, int], _FrameUnwrapper] = {}
+        # Per-(side, cam) count of stale/non-monotonic frames dropped this
+        # scan. A non-zero count is a hardware-health signal — the sensor
+        # shipped a leftover/garbage frame (e.g. unflushed histogram buffer)
+        # that we excluded. First occurrence per camera is logged live; the
+        # totals are summarised at on_scan_stop.
+        self._stale_counts: dict[tuple[int, int], int] = {}
+        self._stale_logged: set[tuple[int, int]] = set()
 
     def process(self, batch: FrameBatch) -> FrameBatch:
         n = batch.frame_ids.shape[0]
@@ -113,8 +124,12 @@ class FrameClassificationStage:
                 # histogram buffer at scan start or a mid-scan counter blip).
                 # Excluded downstream so it can't poison dark/timestamp align.
                 types[i] = "stale"
+                self._note_stale(side_idx, cam_id, raw_id,
+                                 "non-monotonic frame id (backward/duplicate)")
             elif unwrapper.first_was_stale and abs_id == raw_id:
                 types[i] = "stale"
+                self._note_stale(side_idx, cam_id, raw_id,
+                                 "leading stale frame (stream did not start at 1)")
             elif abs_id <= self.discard_count:
                 types[i] = "warmup"
             elif self._is_dark(abs_id):
@@ -125,6 +140,37 @@ class FrameClassificationStage:
         batch.abs_frame_ids = abs_ids
         batch.frame_type = types
         return batch
+
+    def _note_stale(self, side_idx: int, cam_id: int, raw_id: int,
+                    reason: str) -> None:
+        """Count a dropped stale frame and log the first one per camera."""
+        key = (side_idx, cam_id)
+        self._stale_counts[key] = self._stale_counts.get(key, 0) + 1
+        if key not in self._stale_logged:
+            self._stale_logged.add(key)
+            logger.warning(
+                "dropping stale frame: side=%d cam=%d raw_frame_id=%d — %s; "
+                "excluded so it can't desync the dark/timestamp schedule. "
+                "Likely an unflushed sensor histogram buffer "
+                "(leftover/duplicate frame); per-camera totals at scan stop.",
+                side_idx, cam_id, raw_id, reason,
+            )
+
+    def on_scan_stop(self, batch: FrameBatch) -> None:
+        """End-of-scan summary of stale/non-monotonic frames dropped.
+
+        A non-zero count means the sensor shipped leftover/garbage frames
+        (e.g. an unflushed histogram buffer) that were excluded to protect
+        the dark/timestamp alignment — a hardware-health signal worth
+        surfacing even when the per-scan damage was contained."""
+        total = sum(self._stale_counts.values())
+        if total:
+            per_cam = {f"s{s}c{c}": n
+                       for (s, c), n in sorted(self._stale_counts.items())}
+            logger.warning(
+                "Scan summary: dropped %d stale/non-monotonic frame(s) across "
+                "%d camera(s): %s", total, len(self._stale_counts), per_cam,
+            )
 
     def _is_dark(self, abs_id: int) -> bool:
         """Per SciencePipeline.md §4.2:
@@ -138,3 +184,5 @@ class FrameClassificationStage:
 
     def reset(self) -> None:
         self._unwrappers.clear()
+        self._stale_counts.clear()
+        self._stale_logged.clear()

--- a/tests/test_pipeline/test_classify_stage.py
+++ b/tests/test_pipeline/test_classify_stage.py
@@ -71,6 +71,42 @@ def test_unwrap_handles_8bit_rollover():
     np.testing.assert_array_equal(batch.abs_frame_ids, expected_abs)
 
 
+def test_stale_leftover_frames_at_start_are_rejected_not_offsetting_epoch():
+    """Reproduces the Varun-unit left-sensor capture (issue #172): an unflushed
+    histogram buffer emits stale frames (raw 255, 173) after the real first
+    frame, then the real sequence resumes (4, 5, 6 …). The old unwrapper read
+    255 as a forward jump and 4 as a rollover, injecting a permanent +256
+    epoch offset that shifted the entire dark/warmup schedule. The stale frames
+    must be rejected without advancing the counter."""
+    raw_ids = [1, 255, 173, 4, 5, 6, 7, 8, 9, 10, 11]
+    batch = _batch_with_raw_ids({(0, 0): raw_ids})
+    FrameClassificationStage(discard_count=9, dark_interval=600).process(batch)
+    # 255 and 173 rejected as stale; real frames keep their true abs_id (no +256).
+    np.testing.assert_array_equal(
+        batch.frame_type,
+        ["warmup", "stale", "stale", "warmup", "warmup", "warmup",
+         "warmup", "warmup", "warmup", "dark", "light"],
+    )
+    np.testing.assert_array_equal(
+        batch.abs_frame_ids, [1, 255, 173, 4, 5, 6, 7, 8, 9, 10, 11]
+    )
+
+
+def test_midscan_counter_blip_is_rejected_and_sequence_resumes():
+    """A mid-scan counter glitch (…3, 4, [2, 3], 5 …) must not reset the epoch:
+    the spurious backward 2,3 are rejected and 5 continues the run."""
+    raw_ids = [1, 2, 3, 4, 2, 3, 5, 6]
+    batch = _batch_with_raw_ids({(0, 0): raw_ids})
+    FrameClassificationStage(discard_count=9, dark_interval=600).process(batch)
+    # backward 2,3 rejected; the real run 1..6 keeps monotonic abs ids.
+    assert list(batch.frame_type) == [
+        "warmup", "warmup", "warmup", "warmup",
+        "stale", "stale", "warmup", "warmup"]
+    np.testing.assert_array_equal(
+        batch.abs_frame_ids, [1, 2, 3, 4, 2, 3, 5, 6]
+    )
+
+
 def test_zero_filled_row_keeps_source_assigned_side():
     """A row whose raw_histogram is all zeros (e.g. firmware-dropped frame)
     must still be routed to its source-assigned side.

--- a/tests/test_pipeline/test_classify_stage.py
+++ b/tests/test_pipeline/test_classify_stage.py
@@ -1,5 +1,7 @@
 """FrameClassificationStage — abs_frame_id unwrap + frame_type labeling."""
 
+import logging
+
 import numpy as np
 from omotion.pipeline.batch import FrameBatch
 from omotion.pipeline.stages.classify import FrameClassificationStage
@@ -136,6 +138,32 @@ def test_zero_filled_row_keeps_source_assigned_side():
     # The unwrapper key is (side_idx, cam_id) — verify state went to side=1.
     assert (1, 0) in stage._unwrappers
     assert (0, 0) not in stage._unwrappers
+
+
+def test_dropped_stale_frames_are_logged_and_summarised(caplog):
+    """Stale/non-monotonic frames the unwrapper drops must be visible in the
+    log — a hardware-health signal. First occurrence logs live per camera;
+    on_scan_stop emits a per-scan total."""
+    batch = _batch_with_raw_ids({(0, 0): [1, 255, 173, 4, 5, 6]})
+    stage = FrameClassificationStage(discard_count=9, dark_interval=600)
+    with caplog.at_level(logging.WARNING):
+        stage.process(batch)
+        assert any("dropping stale frame" in r.message for r in caplog.records), \
+            "expected a live WARNING when a stale frame is dropped"
+        caplog.clear()
+        stage.on_scan_stop(batch)
+    summary = [r.message for r in caplog.records if "Scan summary" in r.message]
+    assert summary, "expected a stale-frame scan summary at on_scan_stop"
+    assert "2" in summary[0]  # 255 and 173 were dropped
+
+
+def test_clean_scan_logs_no_stale_warnings(caplog):
+    batch = _batch_with_raw_ids({(0, 0): list(range(1, 15))})
+    stage = FrameClassificationStage(discard_count=9, dark_interval=600)
+    with caplog.at_level(logging.WARNING):
+        stage.process(batch)
+        stage.on_scan_stop(batch)
+    assert not any("stale" in r.message.lower() for r in caplog.records)
 
 
 def test_reset_clears_unwrapper_state():

--- a/tests/test_pipeline/test_diagnostics_sink.py
+++ b/tests/test_pipeline/test_diagnostics_sink.py
@@ -10,6 +10,7 @@ TerminalDarkResult) are excluded from the integrity record.
 import json
 import logging
 import sqlite3
+from types import SimpleNamespace
 
 from omotion.pipeline.batch import (
     DarkIntegrityWarning,
@@ -33,6 +34,18 @@ def _dark_warning(abs_id=42):
         side="left", cam_id=0, abs_frame_id=abs_id,
         u1=90.0, pedestal=64.0, threshold=5.0,
     )
+
+
+def _final_interval():
+    """One corrected frame so the session persists as a real scan. Empty scans
+    (no corrected rows) are deleted by ScanDBSink — that path is covered by
+    test_scan_db_sink_empty.py; these tests exercise the session_meta /
+    diagnostics summary on a scan that actually produced rows."""
+    frame = SimpleNamespace(
+        cam_id=0, side="left", abs_frame_id=1, t=0.1,
+        bfi=1.0, bvi=2.0, mean=3.0, contrast=0.4, quality="ok",
+    )
+    return SimpleNamespace(frames=[frame])
 
 
 def test_log_sink_warns_on_integrity_events(caplog):
@@ -66,6 +79,7 @@ def test_scan_db_sink_writes_diagnostics_summary_to_session_meta(tmp_path):
     db_path = str(tmp_path / "scan.db")
     sink = ScanDBSink(db_path=db_path)
     sink.on_scan_start(_meta())
+    sink.consume("final", _final_interval())
     sink.consume("diagnostics", _dark_warning(abs_id=10))
     sink.consume("diagnostics", _dark_warning(abs_id=610))
     sink.consume("diagnostics", TerminalDarkResult(
@@ -92,6 +106,7 @@ def test_scan_db_sink_meta_has_no_diagnostics_key_when_clean(tmp_path):
     db_path = str(tmp_path / "scan.db")
     sink = ScanDBSink(db_path=db_path)
     sink.on_scan_start(_meta())
+    sink.consume("final", _final_interval())
     sink.on_complete()
 
     conn = sqlite3.connect(db_path)

--- a/tests/test_pipeline/test_scan_db_sink.py
+++ b/tests/test_pipeline/test_scan_db_sink.py
@@ -71,6 +71,9 @@ def test_scan_db_sink_stamps_session_meta(tmp_path):
     db_path = str(tmp_path / "scan.db")
     sink = ScanDBSink(db_path=db_path)
     sink.on_scan_start(_meta_reduced())
+    # One side-average row so the session persists (empty scans are deleted —
+    # see test_scan_db_sink_empty.py). Reduced mode keeps only cam_id=-1 rows.
+    sink.consume("final", _interval([_frame(42, side="right", cam_id=-1)]))
     sink.on_complete()
 
     conn = sqlite3.connect(db_path)

--- a/tests/test_scan_database.py
+++ b/tests/test_scan_database.py
@@ -2,6 +2,8 @@
 
 import json
 import os
+import sqlite3
+import stat
 import sys
 from pathlib import Path
 
@@ -74,3 +76,45 @@ def test_session_meta_survives_unicode_and_none(tmp_db: ScanDatabase) -> None:
     )
     session = tmp_db.get_session(sid)
     assert session["session_meta"] == meta
+
+
+# ---------------------------------------------------------------------------
+# assert_writable — write-probe so a read-only DB fails the scan preflight
+# synchronously (before the laser fires) instead of asynchronously on the
+# first INSERT inside the scan worker thread. See bloodflow-app issue #213.
+# ---------------------------------------------------------------------------
+
+def test_assert_writable_raises_on_readonly_db(tmp_path: Path) -> None:
+    """A read-only DB file opens fine (open never writes) but a write fails.
+    assert_writable must force that write and surface the OperationalError."""
+    p = tmp_path / "ro.db"
+    ScanDatabase(db_path=str(p)).close()  # create + schema while writable
+    os.chmod(p, stat.S_IREAD)             # Windows read-only attribute
+    db = ScanDatabase(db_path=str(p))     # reopen: succeeds, no write yet
+    try:
+        with pytest.raises(sqlite3.OperationalError):
+            db.assert_writable()
+    finally:
+        db.close()
+        os.chmod(p, stat.S_IWRITE)
+
+
+def test_assert_writable_noop_on_writable_db(tmp_db: ScanDatabase) -> None:
+    """On a writable DB the probe returns None and persists nothing."""
+    settings_before = tmp_db._connection().execute(
+        "SELECT COUNT(*) FROM database_settings"
+    ).fetchone()[0]
+    version_before = tmp_db._connection().execute(
+        "PRAGMA user_version"
+    ).fetchone()[0]
+
+    assert tmp_db.assert_writable() is None
+
+    settings_after = tmp_db._connection().execute(
+        "SELECT COUNT(*) FROM database_settings"
+    ).fetchone()[0]
+    version_after = tmp_db._connection().execute(
+        "PRAGMA user_version"
+    ).fetchone()[0]
+    assert settings_after == settings_before
+    assert version_after == version_before

--- a/tests/test_scan_workflow.py
+++ b/tests/test_scan_workflow.py
@@ -480,3 +480,46 @@ def test_start_scan_trigger_config_override_is_merged():
     # untouched keys fall through to the resolved default
     assert sent["LaserPulseSkipInterval"] == \
         motion.resolve_trigger_config(None)["LaserPulseSkipInterval"]
+
+
+def test_telemetry_csv_logs_converted_tec_engineering_units():
+    """The per-scan telemetry CSV records converted TEC engineering units
+    (measured/setpoint temperature in °C, current in A, voltage in V) alongside
+    the existing raw ADC values, so the TEC temperature is human-readable in the
+    log -- e.g. while watching the console cool down during power-off.
+    See OpenwaterHealth/openmotion-bloodflow-app#244.
+    """
+    from omotion.ScanWorkflow import _TELEMETRY_HEADERS, _snap_to_row
+    from omotion.ConsoleTelemetry import ConsoleTelemetry
+    from omotion.console_telemetry_conversions import (
+        tec_thermistor_voltage_to_celsius,
+        tec_current_to_amps,
+        tec_voltage_to_volts,
+    )
+
+    # Real device readings (~25 °C bench idle), distinct per field so the test
+    # also pins which raw column feeds which converted column.
+    snap = ConsoleTelemetry(
+        tec_v_raw=1.194286,
+        tec_set_raw=1.190256,
+        tec_curr_raw=1.504542,
+        tec_volt_raw=1.544029,
+        tec_good=True,
+    )
+
+    # The 4 converted columns sit immediately after tec_good, keeping the raw
+    # columns (and every column after) in place for header-based consumers.
+    gi = _TELEMETRY_HEADERS.index("tec_good")
+    assert _TELEMETRY_HEADERS[gi + 1:gi + 5] == [
+        "tec_temp_c", "tec_set_c", "tec_curr_a", "tec_volt_v",
+    ]
+
+    row = _snap_to_row(snap)
+    assert len(row) == len(_TELEMETRY_HEADERS)
+
+    # Each converted value is wired to the correct raw field and rounded to the
+    # same precision the live display uses (temps 2 dp, current/voltage 3 dp).
+    assert row[gi + 1] == round(tec_thermistor_voltage_to_celsius(snap.tec_v_raw), 2)
+    assert row[gi + 2] == round(tec_thermistor_voltage_to_celsius(snap.tec_set_raw), 2)
+    assert row[gi + 3] == round(tec_current_to_amps(snap.tec_curr_raw), 3)
+    assert row[gi + 4] == round(tec_voltage_to_volts(snap.tec_volt_raw), 3)

--- a/tests/test_scan_workflow.py
+++ b/tests/test_scan_workflow.py
@@ -1,6 +1,8 @@
 """Tests for ScanWorkflow and ScanRequest."""
 
 import dataclasses
+import os
+import stat
 import threading
 import time
 from unittest import mock
@@ -389,6 +391,75 @@ def test_start_scan_sends_trigger_config_before_start_trigger():
         "set_trigger_json must be sent before start_trigger"
     sent = next(payload for kind, payload in calls if kind == "set")
     assert sent == expected_cfg
+
+
+def test_start_scan_aborts_synchronously_when_scan_db_readonly(tmp_path):
+    """Issue #213: a read-only scan DB must abort the scan in the synchronous
+    preflight — start_scan returns False (so the worker that fires the laser is
+    never spawned) and records last_scan_error. The old preflight only *opened*
+    the DB, which succeeds on a read-only file because opening never writes; the
+    write-probe forces the failure to surface here instead of asynchronously on
+    the first INSERT in the worker thread."""
+    db_path = tmp_path / "scans.db"
+    from omotion.ScanDatabase import ScanDatabase
+    ScanDatabase(db_path=str(db_path)).close()  # create while writable
+    os.chmod(db_path, stat.S_IREAD)             # then mark read-only
+    try:
+        motion = _build_motion_with_data_dir(str(tmp_path), scan_db_path=str(db_path))
+        request = ScanRequest(
+            subject_id="x", duration_sec=1,
+            left_camera_mask=0xFF, right_camera_mask=0, reduced_mode=False,
+        )
+        started = motion.scan_workflow.start_scan(request)
+
+        assert started is False
+        # No worker thread spawned -> the laser path is never reached.
+        assert motion.scan_workflow._thread is None
+        err = motion.scan_workflow.last_scan_error
+        assert err is not None
+        assert "readonly" in err.lower()
+    finally:
+        os.chmod(db_path, stat.S_IWRITE)
+
+
+def test_worker_invokes_on_error_when_scan_aborts(tmp_path):
+    """A scan failure that surfaces only in the worker thread (e.g. the scan DB
+    becoming unwritable in the race window after the synchronous preflight
+    passed) must notify the caller via ScanRequest.on_error — start_scan already
+    returned True, so a return value can't carry the failure. Without this the
+    worker dies silently and the app shows no error. See bloodflow-app #213."""
+    motion = _build_motion_with_data_dir(None)
+
+    errors = []
+    done = threading.Event()
+
+    def on_error(exc):
+        errors.append(exc)
+        done.set()
+
+    class _ExplodingCriticalSink:
+        critical = True
+        channels: set = set()
+
+        def on_scan_start(self, meta):
+            raise RuntimeError("db vanished mid-scan")
+
+        def consume(self, channel, payload):
+            pass
+
+        def on_complete(self):
+            pass
+
+    request = ScanRequest(
+        subject_id="x", duration_sec=1,
+        left_camera_mask=0xFF, right_camera_mask=0, reduced_mode=False,
+        sinks=[_ExplodingCriticalSink()], skip_default_storage=True,
+        on_error=on_error,
+    )
+    assert motion.scan_workflow.start_scan(request) is True
+    assert done.wait(timeout=5.0), "on_error was never invoked"
+    assert isinstance(errors[0], BaseException)
+    assert "db vanished mid-scan" in str(errors[0])
 
 
 def test_start_scan_trigger_config_override_is_merged():


### PR DESCRIPTION
## Release: SDK `next` → `main`

Promotes the `next` branch to `main` to cut the next `omotion` PyPI release.

**8 commits** since the last release:

- fix: surface read-only scan DB as **E-301** instead of a silent worker death (#213)
- fix: reject non-monotonic frame ids in the unwrapper (#172)
- feat: log when stale / non-monotonic frames are dropped (#172)
- feat: log converted **TEC engineering units** in the per-scan telemetry CSV
- test: align `ScanDBSink` `session_meta` tests with empty-session deletion (#82)

### Release mechanics
- After merge, tagging `main` with `X.Y.Z` triggers `release-build.yml` → builds sdist + wheel via setuptools_scm → creates a GitHub Release → `publish-pypi.yml` fires on publish and twine-uploads to PyPI.
- Release version: **1.8.1** (from 1.8.0).
- This must be published to PyPI **before** the bloodflow `1.3.0` tag, since the bloodflow production build installs `openmotion-sdk` from PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
