### PR TITLE
fix: bugs surfaced by Google style-guide audit (missing import, error contracts, silent failure paths)

### DIFF
--- a/omotion/CalibrationWorkflow.py
+++ b/omotion/CalibrationWorkflow.py
@@ -1005,7 +1005,7 @@ class CalibrationWorkflow:
                 try:
                     self._interface.scan_workflow.cancel_scan()
                 except Exception:
-                    pass
+                    logger.exception("Calibration watchdog: cancel_scan raised.")
             wd = threading.Timer(request.max_duration_sec, _watchdog)
             wd.daemon = True
             wd.start()
@@ -1416,7 +1416,7 @@ class CalibrationWorkflow:
                 try:
                     self._interface.scan_workflow.cancel_scan()
                 except Exception:
-                    pass
+                    logger.exception("Test-scan watchdog: cancel_scan raised.")
 
             wd = threading.Timer(request.max_duration_sec, _watchdog)
             wd.daemon = True

--- a/omotion/ConsoleTelemetry.py
+++ b/omotion/ConsoleTelemetry.py
@@ -436,9 +436,15 @@ class ConsoleTelemetryPoller:
             )
 
     def _read_analog(self, snap: ConsoleTelemetry) -> None:
-        # get_lsync_pulsecount swallows transient errors and returns None;
-        # default to 0 so a single bad poll doesn't raise TypeError.
-        lsync = self._console.get_lsync_pulsecount()
+        # Tolerate a transient lsync failure — one bad read must not fail
+        # the whole snapshot; tcm just defaults to 0 for this poll.
+        # (get_lsync_pulsecount re-raises transport errors, matching its
+        # fsync sibling.)
+        try:
+            lsync = self._console.get_lsync_pulsecount()
+        except Exception as e:
+            logger.debug("lsync read failed for this poll; tcm -> 0: %s", e)
+            lsync = None
         snap.tcm = int(lsync) if lsync is not None else 0
 
         tcl_raw, _ = self._console.read_i2c_packet(

--- a/omotion/FPGAProgrammer.py
+++ b/omotion/FPGAProgrammer.py
@@ -8,25 +8,23 @@ sequence one 16-byte page at a time over the UART link.
 
 Usage::
 
-    from transport import SerialTransport
-    from api import HardwareAPI, FpgaPageProgrammer
+    from omotion.FPGAProgrammer import FpgaPageProgrammer
+    from omotion.config import MuxChannel
 
-    with SerialTransport("/dev/ttyACM0", timeout=5.0) as transport:
-        hw   = HardwareAPI(transport)
-        prog = FpgaPageProgrammer(hw)
-        prog.program_from_jedec("my_design.jed")
+    prog = FpgaPageProgrammer(console)  # console: a connected MotionConsole
+    prog.program_from_jedec(MuxChannel.FPGA_TA, "my_design.jed")
 """
 
 from __future__ import annotations
 
 import logging
-import sys
 import os
 from pathlib import Path
 import time
 from typing import Callable, Optional
 from omotion import _log_root
 from omotion.CommandError import CommandError
+from omotion.jedecParser import parse_jedec_file
 from omotion.MotionConsole import MotionConsole
 from omotion.config import (
     XO2_FLASH_PAGE_SIZE,
@@ -37,15 +35,6 @@ from omotion.config import (
 
 
 logger = logging.getLogger(f"{_log_root}.FPGAProgrammer" if _log_root else "FPGAProgrammer")
-
-# --------------------------------------------------------------------------- #
-# Make the project-root jedec_parser importable from the py-demo subtree
-# --------------------------------------------------------------------------- #
-_REPO_ROOT = Path(__file__).resolve().parents[2]
-if str(_REPO_ROOT) not in sys.path:
-    sys.path.insert(0, str(_REPO_ROOT))
-
-from omotion.jedecParser import parse_jedec_file  # noqa: E402
 
 
 # --------------------------------------------------------------------------- #
@@ -157,8 +146,8 @@ class FpgaPageProgrammer:
     Parameters
     ----------
     api:
-        An initialised :class:`~api.commands.HardwareAPI` instance whose
-        transport is already open.
+        An initialised :class:`~omotion.MotionConsole.MotionConsole`
+        instance whose UART transport is already open.
     verify:
         If True, read back each sector after writing and compare with the
         written data.  Adds one round-trip per page.  Default True.

--- a/omotion/MotionConsole.py
+++ b/omotion/MotionConsole.py
@@ -971,7 +971,7 @@ class MotionConsole(SignalWrapper):
         Returns:
             tuple[bytes, int]: The received data and its length, None if failed
         """
-        """Validate MUX index and channel parameters"""
+        # Validate MUX index and channel parameters.
         if mux_index not in (0, 1):
             raise ValueError(f"Invalid mux_index {mux_index}. Must be 0 or 1")
         if channel < 0 or channel > 7:
@@ -1006,7 +1006,8 @@ class MotionConsole(SignalWrapper):
             # The underlying error is already logged by MotionUart.send_packet()
             # Only log here if we want additional context about the I2C operation
             logger.debug(
-                f"I2C read operation failed (underlying error logged by UART layer): {str(e)}"
+                "I2C read operation failed (underlying error logged by UART layer): %s",
+                e,
             )
             return None, None
 
@@ -1026,7 +1027,7 @@ class MotionConsole(SignalWrapper):
         Returns:
             bool: True if write succeeded, False otherwise
         """
-        """Validate MUX index and channel parameters"""
+        # Validate MUX index and channel parameters.
         if mux_index not in (0, 1):
             raise ValueError(f"Invalid mux_index {mux_index}. Must be 0 or 1")
         if channel < 0 or channel > 7:
@@ -1056,7 +1057,7 @@ class MotionConsole(SignalWrapper):
                 return True
 
         except Exception as e:
-            print(f"I2C Write failed: {str(e)}")
+            logger.error("I2C Write failed: %s", e)
             return False
 
     def set_fan_speed(self, fan_speed: int = 50) -> int:
@@ -1511,6 +1512,7 @@ class MotionConsole(SignalWrapper):
 
         except Exception as e:
             self._log_command_error("get_lsync_pulsecount", e)
+            raise  # Re-raise the exception for the caller to handle
 
     def get_system_odometer_minutes(self) -> Optional[int]:
         """Cumulative console uptime in minutes, persisted in flash.
@@ -1891,7 +1893,7 @@ class MotionConsole(SignalWrapper):
         try:
             # Demo mode mock
             if getattr(self.uart, "demo_mode", False):
-                return (1.0, 0.5, 0.5, 25.0, True)
+                return ("1.000000", "0.500000", "0.500000", "25.000000", True)
 
             if not self.is_connected():
                 raise ValueError("Motion Console not connected")
@@ -2061,7 +2063,7 @@ class MotionConsole(SignalWrapper):
                 id=None, packetType=OW_CONTROLLER, command=OW_CTRL_PDUMON, data=None
             )
             self.uart.clear_buffer()
