### PR TITLE
feat: dark-correction bypass mode for scans (continuous bench illumination)

### DIFF
--- a/omotion/ScanWorkflow.py
+++ b/omotion/ScanWorkflow.py
@@ -135,6 +135,14 @@ class ScanRequest:
     # bfi_left, bfi_right, bvi_left, bvi_right columns.  Uncorrected
     # samples emitted to the UI are also averaged per-side per-frame.
     reduced_mode: bool = False
+    # Engineering bench mode (issue #134): bypass the dark subsystem for
+    # this scan — the scheduled laser-skip frames are not dark (continuous
+    # external illumination), so realtime + batch corrections use a static
+    # pedestal baseline, dark-frame integrity warnings are disabled, and
+    # the terminal flush closes unconditionally. Recorded values are
+    # raw − pedestal and the DB session is marked. Set only from
+    # developer/engineering UIs; clinical scans must leave this False.
+    dark_correction_bypass: bool = False
     # Pipeline sinks list — will be injected by the runner at start_scan time.
     # Normally managed by the SDK at MotionInterface construction (data_dir, scan_db_path).
     sinks: list = field(default_factory=list)
@@ -412,6 +420,13 @@ class ScanWorkflow:
             self._running = True
 
         logger.info("start_scan: building pipeline for new scan")
+        if request.dark_correction_bypass:
+            logger.warning(
+                "DARK CORRECTION BYPASSED for this scan (engineering bench "
+                "mode): values are raw minus pedestal; dark-frame integrity "
+                "checks and terminal-dark handling are disabled. Not valid "
+                "clinical data."
+            )
         self._stop_evt = threading.Event()
 
         # ── Build ScanMetadata ────────────────────────────────────────────
@@ -426,6 +441,7 @@ class ScanWorkflow:
             left_camera_mask=request.left_camera_mask,
             right_camera_mask=request.right_camera_mask,
             reduced_mode=request.reduced_mode,
+            dark_correction_bypass=request.dark_correction_bypass,
         )
         # Mirror ScanDBSink.on_scan_start's label so callers can bind to this
         # exact session row (must match f"{scan_id}_{subject_id}" there).

--- a/omotion/pipeline/factory.py
+++ b/omotion/pipeline/factory.py
@@ -80,6 +80,7 @@ def default_pipeline(*,
             batch_estimator=LinearInterpolation(),
             pedestals=pedestals,
             realtime_history_size=realtime_dark_history_size,
+            bypass=metadata.dark_correction_bypass,
         ),
 
         ShotNoiseCorrectionStage(pedestals=pedestals, camera_gain_map=CAMERA_GAIN_MAP),

--- a/omotion/pipeline/sinks.py
+++ b/omotion/pipeline/sinks.py
@@ -33,6 +33,10 @@ class ScanMetadata:
     left_camera_mask:  int
     right_camera_mask: int
     reduced_mode:      bool
+    # Engineering bench mode (issue #134): dark correction bypassed for this
+    # scan — DarkCorrectionStage uses a static pedestal baseline and the
+    # recorded values are raw − pedestal, not dark-corrected.
+    dark_correction_bypass: bool = False
 
 
 @runtime_checkable
@@ -625,6 +629,11 @@ class ScanDBSink:
                 "right_camera_mask": meta.right_camera_mask,
             },
         }
+        if meta.dark_correction_bypass:
+            # Permanent marker: this session's values are raw − pedestal,
+            # not dark-corrected (issue #134). Readers treat a missing key
+            # as a normal, dark-corrected session.
+            self._session_meta["dark_correction"] = "bypassed"
         self._session_id = self._db.create_session(
             session_label=label,
             session_start=time.time(),

--- a/omotion/pipeline/stages/dark.py
+++ b/omotion/pipeline/stages/dark.py
@@ -396,7 +396,8 @@ class DarkCorrectionStage:
                  batch_estimator: LinearInterpolation,
                  pedestals: Optional[SensorPedestals] = None,
                  realtime_history_size: int = 4,
-                 integrity_max_above_pedestal: float = 5.0):
+                 integrity_max_above_pedestal: float = 5.0,
+                 bypass: bool = False):
         self._realtime = realtime_estimator
         self._batch = batch_estimator
         self._pedestals = pedestals or SensorPedestals(left=64.0, right=64.0)
