### PR TITLE
feat: expose low_light_rt flag on FrameBatch from the dark stage

### DIFF
--- a/omotion/pipeline/batch.py
+++ b/omotion/pipeline/batch.py
@@ -186,7 +186,7 @@ class FrameBatch:
       NoiseFloor:      (mutates raw_histograms in place — no new field)
       Moments:         mean_raw, std_raw, contrast_raw
       PedestalSubtraction: subtracted_mean
-      DarkCorrection:  dark_baseline_rt, mean_dc_rt, std_dc_rt
+      DarkCorrection:  dark_baseline_rt, mean_dc_rt, std_dc_rt, low_light_rt
                        (also appends IntervalClosed to events when interval closes)
       ShotNoise:       std_sn_rt, contrast_sn_rt
       BfiBvi:          bfi_live, bvi_live
@@ -296,6 +296,16 @@ class FrameBatch:
     # (N, 2, 8) float32 — dark-corrected std: sqrt(max(0, raw_var -
     # predicted_dark_var)). Realtime estimate. NaN during warmup.
     std_dc_rt:        Optional[np.ndarray] = None
+
+    # (N, 2, 8) bool — True where a LIGHT-typed frame's raw mean was at or
+    # below pedestal + max_above_pedestal, i.e. the camera received no
+    # meaningful light (sensor covered / off target / laser-off artifact).
+    # For these slots DarkCorrectionStage suppresses realtime emission
+    # (mean_dc_rt stays NaN), so this flag is the only way consumers can
+    # distinguish "frame arrived but unlit" from "no prediction yet"
+    # (warmup). Always False for scheduled dark frames — those are expected
+    # to be unlit. None until DarkCorrectionStage runs.
+    low_light_rt:     Optional[np.ndarray] = None
 
     # ── ShotNoiseCorrectionStage outputs ─────────────────────────────────
 

--- a/omotion/pipeline/stages/dark.py
+++ b/omotion/pipeline/stages/dark.py
@@ -368,7 +368,9 @@ class DarkCorrectionStage:
 
     Per non-dark frame: populates batch.dark_baseline_rt, batch.mean_dc_rt,
     batch.std_dc_rt using HybridRealtimePredictor (NaN where no prediction
-    is available — the warmup window).
+    is available — the warmup window), and batch.low_light_rt (True where a
+    light-typed frame's u1 sat at/below pedestal + max_above_pedestal, so
+    realtime emission was suppressed — covered sensor or laser-off artifact).
 
     Per dark frame: runs the integrity guard, appends to DarkHistory + the
     appropriate PendingInterval, and emits an IntervalClosed event when an
@@ -439,6 +441,7 @@ class DarkCorrectionStage:
         baseline_rt = np.full((n, 2, 8), np.nan, dtype=np.float32)
         mean_dc_rt  = np.full((n, 2, 8), np.nan, dtype=np.float32)
         std_dc_rt   = np.full((n, 2, 8), np.nan, dtype=np.float32)
+        low_light_rt = np.zeros((n, 2, 8), dtype=bool)
 
         for i in range(n):
             ftype = str(batch.frame_type[i])
@@ -502,6 +505,10 @@ class DarkCorrectionStage:
                 pedestal = (self._pedestals.left if side == "left"
                             else self._pedestals.right)
                 dark_like = u1 <= pedestal + self._guard.max_above_pedestal
+                # Surface the classification so consumers can tell "frame
+                # arrived but unlit" (covered sensor, laser-off artifact)
+                # apart from warmup NaN. See FrameBatch.low_light_rt.
+                low_light_rt[i, side_idx, cam_id] = dark_like
 
                 pred = None
                 if not dark_like:
@@ -543,6 +550,7 @@ class DarkCorrectionStage:
         batch.dark_baseline_rt = baseline_rt
         batch.mean_dc_rt = mean_dc_rt
         batch.std_dc_rt = std_dc_rt
+        batch.low_light_rt = low_light_rt
         return batch
 
     def reset(self) -> None:

--- a/tests/test_pipeline/test_dark_correction_stage.py
+++ b/tests/test_pipeline/test_dark_correction_stage.py
@@ -119,6 +119,52 @@ def test_dark_like_light_frame_suppresses_realtime_emission():
     assert np.isnan(batch.dark_baseline_rt[2, 0, 0])
 
 