-            r.print_packet()
+            # r.print_packet()
             if r.packetType == OW_ERROR:
                 logger.error("Error retrieving PDU MON data")
                 return None
@@ -2802,7 +2804,7 @@ class MotionConsole(SignalWrapper):
                 raise CommandError("FPGA_PROG_UFM_READ_PAGE failed", response=r)
 
             if len(r.data) != XO2_FLASH_PAGE_SIZE:
-                raise ValueError(
+                raise CommandError(
                     f"UFM read page returned {len(r.data)} bytes, expected {XO2_FLASH_PAGE_SIZE}",
                     response=r,
                 )
@@ -2837,7 +2839,7 @@ class MotionConsole(SignalWrapper):
         try:
             if getattr(self.uart, "demo_mode", False):
                 logger.info("Demo mode: simulating fpga read status")
-                return None
+                return 0
 
             if not self.uart or not self.is_connected():
                 raise ValueError("Console Device not connected")
@@ -2858,7 +2860,7 @@ class MotionConsole(SignalWrapper):
                 raise CommandError("FPGA_PROG_READ_STATUS failed", response=r)
 
             if len(r.data) != 4:
-                raise ValueError(
+                raise CommandError(
                     f"READ_STATUS returned {len(r.data)} bytes, expected 4",
                     response=r,
                 )

--- a/omotion/MotionSensor.py
+++ b/omotion/MotionSensor.py
@@ -659,14 +659,13 @@ class MotionSensor(SignalWrapper):
     # ------------------------------------------------------------------
     # Factory Commands
     # ------------------------------------------------------------------
-    def i2c_scan(self) -> list[int]:
+    def i2c_scan(self) -> list[int] | Literal[False]:
         """Scan the I2C bus and return a list of found device addresses.
 
         Returns:
-            List of 7-bit I2C addresses (integers) that responded.
-
-        Raises:
-            OWNotConnectedError, OWCommunicationError, OWDeviceError.
+            List of 7-bit I2C addresses (integers) that responded, or
+            ``False`` if the device returned an error response (check
+            with ``is False``).
         """
         r = self._send(packetType=OW_FPGA_PROG, command=OW_FACTORY_I2C_SCAN)
         if r.packetType in _ERROR_TYPES:
@@ -677,7 +676,7 @@ class MotionSensor(SignalWrapper):
                     [f"0x{a:02X}" for a in addresses])
         return addresses
     
-    def creset(self, state: bool | None = None) -> int:
+    def creset(self, state: bool | None = None) -> int | Literal[False]:
         """Control or read the FPGA CRESET pin.
 
         Args:
@@ -686,10 +685,9 @@ class MotionSensor(SignalWrapper):
                    None  → read current state without changing it.
 
         Returns:
-            Current CRESET pin state: 1 = high, 0 = low.
-
-        Raises:
-            OWNotConnectedError, OWCommunicationError, OWDeviceError.
+            Current CRESET pin state: 1 = high, 0 = low, or ``False``
+            if the device returned an error response. 0 is a valid pin
+            state — distinguish errors with ``is False``.
         """
         if state is None:
             data = None          # 0-byte payload → firmware reads pin
@@ -703,7 +701,9 @@ class MotionSensor(SignalWrapper):
         logger.debug("LP creset: pin=%d", pin)
         return pin
 
-    def i2c_write(self, dev_addr: int, data: bytes | bytearray) -> None:
+    def i2c_write(
+        self, dev_addr: int, data: bytes | bytearray
+    ) -> Literal[False] | None:
         """Write bytes to an I2C device.
 
         Payload: [dev_addr, write_len_hi, write_len_lo, data...]
@@ -712,9 +712,12 @@ class MotionSensor(SignalWrapper):
             dev_addr: 7-bit I2C device address.
             data: Bytes to write.
 
+        Returns:
+            None on success, or ``False`` if the device returned an
+            error response (check with ``is False``).
+
         Raises:
             ValueError: If data is empty.
-            OWNotConnectedError, OWCommunicationError, OWDeviceError.
         """
         if not data:
             raise ValueError("i2c_write requires at least 1 data byte")
@@ -730,7 +733,7 @@ class MotionSensor(SignalWrapper):
         logger.debug("LP i2c_write: addr=0x%02X len=%d data=%s",
                      dev_addr, write_len, [f"0x{b:02X}" for b in data])
     
-    def i2c_read(self, dev_addr: int, read_len: int) -> bytes:
+    def i2c_read(self, dev_addr: int, read_len: int) -> bytes | Literal[False]:
         """Read bytes from an I2C device.
 
         Payload: [dev_addr, read_len_hi, read_len_lo]
@@ -740,11 +743,11 @@ class MotionSensor(SignalWrapper):
             read_len: Number of bytes to read.
 
         Returns:
-            Bytes read from the device.
+            Bytes read from the device, or ``False`` if the device
+            returned an error response (check with ``is False``).
 
         Raises:
             ValueError: If read_len < 1.
-            OWNotConnectedError, OWCommunicationError, OWDeviceError.
         """
         if read_len < 1:
             raise ValueError("i2c_read requires read_len >= 1")
@@ -761,7 +764,7 @@ class MotionSensor(SignalWrapper):
         return result
 
     def i2c_write_read(self, dev_addr: int, data: bytes | bytearray,
-                       read_len: int) -> bytes:
+                       read_len: int) -> bytes | Literal[False]:
         """Write bytes then read bytes from an I2C device (combined transfer).
 
         Payload: [dev_addr, write_len_hi, write_len_lo,
@@ -773,11 +776,11 @@ class MotionSensor(SignalWrapper):
             read_len: Number of bytes to read back.
 
         Returns:
-            Bytes read from the device.
+            Bytes read from the device, or ``False`` if the device
+            returned an error response (check with ``is False``).
 
         Raises:
             ValueError: If data is empty or read_len < 1.
-            OWNotConnectedError, OWCommunicationError, OWDeviceError.
         """
         if not data:
             raise ValueError("i2c_write_read requires at least 1 write byte")