@@ -407,6 +408,12 @@ class DarkCorrectionStage:
         )
         self._last_realtime: dict[tuple[str, int], tuple[float, float, float]] = {}
         self._terminal_fsync_count: Optional[int] = None
+        # Engineering bench mode (issue #134): the scheduled laser-skip
+        # frames are NOT dark (continuous external illumination). Realtime
+        # + batch use a static zero-dark baseline (u1=pedestal, var=0), the
+        # integrity guard is silenced, and on_scan_stop closes the final
+        # interval unconditionally.
+        self._bypass = bool(bypass)
 
     def set_terminal_fsync_count(self, count: int) -> None:
         """Ground-truth index of the final FSYNC pulse, from the console
@@ -469,21 +476,27 @@ class DarkCorrectionStage:
 
                 pedestal = (self._pedestals.left if side == "left"
                             else self._pedestals.right)
-                self._guard.check(
-                    side=side, cam_id=cam_id, abs_frame_id=abs_id,
-                    u1=u1, pedestal=pedestal, events=batch.events,
-                )
-                self._history.append(side, cam_id, t=t, u1=u1, std=std)
+                if self._bypass:
+                    # Bypass: the frame is not dark — no guard, no history.
+                    # It still bounds intervals, with a synthetic zero-dark
+                    # observation so batch correction subtracts only the
+                    # static pedestal (baseline_var = 0).
+                    obs = DarkObservation(t=t, u1=pedestal, std=0.0)
+                else:
+                    self._guard.check(
+                        side=side, cam_id=cam_id, abs_frame_id=abs_id,
+                        u1=u1, pedestal=pedestal, events=batch.events,
+                    )
+                    self._history.append(side, cam_id, t=t, u1=u1, std=std)
+                    obs = DarkObservation(t=t, u1=u1, std=std)
 
                 pi = self._pending.get((side, cam_id))
                 if pi is None:
                     pi = PendingInterval()
                     self._pending[(side, cam_id)] = pi
-                    pi.set_left_dark(DarkObservation(t=t, u1=u1, std=std),
-                                     abs_frame_id=abs_id)
+                    pi.set_left_dark(obs, abs_frame_id=abs_id)
                 else:
-                    pi.set_right_dark(DarkObservation(t=t, u1=u1, std=std),
-                                      abs_frame_id=abs_id)
+                    pi.set_right_dark(obs, abs_frame_id=abs_id)
                     if pi.is_closed():
                         interval = pi.flush()
                         # After flush, pi's left has rolled to the just-flushed right.
@@ -512,9 +525,15 @@ class DarkCorrectionStage:
 
                 pred = None
                 if not dark_like:
-                    pred = self._realtime.predict(
-                        side, cam_id, history=self._history, target_t=t,
-                    )
+                    if self._bypass:
+                        # Static zero-dark baseline — same math as a
+                        # prediction of (pedestal, 0.0), so downstream
+                        # variance/std handling is unchanged.
+                        pred = (pedestal, 0.0)
+                    else:
+                        pred = self._realtime.predict(
+                            side, cam_id, history=self._history, target_t=t,
+                        )
                 if pred is not None:
                     u1_hat, std_hat = pred
                     baseline_rt[i, side_idx, cam_id] = np.float32(u1_hat)
@@ -582,7 +601,15 @@ class DarkCorrectionStage:
           4. Call _emit_interval with the remaining lights (which may be empty).
              The stencil for D_prev is applied as normal; if there are no lights,
              D_prev cannot be stencilled (no right neighbours) and is skipped.
+
+        In bypass mode (engineering bench source, issue #134) none of the
+        content/fsync machinery applies — _flush_terminal_bypass promotes
+        the last buffered frame unconditionally.
         """