+def test_low_light_rt_flags_unlit_light_frames_only():
+    """low_light_rt distinguishes "frame arrived but unlit" (covered sensor,
+    laser-off artifact) from warmup NaN. It must be True exactly for
+    light-typed frames whose u1 is within the dark-integrity threshold, and
+    False for genuine light frames and scheduled dark frames (expected to
+    be unlit)."""
+    # dark@10 (u1=65), genuine light@11 (u1=500), dark-like light@12 (u1=66).
+    mean = np.array([[65.0], [500.0], [66.0]], dtype=np.float32).reshape(3, 1, 1) * np.ones((1, 2, 8))
+    std  = np.array([[10.0], [20.0], [11.0]], dtype=np.float32).reshape(3, 1, 1) * np.ones((1, 2, 8))
+    batch = _batch(3, ["dark", "light", "light"], [10, 11, 12],
+                   mean_raw=mean.astype(np.float32), std_raw=std.astype(np.float32))
+
+    stage = DarkCorrectionStage(
+        realtime_estimator=HybridRealtimePredictor(),
+        batch_estimator=LinearInterpolation(),
+    )
+    stage.process(batch)
+
+    assert batch.low_light_rt is not None
+    assert not batch.low_light_rt[0, 0, 0]   # scheduled dark — not flagged
+    assert not batch.low_light_rt[1, 0, 0]   # genuine light — not flagged
+    assert batch.low_light_rt[2, 0, 0]       # unlit light frame — flagged
+    # Slots for cameras that never appear in the batch stay False.
+    assert not batch.low_light_rt[:, 1, :].any()
+
+
+def test_low_light_rt_all_frames_covered_sensor():
+    """A covered sensor streams light-typed frames that are all unlit —
+    every one must be flagged so liveness consumers can tell the camera is
+    alive (frames arriving) even though nothing is plottable."""
+    mean = np.full((4, 2, 8), 66.0, dtype=np.float32)   # pedestal 64 + 2
+    std  = np.full((4, 2, 8), 10.0, dtype=np.float32)
+    batch = _batch(4, ["light", "light", "light", "light"], [11, 12, 13, 14],
+                   mean_raw=mean, std_raw=std)
+
+    stage = DarkCorrectionStage(
+        realtime_estimator=HybridRealtimePredictor(),
+        batch_estimator=LinearInterpolation(),
+    )
+    stage.process(batch)
+
+    assert batch.low_light_rt[:, 0, 0].all()
+    # And realtime emission stays suppressed (NaN), per the existing rule.
+    assert np.isnan(batch.mean_dc_rt[:, 0, 0]).all()
+
+
 def test_emits_corrected_interval():
     """DarkCorrectionStage emits raw CorrectedInterval (enrichment is done
     by downstream stages ShotNoiseCorrectionStage and BfiBviStage)."""


### PR DESCRIPTION
## Summary

The dark stage already classifies light-typed frames as "dark-like" (`u1 <= pedestal + max_above_pedestal`) to suppress realtime emission, but threw the classification away. Consumers couldn't distinguish **"frame arrived but unlit"** (covered sensor, off target, terminal laser-off artifact) from **"no prediction yet"** (warmup) — both present as NaN in `mean_dc_rt` and everything downstream.

This PR surfaces it as `FrameBatch.low_light_rt`: an (N, 2, 8) bool mask set only for light-typed rows. Scheduled dark frames stay `False` (they are *expected* to be unlit).

## Why

Investigated on 2026-07-01 bench scans: the bloodflow app's camera-dropout watchdog keyed liveness to finite BFI, so covered sensors were misdiagnosed as camera dropouts ("no data for >2 s") and permanently suppressed — while frame delivery was provably lossless (48,330/48,330 frames, 0 overruns). With this flag, apps key liveness on frame arrival and report "low light" as its own condition. Companion PR: OpenwaterHealth/openmotion-bloodflow-app `feature/arrival-based-dropout`.

## Changes

- `omotion/pipeline/batch.py` — new `low_light_rt` field + field-ownership doc
- `omotion/pipeline/stages/dark.py` — populate the mask where `dark_like` is computed
- `tests/test_pipeline/test_dark_correction_stage.py` — 2 new tests (single unlit frame; fully covered sensor)

## Testing

- `pytest tests/test_pipeline` — 232 passed, 30 skipped (3 pre-existing benchmark env errors, present on clean `next`)
- Live 10-minute hardware scan (right sensor, FW 1.8.1-rc.2) with the companion app branch: covered camera correctly reported "low light" while staying tracked; 24,012/24,012 frames delivered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
