### PR TITLE
fix: exclude unconnected/unmasked sensors from LiveUsbSource

### DIFF
--- a/omotion/ScanWorkflow.py
+++ b/omotion/ScanWorkflow.py
@@ -550,10 +550,24 @@ class ScanWorkflow:
         all_sinks = default_sinks + list(request.sinks)
 
         # ── Build source + runner (set self._runner synchronously) ─────────
+        # self._interface.left / .right are permanent MotionSensor objects
+        # (see MotionInterface.__init__) — never None, even when no physical
+        # sensor is attached to that side. LiveUsbSource only filters a side
+        # out when its sensor is None, so passing an unconnected/unrequested
+        # sensor through unconditionally makes __iter__ crash on
+        # sensor.uart.histo (uart is None until connect()) on every scan on
+        # a single-sensor rig, or silently streams a side the caller never
+        # asked for on a dual-sensor rig doing a one-sided scan
+        # (bloodflow-app issue #274). Match _resolve_active_sides' gate:
+        # only hand off a sensor that's both requested (nonzero mask) and
+        # actually connected.
+        def _live_sensor(sensor, mask: int):
+            return sensor if (int(mask) != 0 and sensor.is_connected()) else None
+
         source = LiveUsbSource(
             console=self._interface.console,
-            left=self._interface.left,
-            right=self._interface.right,
+            left=_live_sensor(self._interface.left, request.left_camera_mask),
+            right=_live_sensor(self._interface.right, request.right_camera_mask),
             batch_size_frames=request.batch_size_frames or 10,
             metadata=meta,
         )

--- a/tests/test_scan_workflow.py
+++ b/tests/test_scan_workflow.py
@@ -117,6 +117,70 @@ def test_start_scan_uses_new_runner():
     assert isinstance(motion.scan_workflow._runner, ScanRunner)
 
 
+def test_start_scan_excludes_unconnected_unmasked_sensor_from_live_source():
+    """bloodflow-app issue #274: on a single-sensor rig, ``right`` is a real
+    ``MotionSensor`` object (never ``None`` — see ``MotionInterface.__init__``)
+    that's simply never connected, and the request correctly sets
+    ``right_camera_mask=0``. start_scan must NOT hand that unconnected,
+    unrequested sensor to LiveUsbSource: LiveUsbSource's own ``sensor is not
+    None`` filter is a no-op against a permanently-instantiated sensor
+    object, so passing it through unconditionally makes __iter__ call
+    ``sensor.uart.histo.start_streaming(...)`` on a sensor whose ``.uart``
+    is None — 'NoneType' object has no attribute 'histo', on every scan."""
+    motion = _build_motion_with_data_dir(None)
+    # Simulate the field failure mode: left is connected, right never is
+    # (single-sensor rig) — both are still real objects either way.
+    with mock.patch.object(motion.left, "is_connected", return_value=True), \
+         mock.patch.object(motion.right, "is_connected", return_value=False):
+        request = ScanRequest(
+            subject_id="x", duration_sec=1,
+            left_camera_mask=0xFF, right_camera_mask=0x00, reduced_mode=False,
+        )
+
+        captured = {}
+
+        def _factory(*, console, left, right, batch_size_frames, metadata):
+            captured["left"] = left
+            captured["right"] = right
+            return _EmptySource(metadata=metadata)
+
+        with mock.patch("omotion.pipeline.sources.LiveUsbSource", _factory):
+            assert motion.scan_workflow.start_scan(request)
+
+        assert captured["right"] is None, (
+            "right sensor (unconnected, unmasked) was passed into "
+            "LiveUsbSource — it will crash __iter__ on sensor.uart.histo"
+        )
+        assert captured["left"] is motion.left
+
+
+def test_start_scan_excludes_masked_out_sensor_even_when_connected():
+    """A dual-sensor rig doing a left-only scan (right physically connected
+    but right_camera_mask=0) must also exclude right from LiveUsbSource —
+    otherwise the pipeline silently streams+records a side the caller never
+    asked for."""
+    motion = _build_motion_with_data_dir(None)
+    with mock.patch.object(motion.left, "is_connected", return_value=True), \
+         mock.patch.object(motion.right, "is_connected", return_value=True):
+        request = ScanRequest(
+            subject_id="x", duration_sec=1,
+            left_camera_mask=0xFF, right_camera_mask=0x00, reduced_mode=False,
+        )
+
+        captured = {}
+
+        def _factory(*, console, left, right, batch_size_frames, metadata):
+            captured["left"] = left
+            captured["right"] = right
+            return _EmptySource(metadata=metadata)
+
+        with mock.patch("omotion.pipeline.sources.LiveUsbSource", _factory):
+            assert motion.scan_workflow.start_scan(request)
+
+        assert captured["right"] is None
+        assert captured["left"] is motion.left
+
+
 def test_start_scan_auto_injects_csv_sink_when_data_dir_set(tmp_path):
     from omotion.pipeline.sinks import CsvSink
     motion = _build_motion_with_data_dir(str(tmp_path))


### PR DESCRIPTION
## Summary
- `ScanWorkflow.start_scan` passed `self._interface.left`/`.right` into `LiveUsbSource` unconditionally. Those are permanent `MotionSensor` objects (see `MotionInterface.__init__`) that exist even when no physical sensor is attached, so `LiveUsbSource`'s `sensor is not None` filter never excludes them.
- `LiveUsbSource.__iter__` then unconditionally called `sensor.uart.histo.start_streaming(...)` for every side present in `_packet_queues` — including a side that was never connected (`.uart is None`) — crashing every scan on a single-sensor rig with `AttributeError: 'NoneType' object has no attribute 'histo'`.
- Fix: gate each side on the same connected + requested-mask check `_resolve_active_sides` already uses, before constructing `LiveUsbSource`.

Fixes OpenwaterHealth/openmotion-bloodflow-app#274.

## Test plan
- [x] Added `test_start_scan_excludes_unconnected_unmasked_sensor_from_live_source` — reproduces the exact field failure (right unconnected, `right_camera_mask=0x00`), fails before the fix, passes after.
- [x] Added `test_start_scan_excludes_masked_out_sensor_even_when_connected` — dual-sensor rig doing a left-only scan must also exclude a connected-but-unmasked right sensor.
- [x] `pytest tests/test_scan_workflow.py tests/test_pipeline/` — 251 passed, 30 skipped.