### PR TITLE
fix: refresh libusb context on hotplug so sensor left/right stays correct

### DIFF
--- a/omotion/connection_monitor.py
+++ b/omotion/connection_monitor.py
@@ -230,8 +230,13 @@ class ConnectionMonitor(threading.Thread):
 
     def _dispatch(self, event: _Event) -> None:
         if isinstance(event, HotplugWake):
-            # OS noticed USB topology changed; figure out what before the
-            # next 200 ms tick.
+            # OS noticed USB topology changed. Drop the cached libusb context
+            # first so the sweep re-enumerates on a fresh one: a long-lived
+            # context's device list goes stale on Windows after hotplug churn
+            # (issue #139), which otherwise freezes sensor left/right
+            # detection on whatever it last saw.
+            from omotion.usb_backend import invalidate_libusb1_backend
+            invalidate_libusb1_backend()
             self._poll_sweep()
         elif isinstance(event, (IoError, PollArrived, PollGone, UserStop)):
             handle = self._handle_by_name(event.handle_name)

--- a/omotion/usb_backend.py
+++ b/omotion/usb_backend.py
@@ -30,8 +30,30 @@ def _dll_dir() -> Path | None:
     return _base_dir()
 
 
+# Module-cached libusb backend. Reused across enumeration calls so we don't
+# pay libusb_init/exit on every 200 ms poll sweep; dropped (not force-disposed)
+# on USB hotplug via invalidate_libusb1_backend() — see issue #139.
+_cached_backend = None
+
+
 def get_libusb1_backend():
+    """Return a libusb1 backend, building one on first use and after each
+    invalidation. Callers must not cache the result across a hotplug — always
+    go back through this function (the SDK's enumeration paths already do)."""
+    global _cached_backend
+    if _cached_backend is not None:
+        return _cached_backend
+
     import usb.backend.libusb1 as libusb1
+
+    # Force PyUSB to build a NEW libusb context rather than handing back its
+    # own process-wide cached singleton. That singleton's device enumeration
+    # goes stale on Windows after repeated USB hotplug churn (issue #139): a
+    # long-lived context stops reflecting sensor plug/unplug, so a sensor
+    # moved between ports keeps its old left/right label until the process
+    # restarts. We build a fresh context, cache it ourselves, and refresh it
+    # on hotplug via invalidate_libusb1_backend().
+    libusb1._lib_object = None
 
     if _is_win():
         dll_dir = _dll_dir()
@@ -45,7 +67,29 @@ def get_libusb1_backend():
             pass
 
         ctypes.CDLL(str(dll_path))  # preload for clearer errors
-        return libusb1.get_backend(find_library=lambda _: str(dll_path))
+        _cached_backend = libusb1.get_backend(
+            find_library=lambda _: str(dll_path)
+        )
+    else:
+        # Non-Windows: use system libusb via the loader
+        _cached_backend = libusb1.get_backend()
 
-    # Non-Windows: use system libusb via the loader
-    return libusb1.get_backend()
+    return _cached_backend
+
+
+def invalidate_libusb1_backend():
+    """Drop the cached libusb backend so the next :func:`get_libusb1_backend`
+    call builds a fresh context. Called on USB hotplug.
+
+    A long-lived libusb context's device list goes stale on Windows after
+    repeated plug/unplug churn (issue #139): enumeration stops reflecting
+    reality, so a sensor moved between ports keeps its old left/right label.
+
+    We only drop our reference here — we never call ``libusb_exit``. A sensor
+    handle still open on the old context keeps working (its open ``Device``
+    holds the backend alive by refcount), and that context is disposed
+    naturally once its connection closes. The next enumeration builds a fresh
+    context that sees the current topology.
+    """
+    global _cached_backend
+    _cached_backend = None

