### PR TITLE
fix: bump requests to >=2.33.0 (CVE-2026-25645)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
   "matplotlib>=3.8,<4",
   "pyusb>=1.3.1",
   "libusb1>=3.3.1",
-  "requests>=2.32.5",
+  "requests>=2.33.0",
 ]
 
 classifiers = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ matplotlib==3.10.1
 pyusb==1.3.1
 libusb1==3.3.1
 keyboard==0.13.5
-requests==2.32.5
+requests==2.33.0


### PR DESCRIPTION
Fixes #44

Clears Dependabot alert [GHSA-gc5v-m9x4-r6x2](https://github.com/advisories/GHSA-gc5v-m9x4-r6x2) / [CVE-2026-25645](https://nvd.nist.gov/vuln/detail/CVE-2026-25645) (`requests.utils.extract_zipped_paths` predictable temp filename, fixed in requests 2.33.0).

## Changes
- `pyproject.toml`: `requests>=2.32.5` → `requests>=2.33.0`
- `requirements.txt`: `requests==2.32.5` → `requests==2.33.0`

## Exposure
None today — `grep -rn extract_zipped_paths omotion/ scripts/ tests/` finds no callers (the SDK only uses plain `requests.get` in `omotion/GitHubReleases.py`). This is hygiene to clear the alert.

## Verification
- Fresh throwaway venv (Python 3.13.5): `pip install -e .` succeeds and resolves `requests 2.34.2` under the new floor; `import requests, omotion` works.
- Confirmed `2.33.0` exists on PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)