### PR TITLE
fix: accept cropped histograms in sum-validation gate

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -151,8 +151,9 @@ command/response on the sensor):
   `[header][compressed:M][uncmp_crc:2][crc:2][0xDD]`
 - Max packet size: **32 837 B** (~8 cameras + headers); typical scan: one
   camera per packet at 40 Hz.
-- Validation: each parsed sample's `Σ bins` is compared against
-  `EXPECTED_HISTOGRAM_SUM` (`2_457_606`) and dropped on mismatch.
+- Validation: each parsed sample's `Σ bins` must match one of
+  `EXPECTED_HISTOGRAM_SUMS` (`{2_457_606, 2_201_606}` — full and debug-crop
+  geometries, each = W×H + 6) and is dropped otherwise.
 
 ### Transport layer
 
@@ -197,7 +198,7 @@ Always creates `CommInterface` in async mode. Claims all three on `connect()`, r
 |---|---|
 | `parse_histogram_packet()` / `parse_histogram_stream()` | Extract `HistogramSample`s from raw USB bulk bytes; handle multi-camera packets and the `DEBUG_FLAG_HISTO_CMP` decompression path |
 | `bytes_to_integers()` | Converts 4096 histogram bytes to 1024 int bins + hidden figures |
-| `EXPECTED_HISTOGRAM_SUM`, `HISTOGRAM_BYTES` | Validation and framing constants used by `LiveUsbSource` and the firmware-side packet writer |
+| `EXPECTED_HISTOGRAM_SUMS` (+ `EXPECTED_HISTOGRAM_SUM` full-frame alias), `HISTOGRAM_BYTES` | Validation and framing constants used by `LiveUsbSource` and the firmware-side packet writer |
 
 **`omotion/pipeline/`** — the stage-based science pipeline package. Pure transformation over a typed `FrameBatch`; sinks subscribe to named channels for output. The default chain is built by `default_pipeline()`. Full reference: [`SciencePipeline.md`](SciencePipeline.md).
 

--- a/docs/SciencePipeline.md
+++ b/docs/SciencePipeline.md
@@ -142,7 +142,7 @@ Tee("live", filter=ft not in {"warmup","stale"})
 
 - **Cameras:** up to 8 OV2312 cameras per sensor module, up to 2 sensor modules (left + right), 16 cameras max.
 - **Frame rate:** 40 Hz, frame sync controlled by the console MCU.
-- **Histogram:** 1024 bins per camera per frame, 32-bit counts. The expected total count per valid frame is **2,457,606** (= 1920 × 1280 pixels + 6 sentinel counts), validated as `EXPECTED_HISTOGRAM_SUM` in `omotion/MotionProcessing.py`. Frames whose sum does not match are dropped by the parser before they ever reach the pipeline.
+- **Histogram:** 1024 bins per camera per frame, 32-bit counts. A valid frame's bin sum equals its pixel count plus a constant 6-count sentinel — **2,457,606** for the full 1920 × 1280 frame, or **2,201,606** for the debug-cropped 1720 × 1280 frame (`DEBUG_FLAG_CAMERA_CROP`, sensor-fw #86). The parser validates against the set `EXPECTED_HISTOGRAM_SUMS` in `omotion/MotionProcessing.py` (`EXPECTED_HISTOGRAM_SUM` remains the full-frame single value); frames matching none of the valid totals are dropped before they reach the pipeline. Science moments are normalized by the per-frame pixel count, so they are unaffected by which geometry is streaming.
 - **Dark frame protocol:** the firmware deterministically cuts laser illumination on a fixed schedule (see §5.2). The pipeline never has to infer dark/light from the data.
 - **Frame ID:** each histogram packet carries an 8-bit rolling counter (0–255). The pipeline unwraps this per `(side, cam_id)` pair (§5.1).
 - **Pedestal:** the camera-reported value at zero illumination. Per-side, firmware-version-keyed: 64.0 DN for sensor firmware ≤ 1.5.2, 128.0 DN after. `omotion/pipeline/pedestal.py` resolves this from the connected sensors at scan start (`SensorPedestals.from_sensors(left, right)`).