@@ -802,7 +805,7 @@ class MotionSensor(SignalWrapper):
 
     def i2c_read_register(self, dev_addr: int, reg_addr: int, read_len: int = 1,
                           reg_addr_size: int = 1,
-                          mux_channel: Optional[int] = None) -> bytes:
+                          mux_channel: Optional[int] = None) -> bytes | Literal[False]:
         """Read register bytes from an arbitrary I2C device on the sensor bus.
 
         Payload (7 bytes, big-endian):
@@ -819,11 +822,11 @@ class MotionSensor(SignalWrapper):
                 or None to read a device directly on the bus.
 
         Returns:
-            Bytes read from the device, or False on an error response.
+            Bytes read from the device, or ``False`` on an error
+            response (check with ``is False``).
 
         Raises:
             ValueError: On out-of-range arguments.
-            OWNotConnectedError, OWCommunicationError, OWDeviceError.
         """
         if not (0x00 <= dev_addr <= 0x7F):
             raise ValueError(f"dev_addr must be 0x00-0x7F, got {dev_addr:#04x}")

--- a/omotion/NvcmProgrammer.py
+++ b/omotion/NvcmProgrammer.py
@@ -160,7 +160,7 @@ class _SensorI2CDriver(I2CDriver):
         # dispatch nothing — counted on both sim and hardware drivers.
         if self._state == _TxState.WRITE_PHASE and self._write_buf:
             # MotionSensor.i2c_write returns None on success, False on a