--- a/scripts/diag_sensor_usb_topology.py
+++ b/scripts/diag_sensor_usb_topology.py
@@ -1,0 +1,61 @@
+"""Read-only USB topology dump for the left/right sensor mislabel bug
+(bloodflow-app: 'sensor plugged into Left port shows as Right').
+
+MotionSensor._find_dev() identifies a sensor's side purely from
+``port_numbers[-1]`` (2 => left, 3 => right, see omotion/MotionSensor.py).
+This script performs the identical VID/PID enumeration via the SDK's own
+libusb backend, but prints the FULL port_numbers path (plus bus number)
+for every matching device instead of collapsing it to that one bit — so we
+can see exactly what the OS reports for a sensor in each physical jack,
+rather than guessing from the SDK's derived left/right label.
+
+Usage: run it TWICE, replugging between runs:
+  1. Only one sensor connected, in the jack you believe is "Left".
+  2. Only one sensor connected, in the jack you believe is "Right".
+Compare the two port_numbers outputs (not just [-1] — the whole tuple).
+
+No writes, no claims of any interface, no PING sent to the device.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import usb.core
+
+from omotion.usb_backend import get_libusb1_backend
+from omotion.config import SENSOR_MODULE_PID
+
+VID = 0x0483
+PID = SENSOR_MODULE_PID
+
+
+def main():
+    backend = get_libusb1_backend()
+    devices = list(
+        usb.core.find(find_all=True, idVendor=VID, idProduct=PID, backend=backend)
+    )
+
+    if not devices:
+        print(f"No sensor devices found (VID=0x{VID:04X} PID=0x{PID:04X}).")
+        print("Is a sensor connected and enumerated?")
+        return
+
+    print(f"Found {len(devices)} sensor device(s):\n")
+    for i, dev in enumerate(devices):
+        ports = tuple(getattr(dev, "port_numbers", []) or [])
+        bus = getattr(dev, "bus", None)
+        addr = getattr(dev, "address", None)
+        suffix = ports[-1] if ports else None
+        sdk_label = (
+            "left" if suffix == 2 else "right" if suffix == 3 else "NEITHER (unmatched by SDK)"
+        )
+        print(f"  Device #{i}:")
+        print(f"    bus={bus} address={addr}")
+        print(f"    port_numbers={ports}  (full path from root hub)")
+        print(f"    port_numbers[-1]={suffix}  -> SDK would call this: {sdk_label}")
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_connection_monitor_hotplug_invalidate.py
+++ b/tests/test_connection_monitor_hotplug_invalidate.py
@@ -1,0 +1,60 @@
+"""Issue #139: a USB hotplug event must invalidate the cached libusb backend
+before the monitor re-enumerates, so the sweep runs on a fresh context that
+reflects the new topology (a long-lived context goes stale on Windows after
+plug/unplug churn).
+
+No hardware: the sweep itself is stubbed and invalidate is spied on.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import omotion.usb_backend as usb_backend
+from omotion.connection_monitor import ConnectionMonitor, HotplugWake, PollArrived
+
+pytestmark = pytest.mark.unit
+
+
+def _make_monitor():
+    return ConnectionMonitor(
+        console=MagicMock(name="console"),
+        left=MagicMock(name="left"),
+        right=MagicMock(name="right"),
+        console_vid=0x0483,
+        console_pid=0xA53E,
+        sensor_vid=0x0483,
+        sensor_pid=0x5A5A,
+        hotplug=None,
+    )
+
+
+def test_hotplug_invalidates_backend_then_sweeps(monkeypatch):
+    monitor = _make_monitor()
+
+    calls = []
+    monkeypatch.setattr(
+        usb_backend, "invalidate_libusb1_backend",
+        lambda: calls.append("invalidate"),
+    )
+    monkeypatch.setattr(monitor, "_poll_sweep", lambda: calls.append("sweep"))
+
+    monitor._dispatch(HotplugWake())
+
+    # Invalidate must happen, and it must happen BEFORE the sweep — otherwise
+    # the sweep re-enumerates on the stale context we were trying to refresh.
+    assert calls == ["invalidate", "sweep"]
+
+
+def test_non_hotplug_events_do_not_invalidate(monkeypatch):
+    monitor = _make_monitor()
+
+    calls = []
+    monkeypatch.setattr(
+        usb_backend, "invalidate_libusb1_backend",
+        lambda: calls.append("invalidate"),
+    )
+    # A routed handle event must not touch the backend cache.
+    monitor._dispatch(PollArrived(handle_name="left"))
+
+    assert calls == []