@@ -717,7 +717,8 @@ Both consumers are pure sinks — they add no pipeline stages, do not modify Fra
 | `ADC_GAIN` | `(1024 − pedestal_height) / 11_000` (≈ 0.0873 at pedestal 64, ≈ 0.0815 at pedestal 128) | `omotion/pipeline/pedestal.py` (`adc_gain_for_pedestal`) | Sensor ADC gain used for shot-noise correction; derived per-scan from the pedestal |
 | `CAMERA_GAIN_MAP` | `[16, 4, 2, 1, 1, 2, 4, 16]` | `omotion/config.py` | Per-camera analog gain by `cam_id % 8` |
 | `HISTO_BINS` / `HISTO_BINS_SQ` | `[0..1023]` / element-wise square | `omotion/config.py` | Bin-index arrays for moment computations and CSV column names |
-| `EXPECTED_HISTOGRAM_SUM` | 2_457_606 | `omotion/MotionProcessing.py` | Required total count per valid frame (1920 × 1280 px + 6 sentinel) |
+| `EXPECTED_HISTOGRAM_SUMS` | {2_457_606, 2_201_606} | `omotion/MotionProcessing.py` | Accepted total counts per valid frame — full (1920×1280) and debug-crop (1720×1280), each = W×H + 6 sentinel |
+| `EXPECTED_HISTOGRAM_SUM` | 2_457_606 | `omotion/MotionProcessing.py` | Full-frame single value (backward-compat alias) |
 | `FRAME_ID_MODULUS` | 256 | `FrameClassificationStage` | Firmware 8-bit counter rollover period |
 | `_FRAME_ROLLOVER_THRESHOLD` | 128 | `FrameClassificationStage` | Max forward delta before rollover is detected |
 | `batch_size_frames` | 10 (live) / 100 (replay) | `LiveUsbSource` / `CsvReplaySource` | N frames per FrameBatch |

--- a/omotion/MotionProcessing.py
+++ b/omotion/MotionProcessing.py
@@ -13,7 +13,7 @@ What lives here
 ---------------
 - Wire-level constants: HISTO_SIZE_WORDS, HISTOGRAM_BYTES, PACKET_*,
   MIN_*_PACKET_SIZE, MAX_PACKET_SIZE, SOF/SOH/EOH/EOF, FRAME_ID_MODULUS,
-  EXPECTED_HISTOGRAM_SUM, PEDESTAL_HEIGHT
+  EXPECTED_HISTOGRAM_SUM, EXPECTED_HISTOGRAM_SUMS, PEDESTAL_HEIGHT
 - Dataclasses: HistogramSample, HistogramPacket, Sample, CorrectedBatch
 - Parsing helpers: parse_histogram_stream, parse_histogram_packet_structured,
   _rle_decompress (re-exported from omotion.utils), _util_crc16
@@ -30,7 +30,7 @@ import logging
 import struct
 import time
 from dataclasses import dataclass, field
-from typing import Callable, List, Optional
+from typing import Callable, Iterable, List, Optional
 
 import numpy as np
 import queue
@@ -80,13 +80,57 @@ SOF, SOH, EOH, EOF = 0xAA, 0xFF, 0xEE, 0xDD
 FRAME_ID_MODULUS = 256
 FRAME_ROLLOVER_THRESHOLD = 128
 