-            # firmware error packet (despite its docstring claiming it raises).
+            # firmware error packet.
             if self._sensor.i2c_write(self._addr, bytes(self._write_buf)) is False:
                 raise NvcmTransportError(
                     f"i2c_write failed at transaction {self.count}")
@@ -200,7 +200,7 @@ class _SensorI2CDriver(I2CDriver):
             result = self._sensor.i2c_read(self._addr, num_bytes)
             what = "i2c_read"
         # MotionSensor returns bytes on success, False on a firmware error
-        # packet (despite its docstring claiming it raises).
+        # packet.
         if result is False or result is None:
             raise NvcmTransportError(
                 f"{what} failed at transaction {self.count}")

--- a/omotion/StreamInterface.py
+++ b/omotion/StreamInterface.py
@@ -1,5 +1,6 @@
 import logging
 import queue
+import struct
 import time
 import usb.core
 import usb.util

--- a/omotion/i2c_packet.py
+++ b/omotion/i2c_packet.py
@@ -72,6 +72,7 @@ class I2C_Packet:
         print("\nParsed Packet:")
         new_packet.print_packet()
 
+    @staticmethod
     def read_csv_to_i2c_packets(csv_file_path):
         i2c_packets = []
 

--- a/omotion/jedecParser.py
+++ b/omotion/jedecParser.py
@@ -13,8 +13,13 @@ Fuse mapping:
 - Row 0, byte 0 = fuses 0..7 (bit0 = fuse0, bit1 = fuse1, ...).
 """
 
+import logging
 from dataclasses import dataclass
 from typing import List, Optional, Tuple
+
+from omotion import _log_root
+
+logger = logging.getLogger(f"{_log_root}.jedecParser" if _log_root else "jedecParser")
 
 
 class JedecError(Exception):
@@ -206,10 +211,12 @@ def parse_jedec_file(path: str) -> Tuple[JedecImage, dict]:
     if fuse_bits is None:
         fuse_bits = [0] * total_fuses
 
-    print(
-        f"[DEBUG] QF={total_fuses}  set_fuses={sum(fuse_bits)}  "
-        f"feature_row={'present' if feature_row else 'absent'}  "
-        f"feabits={'present (' + feabits + ')' if feabits else 'absent'}"
+    logger.debug(
+        "QF=%d set_fuses=%d feature_row=%s feabits=%s",
+        total_fuses,
+        sum(fuse_bits),
+        "present" if feature_row else "absent",
+        f"present ({feabits})" if feabits else "absent",
     )
 
     # Pack into rows × 16 bytes

--- a/omotion/pipeline/stages/dark.py
+++ b/omotion/pipeline/stages/dark.py
@@ -263,7 +263,8 @@ class PendingInterval:
 
     def flush(self) -> Interval:
         """Return the closed interval; reset for next interval."""
-        assert self.is_closed(), "flush() called on non-closed interval"
+        if not self.is_closed():
+            raise RuntimeError("flush() called on non-closed interval")
         interval = Interval(
             left=self._left,
             right=self._right,

--- a/omotion/utils.py
+++ b/omotion/utils.py
@@ -1,11 +1,5 @@
 import serial.tools.list_ports
 
-SENSOR_VID = 0x0483  # 1155  # Example VID for demonstration
-SENSOR_PID = 0x5A5A  # 23130  # Example PID for demonstration
-
-CONSOLE_VID = 0x483  # Example VID for demonstration
-CONSOLE_PID = 0xA53E  # Example PID for demonstration
-
 # CRC16-ccitt lookup table
 crc16_tab = [
     0x0000,

--- a/tests/test_console_command_contracts.py
+++ b/tests/test_console_command_contracts.py
@@ -1,0 +1,99 @@
+"""Unit tests for MotionConsole command-method return/raise contracts.
+
+Constructs MotionConsole without UART enumeration (``__new__``) and stubs
+``self.uart`` — the same no-hardware pattern as test_i2c_read_register.py.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from omotion.CommandError import CommandError
+from omotion.MotionConsole import MotionConsole
+from omotion.config import OW_RESP
+from omotion.connection_state import ConnectionState
+
+
+def _console(uart) -> MotionConsole:
+    c = MotionConsole.__new__(MotionConsole)
+    c.uart = uart
+    c._state = ConnectionState.CONNECTED
+    c.is_connected = lambda: True
+    return c
+
+
+def test_tec_status_demo_mode_returns_strings():
+    """Demo mode must return the same shape as the real path, which
+    formats the four readings as f"{v:.6f}" strings."""
+    c = _console(SimpleNamespace(demo_mode=True))
+    volt, temp_set, tec_curr, tec_volt, tec_good = c.tec_status()
+    for value in (volt, temp_set, tec_curr, tec_volt):
+        assert isinstance(value, str)
+    assert isinstance(tec_good, bool)
+
+
+def test_fpga_prog_read_status_demo_mode_returns_int():
+    """Callers bit-shift the returned status; demo mode returning None
+    breaks every (sr >> n) & 1 check."""
+    c = _console(SimpleNamespace(demo_mode=True))
+    sr = c.fpga_prog_read_status(0)
+    assert isinstance(sr, int)
+
+
+def test_fpga_prog_read_status_short_response_raises_command_error():
+    """A wrong-length response must surface as CommandError, not the
+    TypeError from ValueError's unsupported response= kwarg."""
+    r = SimpleNamespace(packetType=OW_RESP, data=b"\x01\x02")
+    uart = SimpleNamespace(
+        demo_mode=False,
+        send_packet=MagicMock(return_value=r),
+        clear_buffer=lambda: None,
+    )
+    c = _console(uart)
+    with pytest.raises(CommandError):
+        c.fpga_prog_read_status(0)
+
+
+def test_get_lsync_pulsecount_reraises_transport_errors():
+    """Must match get_fsync_pulsecount: log then re-raise, never swallow
+    the exception and fall through to an implicit None."""
+    uart = SimpleNamespace(
+        demo_mode=False,
+        send_packet=MagicMock(side_effect=RuntimeError("uart torn down")),
+        clear_buffer=lambda: None,
+    )
+    c = _console(uart)
+    with pytest.raises(RuntimeError):
+        c.get_lsync_pulsecount()
+
+
+def test_get_fsync_pulsecount_reraises_transport_errors():
+    """Behavior pin for the sibling method lsync must match."""
+    uart = SimpleNamespace(
+        demo_mode=False,
+        send_packet=MagicMock(side_effect=RuntimeError("uart torn down")),
+        clear_buffer=lambda: None,
+    )
+    c = _console(uart)
+    with pytest.raises(RuntimeError):
+        c.get_fsync_pulsecount()
+
+
+def test_read_pdu_mon_does_not_print_packet():
+    """Every sibling command method has its r.print_packet() commented
+    out; read_pdu_mon must not spam stdout on every poll."""
+    r = SimpleNamespace(
+        packetType=OW_RESP,
+        data=bytes(96),
+        data_len=96,
+        print_packet=MagicMock(),
+    )
+    uart = SimpleNamespace(
+        demo_mode=False,
+        send_packet=MagicMock(return_value=r),
+        clear_buffer=lambda: None,
+    )
+    c = _console(uart)
+    pdu = c.read_pdu_mon()
+    r.print_packet.assert_not_called()
+    assert pdu is not None

