### PR TITLE
feat: DEBUG_FLAG_HISTO_STALL (0x100) constant for sensor-fw histo-stall repro flag

### DIFF
--- a/omotion/MotionSensor.py
+++ b/omotion/MotionSensor.py
@@ -905,6 +905,9 @@ class MotionSensor(SignalWrapper):
         Bit 5 (DEBUG_FLAG_CMD_VERBOSE) enables printf in command handlers.
         Bit 7 (DEBUG_FLAG_SEND_DEFER) defers the per-frame histogram send out
         of the FSIN ISR into the main loop (sensor-fw#68).
+        Bit 8 (DEBUG_FLAG_HISTO_STALL) stops histogram sends after ~45 s of
+        streaming while USB stays alive — deterministic camera-stall repro
+        (sensor-fw#75).
         """
         if self.demo_mode:
             return True

--- a/omotion/config.py
+++ b/omotion/config.py
@@ -158,6 +158,7 @@ DEBUG_FLAG_HISTO_CMP = 0x40  # Send compressed histogram packets (TYPE_HISTO_CMP
 DEBUG_FLAG_COMM_VERBOSE = 0x10  # Enable cmd id and "." response prints in uart_comms
 DEBUG_FLAG_CMD_VERBOSE = 0x20  # Enable printf in command handlers (if_commands.c)
 DEBUG_FLAG_SEND_DEFER = 0x80  # Defer per-frame histogram send out of the FSIN ISR into the main loop (sensor-fw#68)
+DEBUG_FLAG_HISTO_STALL = 0x100  # Stop sending histogram frames after ~45 s while USB stays alive — deterministic camera-stall repro (sensor-fw#75)
 
 # Controller Commands
 OW_CTRL_I2C_SCAN = 0x10


### PR DESCRIPTION
Refs OpenwaterHealth/openmotion-sensor-fw#75. Companion to firmware PR OpenwaterHealth/openmotion-sensor-fw#76.

Adds the `DEBUG_FLAG_HISTO_STALL = 0x100` constant to `omotion/config.py` (and a line in the `set_debug_flags` docstring). The firmware flag makes a sensor stop sending histogram frames after ~45 s of streaming while USB and everything else stays alive — a deterministic bench repro of the silent camera-stall signature for testing the bloodflow app's E-303 watchdog (app#248/app#174/PR app#294).

No new command path: the flag rides the existing `OW_CMD_DEBUG_FLAGS` u32 bitmask (`struct.pack('<I', flags)`), same as every other `DEBUG_FLAG_*` bit. **Both-repos bit check:** sensor-fw `common.h` and SDK `config.py` on `next` agree on bits 0–7 (no drift); bit 8 was free in both — the u8 range is full but the wire format is u32.

Constants only, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)