### PR TITLE
feat: surface decoded laser-safety fault labels on the telemetry snapshot

### DIFF
--- a/omotion/ConsoleTelemetry.py
+++ b/omotion/ConsoleTelemetry.py
@@ -97,6 +97,12 @@ class ConsoleTelemetry:
     # responded, faults absent" (trust safety_ok). See issue
     # OpenwaterHealth/openmotion-bloodflow-app#107.
     safety_known: bool = False
+    # Decoded fault labels across both channels (EE+OPT), de-duplicated,
+    # empty when the interlock is clear. Lets consumers show *which* fault
+    # tripped (peak-current / pulse / rate) without re-deriving from the raw
+    # bytes. Only meaningful when safety_known is True. See
+    # OpenwaterHealth/openmotion-test-app#56.
+    safety_faults: List[str] = field(default_factory=list)
 
     # --- Read health ---
     read_ok: bool = True            # False if any sub-read threw an exception
@@ -409,6 +415,9 @@ class ConsoleTelemetryPoller:
         so_faults = _decode_safety_faults(snap.safety_so & _SAFETY_FAULT_MASK)
         snap.safety_ok = not se_faults and not so_faults
         snap.safety_known = True
+        # Combined, de-duplicated fault labels for consumers (GUI "which fault").
+        # dict.fromkeys preserves first-seen order without duplicates.
+        snap.safety_faults = list(dict.fromkeys(se_faults + so_faults))
 
         if se_faults:
             logger.error(

--- a/tests/test_console_telemetry_unit.py
+++ b/tests/test_console_telemetry_unit.py
@@ -33,6 +33,43 @@ def test_read_safety_logs_named_se_so_faults(caplog):
     assert "Safety interlock SO faults" in caplog.text
     assert "PULSE_UPPER_LIMIT_FAIL_OR_PULSE_LOWER_LIMIT_FAIL" in caplog.text
     assert "RATE_LOWER_LIMIT_FAIL" in caplog.text
+    # Decoded labels are also surfaced on the snapshot for consumers (issue #56):
+    # SE=0x01 (peak) + SO=0x06 (pulse|rate), combined in first-seen order.
+    assert snap.safety_faults == [
+        "POWER_PEAK_CURRENT_LIMIT_FAIL",
+        "PULSE_UPPER_LIMIT_FAIL_OR_PULSE_LOWER_LIMIT_FAIL",
+        "RATE_LOWER_LIMIT_FAIL",
+    ]
+
+
+def test_read_safety_clear_has_empty_faults():
+    poller = ConsoleTelemetryPoller(_FakeConsole(se_raw=0x00, so_raw=0x00))
+    snap = ConsoleTelemetry()
+    poller._read_safety(snap)
+    assert snap.safety_ok is True
+    assert snap.safety_known is True
+    assert snap.safety_faults == []
+
+
+def test_read_safety_dedups_faults_across_channels():
+    # Both channels report the same peak-current fault -> one label, not two.
+    poller = ConsoleTelemetryPoller(_FakeConsole(se_raw=0x01, so_raw=0x01))
+    snap = ConsoleTelemetry()
+    poller._read_safety(snap)
+    assert snap.safety_faults == ["POWER_PEAK_CURRENT_LIMIT_FAIL"]
+
+
+def test_read_safety_unknown_leaves_faults_empty():
+    # Chip not responding (empty read) -> safety_known False, no faults asserted.
+    class _NoData:
+        def read_i2c_packet(self, *a, **k):
+            return None, None
+
+    poller = ConsoleTelemetryPoller(_NoData())
+    snap = ConsoleTelemetry()
+    poller._read_safety(snap)
+    assert snap.safety_known is False
+    assert snap.safety_faults == []
 
 
 from omotion.ConsoleTelemetry import PdcSample, PDC_MA_PER_LSB


### PR DESCRIPTION
## What
Adds `safety_faults: List[str]` to the `ConsoleTelemetry` snapshot — the decoded EE/OPT safety fault labels (peak-current / pulse / rate), combined + de-duplicated across both channels, empty when the interlock is clear.

## Why
`_read_safety` already decoded these labels but only **logged** them, so the decoded reason never reached consumers. The test-app (OpenwaterHealth/openmotion-test-app#56) needs to show *which* fault tripped, and to stop running its own ad-hoc 1 Hz raw-I2C safety poll. With this, `console.telemetry.get_snapshot()` / `add_listener` is one authoritative, synchronized source carrying both the safety state (`safety_ok` / `safety_known`) and the fault reason.

## Test
- Unit: extended `test_console_telemetry_unit.py` — combined/ordered labels, dedup across channels, clear → empty, unknown (no chip) → empty. `9 passed`.
- Bench (EVT2 console): on a peak-current trip, `snapshot.safety_faults == ['POWER_PEAK_CURRENT_LIMIT_FAIL']`; empty when cleared.

Part of the #56 observation-layer fix (SDK piece); the test-app change consumes this.

Refs #144
Refs OpenwaterHealth/openmotion-test-app#56

🤖 Generated with [Claude Code](https://claude.com/claude-code)