--- a/tests/test_console_telemetry_unit.py
+++ b/tests/test_console_telemetry_unit.py
@@ -135,3 +135,17 @@ def test_poller_attaches_dropped_delta_to_first_sample_only():
     poller._tick_once()
     assert received[0].dropped_delta == 7
     assert received[1].dropped_delta == 0
+
+
+def test_read_analog_tolerates_lsync_failure():
+    """A transient lsync failure must not propagate out of _read_analog —
+    one bad read shouldn't fail the whole telemetry snapshot (tcm just
+    defaults to 0 for that poll)."""
+    console = _FakeConsoleForDrain([])
+    console.get_lsync_pulsecount = MagicMock(side_effect=RuntimeError("uart busy"))
+    poller = ConsoleTelemetryPoller(console)
+    snap = ConsoleTelemetry()
+
+    poller._read_analog(snap)
+
+    assert snap.tcm == 0

--- a/tests/test_i2c_packet.py
+++ b/tests/test_i2c_packet.py
@@ -1,0 +1,30 @@
+"""Unit tests for I2C_Packet.read_csv_to_i2c_packets.
+
+The method takes only the CSV path (no self) but had no @staticmethod
+decorator, so it only worked when called unbound through the class —
+calling it on an instance mis-bound the path argument to ``self``.
+"""
+from omotion.i2c_packet import I2C_Packet
+
+
+def _write_csv(path):
+    path.write_text(
+        "id,device_address,register_address,data\n"
+        "1,0x29,0x3012,0x01\n"
+        "2,0x29,0x3013,0xFF\n"
+    )
+    return str(path)
+
+
+def test_read_csv_callable_on_instance(tmp_path):
+    csv_path = _write_csv(tmp_path / "cfg.csv")
+    packets = I2C_Packet().read_csv_to_i2c_packets(csv_path)
+    assert len(packets) == 2
+    assert packets[0].device_address == 0x29
+    assert packets[1].data == 0xFF
+
+
+def test_read_csv_callable_on_class(tmp_path):
+    csv_path = _write_csv(tmp_path / "cfg.csv")
+    packets = I2C_Packet.read_csv_to_i2c_packets(csv_path)
+    assert len(packets) == 2

