### PR TITLE
fix: calibration C_max uses average-of-ratios, not ratio-of-averages (#148)

### DIFF
--- a/omotion/CalibrationWorkflow.py
+++ b/omotion/CalibrationWorkflow.py
@@ -226,27 +226,28 @@ def _compute_calibration_from_samples(
                     f"active camera ({side}, cam={cam_id + 1}) produced "
                     f"no corrected samples; calibration aborted."
                 )
-            # Ratio-of-means contrast, not mean-of-ratios.
-            # mean(std/mean) is statistically biased upward whenever
-            # per-frame mean varies; mean(std)/mean(mean) matches the
-            # live UI's "speckle contrast" and stays bounded by 1 for a
-            # well-conditioned signal.
+            # C_max is a contrast averaged over time, so it uses
+            # average-of-ratios — the mean of each frame's std/mean —
+            # never ratio-of-averages (mean(std)/mean(mean)). The two
+            # disagree whenever the per-frame mean varies across the
+            # window. Average-of-ratios is the project-wide standard for
+            # any time-averaged contrast and matches the validation
+            # scan's avg_contrast, so the two are directly comparable
+            # (issue #148).
             mean_avg = float(np.mean([s.mean for s in cam_samples]))
             std_avg = float(np.mean([s.std_dev for s in cam_samples]))
-            new_c_max = (std_avg / mean_avg) if mean_avg > 0.0 else 0.0
+            new_c_max = float(np.mean([s.contrast for s in cam_samples]))
             new_i_max = CALIBRATION_I_MAX_MULTIPLIER * mean_avg
-            # The biased per-frame average is logged for diagnosis: a
+            # Ratio-of-averages is logged alongside for diagnosis: a
             # large divergence between the two estimators is the smoking
             # gun for a flaky / partially-occluded camera.
-            per_frame_contrast_avg = float(
-                np.mean([s.contrast for s in cam_samples])
-            )
+            ratio_of_averages = (std_avg / mean_avg) if mean_avg > 0.0 else 0.0
             logger.info(
                 "  cam (%s, cam=%d): n=%d  mean=%.2f  std=%.2f  "
-                "C_max(ratio-of-means)=%.4f  C_max(mean-of-ratios)=%.4f  "
+                "C_max(avg-of-ratios)=%.4f  ratio-of-averages=%.4f  "
                 "I_max=%.2f",
                 side, cam_id + 1, len(cam_samples),
-                mean_avg, std_avg, new_c_max, per_frame_contrast_avg,
+                mean_avg, std_avg, new_c_max, ratio_of_averages,
                 new_i_max,
             )
             if new_c_max <= 0.0 or new_i_max <= 0.0:

--- a/tests/test_calibration_workflow_compute.py
+++ b/tests/test_calibration_workflow_compute.py
@@ -317,6 +317,31 @@ def _full_thresholds(*, max_dark_per_camera=None):
     )
 
 
+def test_c_max_uses_average_of_ratios_not_ratio_of_averages():
+    """c_max is a time-averaged contrast and must use average-of-ratios
+    (mean of per-frame std/mean), never ratio-of-averages
+    (mean(std) / mean(mean)). See issue #148.
+
+    Two frames on one camera with different per-frame mean and contrast
+    make the two estimators disagree:
+      * average-of-ratios = mean(0.5, 0.3)              = 0.40
+      * ratio-of-averages = mean(50, 90) / mean(100, 300) = 0.35
+    """
+    from omotion.CalibrationWorkflow import _compute_calibration_from_samples
+
+    samples = [
+        _light("left", 0, mean=100.0, contrast=0.5, frame_id=10),
+        _light("left", 0, mean=300.0, contrast=0.3, frame_id=11),
+    ]
+    cal = _compute_calibration_from_samples(
+        samples,
+        left_camera_mask=0x01,
+        right_camera_mask=0x00,
+    )
+    assert cal.c_max[0, 0] == pytest.approx(0.40)          # average-of-ratios
+    assert cal.c_max[0, 0] != pytest.approx(0.35)          # not ratio-of-averages
+
+
 def test_dark_test_pass_when_below_threshold():
     light = [_light(side, 0) for side in ("left", "right")]
     dark = [_dark(side, 0, mean=1.0) for side in ("left", "right")]


### PR DESCRIPTION
## What

Calibration `C_max` is a contrast **averaged over the calibration scan**, so it must use **average-of-ratios** — the mean of each frame's `std/mean`. It was using **ratio-of-averages** (`mean(std) / mean(mean)`).

The two estimators disagree whenever the per-frame mean varies across the averaging window, which left `C_max` systematically offset from the validation scan's `avg_contrast` — even though that value already uses average-of-ratios on the same kind of data. This is the mismatch Qisda flagged in the WI-00015 dry runs (Brad Hartl's thread): the reported CSV `contrast` never lined up with `C_max`.

Average-of-ratios is now the project-wide standard for any time-averaged contrast, so the two are directly comparable.

## Change

`omotion/CalibrationWorkflow.py` — `_compute_calibration_from_samples`:

- `new_c_max` now = `mean(s.contrast for cam_samples)` (average-of-ratios). This value was already computed, just for logging.
- Ratio-of-averages is retained as a diagnostic log line — a large divergence between the two estimators still flags a flaky / partially-occluded camera.
- `I_max` (uses `mean_avg`) and the degenerate-camera guard are unchanged.

## Tests

- New: `test_c_max_uses_average_of_ratios_not_ratio_of_averages` — two frames on one camera with differing per-frame mean/contrast make the estimators disagree (avg-of-ratios = 0.40 vs ratio-of-averages = 0.35); pins the correct one.
- Full calibration suites pass (68/68). Full SDK suite: no new failures (the one unrelated `test_console.py::test_telemetry_listener_fires` timing flake fails identically on `next` without this change).

## Follow-ups (not in this PR)

- **WI-00015** references these values — update so Qisda's expected numbers match the new `C_max`.
- On-hardware sanity check that BFI/BVI stay in range after the slightly shifted `C_max` (it feeds normalization downstream).

Refs #148