+        if self._bypass:
+            self._flush_terminal_bypass(batch)
+            return
+
         expected_abs = (
             None if self._terminal_fsync_count is None
             else self._terminal_fsync_count + _TERMINAL_FSYNC_ABS_OFFSET
@@ -708,3 +735,36 @@ class DarkCorrectionStage:
 
             # _emit_interval applies the stencil for D_prev and emits the event.
             self._emit_interval((side, cam_id), interval, batch.events)
+
+    def _flush_terminal_bypass(self, batch: FrameBatch) -> None:
+        """Bypass terminal flush — no dark-like content exists (continuous
+        illumination source), so the single last buffered frame per
+        (side, cam) is promoted to the terminal boundary with the synthetic
+        zero-dark observation. No content checks, no fsync matching, no
+        MISSING/CONTAMINATED errors; the final interval always closes."""
+        closed = 0
+        for (side, cam_id), pi in self._pending.items():
+            if not pi._light:
+                continue
+            terminal = pi._light[-1]
+            pi._light = pi._light[:-1]
+            pedestal = (self._pedestals.left if side == "left"
+                        else self._pedestals.right)
+            batch.events.append(TerminalDarkResult(
+                side=side, cam_id=cam_id,
+                abs_frame_id=terminal.abs_frame_id,
+                u1=terminal.u1,
+                threshold=pedestal + self._guard.max_above_pedestal,
+                found=True, identified_by="bypass",
+            ))
+            pi.set_right_dark(
+                DarkObservation(t=terminal.t, u1=pedestal, std=0.0),
+                abs_frame_id=terminal.abs_frame_id,
+            )
+            self._emit_interval((side, cam_id), pi.flush(), batch.events)
+            closed += 1
+        if closed:
+            logger.info(
+                "bypass terminal flush: closed %d interval(s) at the last "
+                "buffered frame (dark correction bypassed)", closed,
+            )

--- a/tests/test_pipeline/test_dark_bypass.py
+++ b/tests/test_pipeline/test_dark_bypass.py
@@ -1,0 +1,152 @@
+"""DarkCorrectionStage bypass mode (issue #134) — engineering bench sources
+that never turn off. Scheduled laser-skip frames are NOT dark, so bypass
+replaces dark subtraction with a static pedestal baseline, silences the
+integrity guard, and closes the terminal interval unconditionally.
+Default pedestals are 64.0/64.0 (SensorPedestals default in the stage).
+"""
+
+import logging
+
+import numpy as np
+import pytest
+from omotion.pipeline.batch import (
+    DarkIntegrityWarning, FrameBatch, IntervalClosed, TerminalDarkResult,
+)
+from omotion.pipeline.stages.dark import (
+    DarkCorrectionStage, HybridRealtimePredictor, LinearInterpolation,
+)
+
+
+def _batch(n_frames, frame_types, abs_ids, *, mean_raw, std_raw):
+    """Minimal FrameBatch — only side=0 cam=0 populated (mirrors
+    test_dark_correction_stage._batch)."""
+    n = n_frames
+    raw_hist = np.zeros((n, 2, 8, 1024), dtype=np.uint32)
+    if n:
+        raw_hist[:, 0, 0, 0] = 1
+    return FrameBatch(
+        cam_ids=np.zeros(n, dtype=np.int8),
+        frame_ids=np.arange(n, dtype=np.uint8),
+        side_ids=np.zeros(n, dtype=np.int8),
+        raw_histograms=raw_hist,
+        temperature_c=np.zeros((n, 2, 8), dtype=np.float32),
+        timestamp_s=np.arange(n, dtype=np.float64) * 0.025,
+        pdc=None, tcm=None, tcl=None,
+        abs_frame_ids=np.array(abs_ids, dtype=np.int64),
+        frame_type=np.array(frame_types, dtype="<U8"),
+        mean_raw=mean_raw, std_raw=std_raw,
+    )
+
+
+def _stage(bypass):
+    return DarkCorrectionStage(
+        realtime_estimator=HybridRealtimePredictor(),
+        batch_estimator=LinearInterpolation(),
+        bypass=bypass,
+    )
+
+
+def _uniform(n, mean, std):
+    return (np.full((n, 2, 8), mean, dtype=np.float32),
+            np.full((n, 2, 8), std, dtype=np.float32))
+
+
+def test_bypass_realtime_emits_from_first_light_frame():
+    """No warmup window: baseline is the static pedestal (64), so the very
+    first light frame emits mean_dc_rt = u1 - 64 and std_dc_rt = raw std."""
+    mean, std = _uniform(3, 500.0, 10.0)
+    batch = _batch(3, ["light"] * 3, [11, 12, 13], mean_raw=mean, std_raw=std)
+    _stage(bypass=True).process(batch)
+    assert batch.mean_dc_rt[0, 0, 0] == pytest.approx(436.0)
+    assert batch.std_dc_rt[0, 0, 0] == pytest.approx(10.0)
+    assert batch.dark_baseline_rt[0, 0, 0] == pytest.approx(64.0)
+
+
+def test_bypass_no_integrity_warning_on_lit_dark_frames(caplog):
+    """A lit scheduled dark frame (u1=500 >> pedestal+5) raises no
+    DarkIntegrityWarning event and no 'brighter than expected' log."""
+    mean, std = _uniform(3, 500.0, 10.0)
+    batch = _batch(3, ["dark", "light", "dark"], [10, 11, 12],
+                   mean_raw=mean, std_raw=std)
+    with caplog.at_level(logging.WARNING,
+                         logger="openmotion.sdk.pipeline.stages.dark"):
+        _stage(bypass=True).process(batch)
+    assert [e for e in batch.events
+            if isinstance(e, DarkIntegrityWarning)] == []
+    assert "brighter than expected" not in caplog.text
+
+
+def test_bypass_interval_baseline_is_pedestal():
+    """Interval closes on the positional darks, but correction uses the
+    synthetic zero-dark boundary: mean = u1 - pedestal, std = raw std."""
+    n = 4
+    mean = np.array([500.0, 500.0, 510.0, 500.0], dtype=np.float32) \
+        .reshape(4, 1, 1) * np.ones((1, 2, 8), dtype=np.float32)
+    std = np.array([10.0, 20.0, 22.0, 10.0], dtype=np.float32) \
+        .reshape(4, 1, 1) * np.ones((1, 2, 8), dtype=np.float32)
+    batch = _batch(n, ["dark", "light", "light", "dark"], [10, 11, 12, 14],
+                   mean_raw=mean.astype(np.float32),
+                   std_raw=std.astype(np.float32))
+    _stage(bypass=True).process(batch)
+
+    closed = [e for e in batch.events if isinstance(e, IntervalClosed)]
+    assert len(closed) == 1
+    frames = {f.abs_frame_id: f for f in closed[0].corrected_batch.frames}
+    assert frames[11].mean == pytest.approx(500.0 - 64.0)
+    assert frames[11].std == pytest.approx(20.0)
+    assert frames[12].mean == pytest.approx(510.0 - 64.0)
+    assert frames[12].std == pytest.approx(22.0)
+
+
+def test_bypass_dark_like_light_suppression_still_active():
+    """A genuinely unlit light frame (covered sensor) still suppresses
+    realtime emission and flags low_light_rt, exactly as in normal mode."""
+    mean = np.array([500.0, 66.0], dtype=np.float32) \
+        .reshape(2, 1, 1) * np.ones((1, 2, 8), dtype=np.float32)
+    std = np.array([20.0, 11.0], dtype=np.float32) \
+        .reshape(2, 1, 1) * np.ones((1, 2, 8), dtype=np.float32)
+    batch = _batch(2, ["light", "light"], [11, 12],
+                   mean_raw=mean.astype(np.float32),
+                   std_raw=std.astype(np.float32))
+    _stage(bypass=True).process(batch)
+    assert batch.mean_dc_rt[0, 0, 0] == pytest.approx(436.0)
+    assert np.isnan(batch.mean_dc_rt[1, 0, 0])
+    assert batch.low_light_rt[1, 0, 0]
+
+
+def test_bypass_terminal_flush_closes_without_errors(caplog):
+    """Scan stop with a fully lit tail: the last buffered frame becomes the
+    terminal boundary (synthetic obs), the interval closes, and there are no
+    TERMINAL DARK errors. TerminalDarkResult reports found=True/bypass."""
+    mean, std = _uniform(3, 500.0, 20.0)
+    stage = _stage(bypass=True)
+    stage.process(_batch(3, ["dark", "light", "light"], [10, 11, 12],
+                         mean_raw=mean, std_raw=std))
+
+    stop_batch = _batch(0, [], [],
+                        mean_raw=np.zeros((0, 2, 8), dtype=np.float32),
+                        std_raw=np.zeros((0, 2, 8), dtype=np.float32))
+    with caplog.at_level(logging.ERROR,
+                         logger="openmotion.sdk.pipeline.stages.dark"):
+        stage.on_scan_stop(stop_batch)
+
+    assert "TERMINAL DARK" not in caplog.text
+    closed = [e for e in stop_batch.events if isinstance(e, IntervalClosed)]
+    assert len(closed) == 1
+    # Interval [10, 12] with light 11: mean = 500 - 64.
+    frames = {f.abs_frame_id: f for f in closed[0].corrected_batch.frames}
+    assert frames[11].mean == pytest.approx(436.0)
+    tdr = [e for e in stop_batch.events if isinstance(e, TerminalDarkResult)]
+    assert len(tdr) == 1
+    assert tdr[0].found is True
+    assert tdr[0].identified_by == "bypass"
+
+
+def test_default_stage_is_not_bypassed():
+    """bypass defaults False; normal-mode behavior is covered by the
+    existing test_dark_correction_stage.py suite."""
+    stage = DarkCorrectionStage(
+        realtime_estimator=HybridRealtimePredictor(),
+        batch_estimator=LinearInterpolation(),
+    )
+    assert stage._bypass is False

--- a/tests/test_pipeline/test_factory.py
+++ b/tests/test_pipeline/test_factory.py
@@ -141,3 +141,24 @@ def test_pipeline_order_raw_tee_before_timestamp_repair():
         f"Tee('raw') at index {raw_tee_idx} must come before "
         f"TimestampRepairStage at index {repair_idx}"
     )