--- a/tests/test_jedec_parser.py
+++ b/tests/test_jedec_parser.py
@@ -1,0 +1,27 @@
+"""Unit tests for jedecParser.parse_jedec_file.
+
+The parser printed an unconditional "[DEBUG] ..." line to stdout on every
+call — including every production FPGA-programming run via
+FPGAProgrammer.program_from_jedec. Diagnostics must go through logging.
+"""
+from omotion.jedecParser import parse_jedec_file
+
+MINIMAL_JED = "QF128*\nL0000 10101010*\n"
+
+
+def _write_jed(path):
+    path.write_text(MINIMAL_JED, encoding="latin1")
+    return str(path)
+
+
+def test_parse_minimal_jed(tmp_path):
+    image, extra = parse_jedec_file(_write_jed(tmp_path / "m.jed"))
+    assert image.total_fuses == 128
+    assert image.rows == 1
+    assert image.data[0] == 0b10101010
+    assert extra == {}
+
+
+def test_parse_does_not_print_to_stdout(tmp_path, capsys):
+    parse_jedec_file(_write_jed(tmp_path / "m.jed"))
+    assert capsys.readouterr().out == ""

--- a/tests/test_pipeline/test_dark_estimators.py
+++ b/tests/test_pipeline/test_dark_estimators.py
@@ -76,6 +76,15 @@ def test_pending_interval_collects_frames_between_darks():
     assert len(interval.light_frames) == 3
 
 
+def test_flush_on_non_closed_interval_raises():
+    """flush() must fail loudly even under ``python -O`` (where assert is
+    stripped); silently proceeding emits an interval with right=None."""
+    pi = PendingInterval()
+    pi.set_left_dark(DarkObservation(t=0.0, u1=100.0, std=10.0), abs_frame_id=10)
+    with pytest.raises(RuntimeError):
+        pi.flush()
+
+
 def test_linear_interpolation_dark_baseline_across_interval():
     pi = PendingInterval()
     pi.set_left_dark(DarkObservation(t=0.0, u1=100.0, std=10.0), abs_frame_id=10)