-# Expected sum of all histogram bins for a valid frame.
-# When this is not None, any parsed histogram whose bin sum differs from this
-# value is treated as corrupt and silently dropped from the sample list.
-# Set to the integer value confirmed during calibration; leave as None to
-# disable the check (e.g. during development before the expected value is
-# known).
-EXPECTED_HISTOGRAM_SUM: int | None = 2_457_606
+# Sum of all histogram bins for a valid frame == number of output pixels
+# (width × height) plus a constant 6-count sentinel that appears in every
+# frame regardless of geometry (bench-confirmed: full and cropped frames both
+# carry exactly +6 over W×H). A frame whose bin sum matches none of the valid
+# geometry totals is treated as corrupt (doubled/partial frame) and dropped.
+#
+# There is more than one legitimate geometry: the sensor normally streams the
+# full 1920×1280 frame, but the sensor-fw debug crop (DEBUG_FLAG_CAMERA_CROP,
+# sensor-fw #86) narrows it to 1720×1280. Add a row here for any new geometry
+# the firmware can emit.
+_HISTOGRAM_SUM_SENTINEL = 6
+_VALID_FRAME_GEOMETRIES: tuple[tuple[int, int], ...] = (
+    (1920, 1280),   # full frame
+    (1720, 1280),   # DEBUG_FLAG_CAMERA_CROP: right 200 columns dropped (sensor-fw #86)
+)
+# Set of accepted bin-sum totals. Empty set disables the check entirely.
+EXPECTED_HISTOGRAM_SUMS: frozenset[int] = frozenset(
+    w * h + _HISTOGRAM_SUM_SENTINEL for (w, h) in _VALID_FRAME_GEOMETRIES
+)
+
+# Backward-compatible single-value alias: the full-frame total. Retained for
+# external importers (scripts, docs, the shim test). The parser and live
+# pipeline validate against EXPECTED_HISTOGRAM_SUMS (the full set) so cropped
+# frames are accepted; pass an explicit int to a parser to force a single
+# expected total.
+EXPECTED_HISTOGRAM_SUM: int | None = 1920 * 1280 + _HISTOGRAM_SUM_SENTINEL  # 2_457_606
+
+
+def _resolve_valid_sums(expected) -> frozenset[int] | None:
+    """Normalize an ``expected_row_sum`` argument into a set of accepted totals.
+
+    - ``None``  → the module default set ``EXPECTED_HISTOGRAM_SUMS``.
+    - ``int``   → a single accepted total ``{int}`` (legacy exact-match).
+    - iterable  → the given totals as a frozenset.
+
+    Returns ``None`` when the resulting set is empty, meaning "check disabled —
+    accept every frame".
+    """
+    if expected is None:
+        sums = EXPECTED_HISTOGRAM_SUMS
+    elif isinstance(expected, int):
+        sums = frozenset((expected,))
+    else:
+        sums = frozenset(expected)
+    return sums or None
+
+
+def _histogram_sum_ok(row_sum: int, expected) -> bool:
+    """True if ``row_sum`` is an accepted total (or the check is disabled)."""
+    valid = _resolve_valid_sums(expected)
+    return valid is None or row_sum in valid
 
 # Camera sensor pedestal height.
 # When no light reaches the sensor the pixel ADC output settles at this