--- a/tests/test_usb_backend_cache.py
+++ b/tests/test_usb_backend_cache.py
@@ -1,0 +1,57 @@
+"""Issue #139: the libusb backend must be cached across enumeration calls
+(so we don't churn libusb_init/exit on every 200 ms poll) but rebuilt from a
+fresh context after invalidate_libusb1_backend() (called on USB hotplug),
+because a long-lived libusb context's device list goes stale on Windows after
+repeated plug/unplug churn.
+
+Pure-logic tests: usb.backend.libusb1.get_backend is mocked, so no real
+libusb context is created and no hardware or DLL is touched.
+"""
+
+import pytest
+
+import usb.backend.libusb1 as libusb1
+
+import omotion.usb_backend as usb_backend
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache_and_backend(monkeypatch):
+    # Force the OS-independent (non-Windows) branch so the test never loads
+    # the vendored DLL; the caching logic under test is identical on both.
+    monkeypatch.setattr(usb_backend, "_is_win", lambda: False)
+    # Each get_backend() call returns a distinct sentinel so "same object"
+    # vs "new object" is observable.
+    monkeypatch.setattr(
+        libusb1, "get_backend",
+        lambda *a, **k: object(),
+    )
+    # Don't leak our None-poking into other tests' view of PyUSB.
+    monkeypatch.setattr(libusb1, "_lib_object", None, raising=False)
+    # Start every test with an empty module cache.
+    usb_backend._cached_backend = None
+    yield
+    usb_backend._cached_backend = None
+
+
+def test_backend_is_cached_across_calls():
+    first = usb_backend.get_libusb1_backend()
+    second = usb_backend.get_libusb1_backend()
+    assert first is second, "repeated calls must reuse the cached context"
+
+
+def test_invalidate_forces_a_fresh_backend():
+    first = usb_backend.get_libusb1_backend()
+    usb_backend.invalidate_libusb1_backend()
+    second = usb_backend.get_libusb1_backend()
+    assert first is not second, "invalidate must rebuild a fresh context"
+
+
+def test_calls_after_invalidate_recache():
+    usb_backend.get_libusb1_backend()
+    usb_backend.invalidate_libusb1_backend()
+    a = usb_backend.get_libusb1_backend()
+    b = usb_backend.get_libusb1_backend()
+    assert a is b, "a rebuilt context must itself be cached until next invalidate"


### PR DESCRIPTION
## Summary

Fixes [#139](https://github.com/OpenwaterHealth/openmotion-sdk/issues/139) (and the app-side report [bloodflow-app#352](https://github.com/OpenwaterHealth/openmotion-bloodflow-app/issues/352)): a sensor moved between console ports **mid-session** kept its old left/right label — a sensor physically in the LEFT jack showing as RIGHT in the app — while a fresh app launch was always correct.

## Root cause (confirmed live on the bench)

**Not** the `_port_suffix = 2/3` / `port_numbers[-1]` convention — that mapping is correct. The bug is **stale USB enumeration** in the long-lived process. PyUSB's `usb.backend.libusb1.get_backend()` returns a **process-wide cached libusb context**, and on Windows that context's device list goes **stale after repeated hotplug churn** — it stops reflecting sensor plug/unplug. `ConnectionMonitor._poll_sensors` and `MotionSensor._find_dev` both re-query but receive the same cached stale context.

Decisive evidence: with a sensor moved left→right (no restart), a **fresh standalone process** (`scripts/diag_sensor_usb_topology.py`) saw `port_numbers=(1,1,3)` → right, while the **running app** still saw `(1,1,2)` → left with **no disconnect event ever logged**. Forcing a fresh context per call made the app's poll immediately track reality; Ethan confirmed the switch then works.

## Fix

Cache one libusb backend and reuse it across the 200 ms poll sweeps (no `libusb_init/exit` churn), but **drop it on every USB hotplug** (`ConnectionMonitor._dispatch(HotplugWake)` → `invalidate_libusb1_backend()`) so the next enumeration builds a fresh context reflecting the new topology. The bench logs show a burst of poll sweeps ~22 ms apart around each replug, i.e. the Win32 hotplug reliably fires on these events, so this catches the real failure case.

`invalidate` only releases our reference — it **never calls `libusb_exit`** — so a sensor handle still open on the old context keeps working (the open `Device` holds the backend alive by refcount), and that context is disposed naturally when its connection closes.

## Testing

- New mocked unit tests (no hardware, no real libusb): `tests/test_usb_backend_cache.py` (caching + invalidation contract) and `tests/test_connection_monitor_hotplug_invalidate.py` (hotplug invalidates before sweeping; non-hotplug events don't). Written red-first.
- Full pipeline unit suite: 240 passed, 30 skipped, no regressions.
- **Bench validation still needed** (needs physical hotplug cycling): confirm a sensor moved between jacks several times in one session tracks the correct side, and that a long run with repeated replugs stays stable.

## Note on approach

Chosen (with Ethan) as *refresh-on-hotplug* over per-sweep fresh contexts (avoids 5×/s `libusb_init/exit`) and over a full enumerate/IO context split (larger change). One residual edge case: a *missed* hotplug event would leave the stale context until the next hotplug — acceptable given the observed reliability of WM_DEVICECHANGE here, but noted.

Refs #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)