--- a/tests/test_sensor_factory_contracts.py
+++ b/tests/test_sensor_factory_contracts.py
@@ -1,0 +1,71 @@
+"""Unit tests for MotionSensor factory-command error contracts.
+
+Pins the established False-on-error convention that NvcmProgrammer's
+_SensorI2CDriver depends on (``is False`` identity checks), and guards
+against the phantom OW*Error exception types reappearing in docstrings —
+those names were never defined anywhere in the package.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from omotion.MotionSensor import MotionSensor
+from omotion.config import OW_ERROR, OW_RESP
+
+PHANTOM_EXCEPTIONS = ("OWNotConnectedError", "OWCommunicationError", "OWDeviceError")
+
+FACTORY_METHODS = [
+    "i2c_scan",
+    "creset",
+    "i2c_write",
+    "i2c_read",
+    "i2c_write_read",
+    "i2c_read_register",
+]
+
+
+def _make_sensor(response):
+    s = MotionSensor.__new__(MotionSensor)
+    s._send = MagicMock(return_value=response)
+    return s
+
+
+def _resp(data=b"", packet_type=OW_RESP):
+    data = bytes(data)
+    return SimpleNamespace(packetType=packet_type, data=data, data_len=len(data))
+
+
+def test_i2c_scan_success_returns_address_list():
+    sensor = _make_sensor(_resp(b"\x29\x68"))
+    assert sensor.i2c_scan() == [0x29, 0x68]
+
+
+def test_i2c_scan_error_returns_false_identity():
+    sensor = _make_sensor(_resp(packet_type=OW_ERROR))
+    assert sensor.i2c_scan() is False
+
+
+def test_creset_error_returns_false_identity():
+    sensor = _make_sensor(_resp(packet_type=OW_ERROR))
+    assert sensor.creset(True) is False
+
+
+def test_i2c_write_error_returns_false_identity():
+    sensor = _make_sensor(_resp(packet_type=OW_ERROR))
+    assert sensor.i2c_write(0x40, b"\x01") is False
+
+
+def test_i2c_read_error_returns_false_identity():
+    sensor = _make_sensor(_resp(packet_type=OW_ERROR))
+    assert sensor.i2c_read(0x40, 4) is False
+
+
+@pytest.mark.parametrize("method_name", FACTORY_METHODS)
+def test_docstrings_do_not_promise_undefined_exceptions(method_name):
+    doc = getattr(MotionSensor, method_name).__doc__ or ""
+    for phantom in PHANTOM_EXCEPTIONS:
+        assert phantom not in doc, (
+            f"{method_name} docstring promises {phantom}, which is not "
+            "defined anywhere in the package"
+        )

--- a/tests/test_stream_interface_decompress.py
+++ b/tests/test_stream_interface_decompress.py
@@ -1,0 +1,55 @@
+"""Unit tests for StreamInterface's TYPE_HISTO_CMP decompression helpers.
+
+Pure software — synthesizes a compressed packet and round-trips it through
+``_decompress_histo_cmp``. Regression for the missing ``import struct``:
+every TYPE_HISTO_CMP packet raised NameError, which ``_process_packet``
+logged as a generic "decompression FAILED" and silently dropped.
+"""
+import struct
+
+from omotion.StreamInterface import (
+    _decompress_histo_cmp,
+    _rle_decompress,
+    _util_crc16,
+)
+from omotion.config import TYPE_HISTO, TYPE_HISTO_CMP
+
+
+def _rle_literal(data: bytes) -> bytes:
+    """PackBits-style literal encoding: runs of <=128 literal bytes."""
+    out = bytearray()
+    for i in range(0, len(data), 128):
+        chunk = data[i : i + 128]
+        out.append(len(chunk) - 1)
+        out += chunk
+    return bytes(out)
+
+
+def _build_cmp_packet(payload: bytes) -> bytes:
+    """Build a TYPE_HISTO_CMP packet the way the firmware frames one.
+
+    Layout: [SOF, type, size:4][compressed][UNCMP_CRC16][PKT_CRC16][0xDD],
+    with both CRCs computed over range-minus-last-byte to match the
+    firmware's (and _decompress_histo_cmp's) off-by-one convention.
+    """
+    compressed = _rle_literal(payload)
+    uncmp_crc = struct.pack("<H", _util_crc16(payload[:-1]))
+    total = 6 + len(compressed) + 2 + 3
+    header = struct.pack("<BBI", 0xAA, TYPE_HISTO_CMP, total)
+    body = header + compressed + uncmp_crc
+    pkt_crc = struct.pack("<H", _util_crc16(body[:-1]))
+    return body + pkt_crc + b"\xDD"
+
+
+def test_rle_literal_roundtrip():
+    data = bytes(range(64)) * 3
+    assert _rle_decompress(_rle_literal(data)) == data
+
+
+def test_decompress_histo_cmp_rebuilds_type_histo_packet():
+    payload = bytes((i * 7) % 251 for i in range(300))
+    rebuilt = _decompress_histo_cmp(_build_cmp_packet(payload))
+    assert rebuilt[0] == 0xAA
+    assert rebuilt[1] == TYPE_HISTO
+    assert rebuilt[-1] == 0xDD
+    assert rebuilt[6:-3] == payload


### PR DESCRIPTION
Refs #120.

## What

Fixes the correctness bugs found by a Google-Python-style-guide audit of the `omotion` package (every finding was re-validated line-by-line against source before fixing):

| Fix | Site |
|---|---|
| Add missing `import struct` — every `TYPE_HISTO_CMP` packet raised `NameError`, misreported by the broad catch in `_process_packet` as a generic "decompression FAILED" and dropped | `StreamInterface.py` |
| `raise ValueError(msg, response=r)` → `CommandError` — built-in `ValueError` takes no kwargs, so the real short-response error surfaced as a confusing `TypeError` | `MotionConsole.py` (UFM read page, READ_STATUS) |
| `get_lsync_pulsecount` re-raises like its fsync sibling instead of swallowing the exception and falling through to an implicit `None` (breaking `-> int`) | `MotionConsole.py` |
| Companion: `_read_analog` tolerates an lsync failure locally, so one bad read can't fail the whole telemetry snapshot (the tolerance used to live inside the swallow this PR removes) | `ConsoleTelemetry.py` |
| `tec_status` demo mode returns `"%.6f"` strings matching the real path (was floats, violating the declared tuple type) | `MotionConsole.py` |
| `fpga_prog_read_status` demo mode returns `0`, not `None` — callers bit-shift the result | `MotionConsole.py` |
| Factory-command signatures/docstrings now tell the truth: `-> bytes \| Literal[False]` etc., and the phantom `Raises: OWNotConnectedError/OWCommunicationError/OWDeviceError` lines are gone (those exception types were never defined anywhere in the package) | `MotionSensor.py` |
| Both calibration safety watchdogs log via `logger.exception` when their emergency `cancel_scan()` raises, instead of `except Exception: pass` | `CalibrationWorkflow.py` |
| `flush()` precondition raises `RuntimeError` instead of `assert` (stripped under `python -O`, which would let a caller bug silently corrupt the emitted interval) | `pipeline/stages/dark.py` |
| Unconditional `print("[DEBUG] ...")` on every FPGA-programming run → `logger.debug` | `jedecParser.py` |
| Missing `@staticmethod` on `read_csv_to_i2c_packets` — instance calls mis-bound the CSV path to `self` | `i2c_packet.py` |
| Stale docstrings referencing nonexistent `SerialTransport`/`HardwareAPI`; vestigial `sys.path.insert` hack removed (it inserted site-packages' *parent* dir in installed environments) | `FPGAProgrammer.py` |
| Dead duplicate VID/PID constants deleted (`config.py` is the canonical source; only the archived CLI referenced them, and it is already broken for unrelated reasons) | `utils.py` |
| Misc: stray `r.print_packet()` in `read_pdu_mon` commented out to match all siblings; lone `print()` and one f-string log call converted to lazy `%s`-style logging; two inert triple-quoted strings converted to comments | `MotionConsole.py` |

## Why the False-on-error returns were kept

The audit originally flagged the six `MotionSensor` factory commands for returning `False` where their signatures promised `bytes`/`list`/`int`. Caller investigation showed that contract is **load-bearing**: `NvcmProgrammer._SensorI2CDriver` error-detects with `is False` identity checks in the one-time-programmable NVCM burn path, and `test_i2c_read_register.py` explicitly asserts it. Changing the returns risked un-detected write failures during a permanent burn, so the annotations and docstrings were corrected to match the (deliberate) behavior instead — and NvcmProgrammer's "despite its docstring claiming it raises" comments are updated now that the docstrings are honest.

## Testing

- 16 new hardware-free regression tests, written first and watched fail (TDD), covering every behavioral change: synthetic compressed-packet round-trip, demo-mode return types, lsync re-raise + poller tolerance, CommandError on short responses, `read_pdu_mon` print suppression, flush precondition, jedec stdout silence, i2c_packet instance call, factory-contract pins + phantom-exception docstring guard.
- Full software-only suite: `pytest tests/ -m "not console and not sensor and not destructive"` → **546 passed, 29 skipped, 0 failed** (176 deselected = hardware-marked).

## Reviewer notes

- Two deliberate behavior changes to eyeball: `get_lsync_pulsecount` now **raises** on transport errors (only production caller was ConsoleTelemetry, patched here; the hardware tests in `test_console.py`/`test_sequences.py` call it on a healthy link), and demo-mode `tec_status`/`fpga_prog_read_status` return types changed to match their real paths.
- The `struct` fix is exercised by a synthetic-packet test but hasn't been verified against real compressed-histogram streaming (`DEBUG_FLAG_HISTO_CMP`) on hardware — worth a bench check next time the compression branch is exercised.
- Not touched (follow-up material): `fpga_prog_write_feature_row`'s demo branch logs a copy-pasted "simulating fpga read status" message; the broader style-audit cleanups (f-string logging sweep, remaining silent excepts, `from .config import *`) are tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