+
+
+def test_default_pipeline_plumbs_dark_correction_bypass():
+    """metadata.dark_correction_bypass reaches the dark stage (issue #134);
+    default stays off."""
+    def _meta(bypass):
+        return ScanMetadata(
+            scan_id="x", subject_id="y", operator="z",
+            started_at_iso="2026-05-22T00:00:00Z", duration_sec=60,
+            left_camera_mask=0xFF, right_camera_mask=0xFF,
+            reduced_mode=False, dark_correction_bypass=bypass,
+        )
+
+    for bypass in (False, True):
+        pipeline = default_pipeline(
+            metadata=_meta(bypass), calibration=_trivial_calibration(),
+            pedestals=SensorPedestals(left=64.0, right=64.0),
+        )
+        stage = next(s for s in pipeline.stages
+                     if s.name == "dark_correction")
+        assert stage._bypass is bypass

--- a/tests/test_pipeline/test_scan_db_sink.py
+++ b/tests/test_pipeline/test_scan_db_sink.py
@@ -276,3 +276,30 @@ def test_session_data_has_quality_column(tmp_path):
     columns = {row[1] for row in cursor.fetchall()}
     assert "quality" in columns
     db.close()
+
+
+def test_scan_db_sink_marks_bypassed_sessions(tmp_path):
+    """A dark-correction-bypassed scan is permanently distinguishable:
+    session_meta carries dark_correction=bypassed (issue #134). Normal
+    scans carry no such key."""
+    def _run(db_path, bypass):
+        meta = ScanMetadata(
+            scan_id="b", subject_id="subj", operator="op",
+            started_at_iso="2026-07-10T00:00:00Z", duration_sec=300,
+            left_camera_mask=0x01, right_camera_mask=0,
+            reduced_mode=False, dark_correction_bypass=bypass,
+        )
+        sink = ScanDBSink(db_path=db_path)
+        sink.on_scan_start(meta)
+        sink.consume("final", _interval([_frame(42)]))
+        sink.on_complete()
+        conn = sqlite3.connect(db_path)
+        meta_json = conn.execute(
+            "SELECT session_meta FROM sessions").fetchone()[0]
+        conn.close()
+        return json.loads(meta_json)
+
+    bypassed = _run(str(tmp_path / "bypass.db"), True)
+    assert bypassed["dark_correction"] == "bypassed"
+    normal = _run(str(tmp_path / "normal.db"), False)
+    assert "dark_correction" not in normal


### PR DESCRIPTION
Adds an opt-in bypass of the dark subsystem for engineering bench sources that never turn off (Refs #134).

- `DarkCorrectionStage(bypass=True)`: realtime + batch use a static pedestal baseline (mean = raw − pedestal, std = raw std), integrity guard silenced, terminal flush closes the final interval unconditionally (`TerminalDarkResult(found=True, identified_by="bypass")`).
- Plumbed via `ScanRequest.dark_correction_bypass` → `ScanMetadata` → `default_pipeline`; WARNING log at scan start.
- `ScanDBSink` marks bypassed sessions: `session_meta["dark_correction"] = "bypassed"`.
- Default-off; normal-mode behavior unchanged.

Verification: 6 new stage tests + factory/DB-sink plumbing tests; full `tests/test_pipeline` suite 240 passed / 30 skipped, `tests/test_scan_workflow.py` 21 passed.

Consumed by OpenwaterHealth/openmotion-bloodflow-app#345 (dev-gated Settings toggle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)