@@ -208,7 +252,7 @@ def bytes_to_integers(byte_array: bytes | bytearray) -> tuple[list[int], list[in
 
 def _parse_histo_payload(
     payload: bytes,
-    expected_row_sum: int | None,
+    expected_row_sum: "int | Iterable[int] | None",
     original_pkt_len: int,
 ) -> "HistogramPacket":
     """
@@ -261,12 +305,12 @@ def _parse_histo_payload(
         ts_val = timestamp_sec if timestamp_sec is not None else 0.0
         row_sum = int(hist.sum(dtype=np.uint64))
 
-        _expected = expected_row_sum if expected_row_sum is not None else EXPECTED_HISTOGRAM_SUM
-        if _expected is not None and row_sum != _expected:
+        if not _histogram_sum_ok(row_sum, expected_row_sum):
             logger.warning(
                 "Histogram sum mismatch for cam %d frame %d: "
-                "got %d, expected %d — dropping sample",
-                int(cam_id), int(frame_id), row_sum, _expected,
+                "got %d, expected one of %s — dropping sample",
+                int(cam_id), int(frame_id), row_sum,
+                sorted(_resolve_valid_sums(expected_row_sum) or ()),
             )
             continue
 
@@ -298,7 +342,7 @@ def _candidate_packet_size_ok(pkt_type_byte: int, candidate_size: int) -> bool:
 
 def parse_histogram_packet_structured(
     pkt: memoryview,
-    expected_row_sum: int | None = None,
+    expected_row_sum: "int | Iterable[int] | None" = None,
 ) -> HistogramPacket:
     """
     Parse a binary histogram packet into normalized packet/sample dataclasses.
@@ -308,13 +352,14 @@ def parse_histogram_packet_structured(
     pkt
         Raw bytes of a single histogram packet.
     expected_row_sum
-        When not None, each parsed sample's bin sum is compared against this
-        value.  Samples whose sum does not match are logged as warnings and
-        excluded from the returned ``HistogramPacket.samples`` list — they are
-        treated as if the frame never arrived (will not be written to CSV and
-        will not be fed into the science pipeline).  Pass ``None`` (default) to
-        disable the check.  The module-level ``EXPECTED_HISTOGRAM_SUM``
-        constant is a convenient global override point.
+        Accepted histogram bin-sum total(s). ``None`` (default) validates
+        against the module set ``EXPECTED_HISTOGRAM_SUMS`` (full + debug-crop
+        geometries). Pass an ``int`` to require a single exact total, or an
+        iterable of ints for a custom set. Samples whose sum matches none of
+        the accepted totals are logged and excluded from the returned
+        ``HistogramPacket.samples`` — treated as if the frame never arrived
+        (not written to CSV, not fed into the science pipeline). An empty
+        iterable disables the check (accept every frame).
 
     Returns
     -------
@@ -412,14 +457,15 @@ def parse_histogram_packet_structured(
         row_sum = int(hist.sum(dtype=np.uint64))
 
         # Sum validation — drop corrupt/doubled frames before they reach the
-        # pipeline.  The expected value is the invariant photon-count total
-        # that every valid frame must satisfy.
-        _expected = expected_row_sum if expected_row_sum is not None else EXPECTED_HISTOGRAM_SUM
-        if _expected is not None and row_sum != _expected:
+        # pipeline.  A valid frame's bin sum equals one of the known geometry
+        # totals (full frame, or a debug-cropped frame); anything else is a
+        # partial/doubled/garbled frame.
+        if not _histogram_sum_ok(row_sum, expected_row_sum):
             logger.warning(
                 "Histogram sum mismatch for cam %d frame %d: "
-                "got %d, expected %d — dropping sample",
-                int(cam_id), int(frame_id), row_sum, _expected,
+                "got %d, expected one of %s — dropping sample",
+                int(cam_id), int(frame_id), row_sum,
+                sorted(_resolve_valid_sums(expected_row_sum) or ()),
             )
             continue
 
@@ -536,7 +582,7 @@ def parse_histogram_stream(
     stop_evt: threading.Event,
     buffer_accumulator: bytearray,
     on_row_fn: Callable[[int, int, float, np.ndarray, int, float], None] | None = None,
-    expected_row_sum: int | None = None,
+    expected_row_sum: "int | Iterable[int] | None" = None,
     t0_normalizer: Callable[[float], float] | None = None,
 ) -> int:
     """

--- a/omotion/pipeline/sources.py
+++ b/omotion/pipeline/sources.py
@@ -343,7 +343,7 @@ class LiveUsbSource(_BaseSource):
         shared batch queue.
         """
         from omotion.MotionProcessing import (
-            parse_histogram_stream, EXPECTED_HISTOGRAM_SUM,
+            parse_histogram_stream, EXPECTED_HISTOGRAM_SUMS,
         )
 
         side_idx = 0 if side_name == "left" else 1
@@ -364,7 +364,7 @@ class LiveUsbSource(_BaseSource):
         parse_histogram_stream(
             self._packet_queues[side_name], self._stop, buf,
             on_row_fn=on_row,
-            expected_row_sum=EXPECTED_HISTOGRAM_SUM,
+            expected_row_sum=EXPECTED_HISTOGRAM_SUMS,
             t0_normalizer=partial(self._t0_normalize, side_name),
         )
         # Flush any remaining samples after parse_histogram_stream returns

--- a/scripts/validate_scan_integrity.py
+++ b/scripts/validate_scan_integrity.py
@@ -4,8 +4,9 @@
 Runs the full scan bring-up (power -> FPGA program -> sensor config ->
 stream -> trigger) on one sensor side, parses the live HISTO stream with
 the production parser, and reports how many samples passed or failed the
-histogram-sum invariant (every valid frame must sum to
-EXPECTED_HISTOGRAM_SUM = 1920*1280 + metadata).
+histogram-sum invariant (every valid frame must sum to one of the known
+geometry totals in EXPECTED_HISTOGRAM_SUMS - full 1920*1280 or a debug-cropped
+frame - each = width*height + 6).
 
 A bit-shifted serial link (e.g. stray bits clocked into a USART before
 the scan) multiplies every bin by a power of two, so failures are
@@ -29,6 +30,7 @@ from collections import Counter, defaultdict
 from omotion import MotionInterface
 from omotion.MotionProcessing import (
     EXPECTED_HISTOGRAM_SUM,
+    EXPECTED_HISTOGRAM_SUMS,
     HISTOGRAM_BYTES,
     parse_histogram_stream,
 )
@@ -53,9 +55,18 @@ class MismatchCounter(logging.Handler):
             return
         self.count += 1
         try:
-            # args: (cam_id, frame_id, row_sum, expected)
-            got, expected = record.args[2], record.args[3]
-            self.ratios[round(got / expected, 3)] += 1
+            # args: (cam_id, frame_id, row_sum, accepted_sums)
+            # accepted_sums is a list of valid geometry totals (or, for a
+            # legacy single-value caller, a scalar). A bit-shifted link
+            # multiplies the true total by a power of two, so report the ratio
+            # against the nearest valid total to keep the 2^k signature obvious.
+            got, accepted = record.args[2], record.args[3]
+            if isinstance(accepted, (list, tuple, set, frozenset)):
+                base = min(accepted, key=lambda v: abs(got - v)) if accepted else None
+            else:
+                base = accepted
+            if base:
+                self.ratios[round(got / base, 3)] += 1
         except Exception:
             pass
 
@@ -138,7 +149,7 @@ def main() -> int:
             target=parse_histogram_stream,
             args=(q, stop_evt, buf),
             kwargs={"on_row_fn": on_row,
-                    "expected_row_sum": EXPECTED_HISTOGRAM_SUM},
+                    "expected_row_sum": EXPECTED_HISTOGRAM_SUMS},
             daemon=True,
         )
         parser_thread.start()

--- a/tests/test_histogram_crop_sum.py
+++ b/tests/test_histogram_crop_sum.py
@@ -1,0 +1,111 @@
+"""Histogram sum-validation accepts cropped frames (issue #150).
+
+The sensor-fw debug crop (DEBUG_FLAG_CAMERA_CROP, sensor-fw #86) streams
+1720x1280 frames whose bins sum to 2,201,606 instead of the full-frame
+2,457,606. The parser must accept both geometries while still dropping
+genuinely corrupt (partial/doubled) frames.
+"""
+import struct
+
+import numpy as np
+import pytest
+
+from omotion.config import TYPE_HISTO
+from omotion.MotionProcessing import (
+    EOF,
+    EOH,
+    EXPECTED_HISTOGRAM_SUM,
+    EXPECTED_HISTOGRAM_SUMS,
+    HISTO_SIZE_WORDS,
+    SOF,
+    SOH,
+    _crc16,
+    _histogram_sum_ok,
+    _resolve_valid_sums,
+    parse_histogram_packet_structured,
+)
+
+FULL_SUM = 1920 * 1280 + 6   # 2,457,606
+CROP_SUM = 1720 * 1280 + 6   # 2,201,606
+
+
+def _build_histo_packet(total: int, cam_id: int = 0, frame_id: int = 7,
+                        temp: float = 25.0) -> bytes:
+    """Build a single-camera TYPE_HISTO wire packet whose bins sum to `total`.
+
+    Mirrors the firmware framing the parser expects: 6-byte header, one
+    [SOH, cam_id, 1024xu32 LE, f32 temp, EOH] block, then [crc16, EOF]. The
+    frame id lives in the high byte of the last histogram word.
+    """
+    hist = np.zeros(HISTO_SIZE_WORDS, dtype=np.uint32)
+    hist[0] = total                       # whole count in bin 0
+    hist[-1] = (frame_id & 0xFF) << 24    # frame id in high byte, 0 count
+
+    block = (bytes([SOH, cam_id]) + hist.tobytes()
+             + struct.pack("<f", temp) + bytes([EOH]))
+    pkt_len = 6 + len(block) + 3          # header + body + [crc16, EOF]
+    header = struct.pack("<BBI", SOF, TYPE_HISTO, pkt_len)
+    # Parser checks _crc16 over pkt[:pkt_len-4] == header + body without its
+    # trailing EOH byte.
+    crc = _crc16(memoryview(header + block[:-1]))
+    return header + block + struct.pack("<H", crc) + bytes([EOF])
+
+
+def _parse(total: int, **kw):
+    pkt = _build_histo_packet(total)
+    return parse_histogram_packet_structured(memoryview(pkt), **kw)
+
+
+def test_full_frame_roundtrip_sanity():
+    """A full-frame packet parses into exactly one sample (self-check of the
+    test's own framing/CRC before we trust the crop cases)."""
+    result = _parse(FULL_SUM)
+    assert len(result.samples) == 1
+    s = result.samples[0]
+    assert s.row_sum == FULL_SUM
+    assert s.frame_id == 7
+
+
+def test_cropped_frame_is_accepted():
+    """The 1720x1280 cropped total must NOT be dropped (the bug)."""
+    result = _parse(CROP_SUM)
+    assert len(result.samples) == 1
+    assert result.samples[0].row_sum == CROP_SUM
+
+
+@pytest.mark.parametrize("bad", [
+    FULL_SUM * 2,      # doubled/concatenated frame
+    CROP_SUM * 2,
+    FULL_SUM - 1000,   # partial frame
+    12345,             # garbage
+])
+def test_corrupt_sums_are_dropped(bad):
+    """Sums matching no known geometry are still rejected."""
+    result = _parse(bad)
+    assert result.samples == []
+
+
+def test_explicit_single_int_still_exact_matches():
+    """Passing an int keeps legacy exact-match behavior."""
+    assert _parse(CROP_SUM, expected_row_sum=FULL_SUM).samples == []
+    assert len(_parse(FULL_SUM, expected_row_sum=FULL_SUM).samples) == 1
+
+
+def test_empty_iterable_disables_check():
+    """An empty accepted-set accepts any sum."""
+    assert len(_parse(999_999, expected_row_sum=()).samples) == 1
+
+
+def test_expected_sums_set_contents():
+    assert EXPECTED_HISTOGRAM_SUMS == frozenset({FULL_SUM, CROP_SUM})
+    assert EXPECTED_HISTOGRAM_SUM == FULL_SUM  # backward-compat alias
+
+
+def test_resolve_and_predicate_helpers():
+    assert _resolve_valid_sums(None) == EXPECTED_HISTOGRAM_SUMS
+    assert _resolve_valid_sums(FULL_SUM) == frozenset({FULL_SUM})
+    assert _resolve_valid_sums([1, 2, 3]) == frozenset({1, 2, 3})
+    assert _resolve_valid_sums(()) is None          # empty -> disabled
+    assert _histogram_sum_ok(CROP_SUM, None) is True
+    assert _histogram_sum_ok(999, None) is False
+    assert _histogram_sum_ok(999, ()) is True       # disabled -> accept


### PR DESCRIPTION
## Summary
The histogram parser dropped every frame whose 1024 bins didn't sum to exactly `EXPECTED_HISTOGRAM_SUM` (2,457,606 = 1920×1280 + 6). The sensor-fw debug crop (`DEBUG_FLAG_CAMERA_CROP`, sensor-fw #86) streams 1720×1280 frames that sum to **2,201,606**, so **every cropped frame was silently rejected as corrupt** and never reached the pipeline.

## Fix
Replace the single expected total with a geometry-derived set:
```python
EXPECTED_HISTOGRAM_SUMS = frozenset(w*h + 6 for (w,h) in _VALID_FRAME_GEOMETRIES)  # {2_457_606, 2_201_606}
```
A frame passes if its sum matches any known total; doubled/partial frames (sums far off) are still dropped, so corruption detection is preserved. `expected_row_sum` now accepts `int | Iterable[int] | None` (None → the set; int → legacy exact match; empty iterable → disabled). `EXPECTED_HISTOGRAM_SUM` stays as the full-frame single-value alias for external importers.

- **Live pipeline** (`pipeline/sources.py`) and **`validate_scan_integrity.py`** now pass the set. The validator's bit-shift ratio report bases the ratio on the nearest valid total, so the 2^k signature stays obvious for both geometries.
- **Science is unaffected:** `MomentsStage` normalizes every moment by the per-frame pixel count (`counts = h.sum(axis=-1)`), so mean/std/contrast/BFI/BVI don't depend on which geometry streams. This is why only the integrity gate needed changing.

## Tests
`tests/test_histogram_crop_sum.py` (new): full-frame round-trip sanity, cropped sum accepted, corrupt sums (doubled/partial/garbage) dropped, single-int exact-match still works, empty-set disables, helper semantics.

Non-hardware suite green: **248 passed, 29 skipped**.

## Context
Companion to sensor-fw #86 (the crop firmware), bench-validated: cropped histograms sum to exactly 2,201,606 = 1720×1280 + 6. Docs (`SciencePipeline.md`, `Architecture.md`) updated.

Refs #150