### PR TITLE
Add get_diag_stats() accessor (sensor-fw#70 companion)

### DIFF
--- a/omotion/MotionSensor.py
+++ b/omotion/MotionSensor.py
@@ -19,6 +19,7 @@ from omotion.config import (
     OW_CAMERA_SINGLE_HISTOGRAM,
     OW_CAMERA_SET_CONFIG,
     OW_CMD,
+    OW_CMD_DIAG_STATS,
     OW_CMD_ECHO,
     OW_CMD_HWID,
     OW_CMD_I2C_REG_READ,
@@ -552,6 +553,56 @@ class MotionSensor(SignalWrapper):
             "fpgas": [bool(fpga_mask & (1 << i)) for i in range(8)],
             "cameras_expected": d[5],
             "all_present": bool(d[6]),
+        }
+
+    # ------------------------------------------------------------------
+    # Diagnostics (sensor-fw#70)
+    # ------------------------------------------------------------------
+
+    _DIAG_STATS_FMT = "<B3x8IIIII"  # version, pad[3], cam_overrun_count[8], cmp_fail/timeout/fallback_count, cmp_max_time_us
+    _DIAG_STATS_SIZE = struct.calcsize(_DIAG_STATS_FMT)  # 52 bytes
+
+    def get_diag_stats(self) -> dict | None:
+        """Return the live firmware diagnostics snapshot, or None on error.
+
+        Printf-independent (works regardless of DEBUG_FLAG_USB_PRINTF) —
+        queries cam_diag_stats_t directly via OW_CMD_DIAG_STATS. Counters are
+        for the CURRENT scan (reset at scan start/end by the firmware); query
+        mid-scan to see live values, see sensor-fw camera_manager.c.
+
+        Returns a dict::
+
+            {
+                "version": int,
+                "cam_overrun_count": [int] * 8,  # per-camera SPI/USART RX overruns
+                "cmp_fail_count": int,           # rle_compress dst_max overflow
+                "cmp_timeout_count": int,         # rle_compress hit its time budget (#70)
+                "cmp_fallback_count": int,        # frames sent uncompressed (either above)
+                "cmp_max_time_us": int,           # worst-case compression time this scan
+            }
+        """
+        if self.demo_mode:
+            return {
+                "version": 1,
+                "cam_overrun_count": [0] * 8,
+                "cmp_fail_count": 0,
+                "cmp_timeout_count": 0,
+                "cmp_fallback_count": 0,
+                "cmp_max_time_us": 0,
+            }
+        r = self._send(packetType=OW_CMD, command=OW_CMD_DIAG_STATS)
+        if r is None or r.packetType in _ERROR_TYPES or r.data_len < self._DIAG_STATS_SIZE:
+            return None
+        (version, *counts) = struct.unpack(
+            self._DIAG_STATS_FMT, r.data[: self._DIAG_STATS_SIZE]
+        )
+        return {
+            "version": version,
+            "cam_overrun_count": list(counts[0:8]),
+            "cmp_fail_count": counts[8],
+            "cmp_timeout_count": counts[9],
+            "cmp_fallback_count": counts[10],
+            "cmp_max_time_us": counts[11],
         }
 
     def _check_i2c_health(self) -> None:

--- a/omotion/config.py
+++ b/omotion/config.py
@@ -130,6 +130,7 @@ CMP_UNCMP_CRC_SIZE = 2
 
 # Global Commands
 OW_CMD_PING = 0x00
+OW_CMD_DIAG_STATS = 0x01  # #70: cam_diag_stats_t snapshot, printf-independent
 OW_CMD_VERSION = 0x02
 OW_CMD_ECHO = 0x03
 OW_CMD_TOGGLE_LED = 0x04


### PR DESCRIPTION
## What

Companion to sensor-fw#70 / [sensor-fw PR #71](https://github.com/OpenwaterHealth/openmotion-sensor-fw/pull/71) (time-bound compression guard + diag stats).

- `OW_CMD_DIAG_STATS = 0x01` — free in both the firmware and SDK `OW_CMD` enums.
- `MotionSensor.get_diag_stats()` — parses the 52-byte `cam_diag_stats_t` wire struct, mirroring `get_i2c_status()`'s dict-return pattern:

```python
{
    "version": int,
    "cam_overrun_count": [int] * 8,   # per-camera SPI/USART RX overruns this scan
    "cmp_fail_count": int,            # rle_compress dst_max overflow
    "cmp_timeout_count": int,         # rle_compress hit its time budget (sensor-fw#70)
    "cmp_fallback_count": int,        # frames sent uncompressed (either above)
    "cmp_max_time_us": int,           # worst-case compression time this scan
}
```

Printf-independent — works regardless of `DEBUG_FLAG_USB_PRINTF`. Counters are for the firmware's CURRENT/just-finished scan (reset at scan start on the firmware side, per the matching FW PR).

## Validation

Struct format (`"<B3x8IIIII"`, 52 bytes) verified byte-for-byte against the firmware struct layout before touching hardware. Round-tripped against real sensor-fw#70 firmware on both modules:
- Normal load: returns all-zero counters as expected, plus a real non-zero `cmp_max_time_us` (3.8–4.7 ms) confirming the round-trip works for non-zero data too.
- Forced-trip bench test (firmware temporarily set to a 50 µs budget): `get_diag_stats()` read `cmp_timeout=407 cmp_fallback=407` matching the firmware's own printf summary exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
