### PR TITLE
feat: MotionSensor.set_camera_raw_mode() — control DEBUG_FLAG_CAMERA_RAW (sensor-fw#89)

### DIFF
--- a/omotion/MotionSensor.py
+++ b/omotion/MotionSensor.py
@@ -17,6 +17,7 @@ from omotion.config import (
     OW_CAMERA_GET_HISTOGRAM,
     OW_CAMERA_SET_TESTPATTERN,
     OW_CAMERA_SINGLE_HISTOGRAM,
+    DEBUG_FLAG_CAMERA_RAW,
     OW_CAMERA_SET_CONFIG,
     OW_CMD,
     OW_CMD_DIAG_STATS,
@@ -912,6 +913,11 @@ class MotionSensor(SignalWrapper):
         Bit 8 (DEBUG_FLAG_HISTO_STALL) stops histogram sends after ~45 s of
         streaming while USB stays alive — deterministic camera-stall repro
         (sensor-fw#75).
+        Bit 9 (DEBUG_FLAG_CAMERA_CROP) crops camera output to 1720x1280 at
+        camera (re)configuration (sensor-fw#86).
+        Bit 10 (DEBUG_FLAG_CAMERA_RAW) disables all on-sensor pixel
+        corrections at camera (re)configuration (sensor-fw#89) — prefer
+        :meth:`set_camera_raw_mode`.
         """
         if self.demo_mode:
             return True
@@ -937,6 +943,30 @@ class MotionSensor(SignalWrapper):
         flags = struct.unpack("<I", r.data)[0]
         logger.info("Debug flags: 0x%08X", flags)
         return flags
+
+    def set_camera_raw_mode(self, enable: bool) -> bool:
+        """Enable/disable the raw "scientific sensor" camera mode (sensor-fw#89).
+
+        Sets or clears DEBUG_FLAG_CAMERA_RAW (bit 10), preserving all other
+        debug flags. While the flag is set, camera (re)configuration disables
+        every on-sensor pixel correction — BLC, DC-BLC, BLC dither and OTP
+        defect-pixel correction — so pixels are bare ADC codes.
+
+        The flag is read at camera-configure time only: power-cycle the
+        cameras (or the sensor) and re-run the configure workflow for it to
+        take effect — OW_CAMERA_SET_CONFIG skips cameras it considers
+        already configured. In raw mode the dark level sits at the raw
+        per-channel pedestal (roughly 255 DN at 1x analog gain, 495 DN at
+        16x) instead of the servoed target, so PEDESTAL_HEIGHT-based dark
+        handling is invalid — engineering/scientific captures only, not
+        production scans.
+        """
+        flags = self.get_debug_flags()
+        if enable:
+            flags |= DEBUG_FLAG_CAMERA_RAW
+        else:
+            flags &= ~DEBUG_FLAG_CAMERA_RAW
+        return self.set_debug_flags(flags)
 
     # ------------------------------------------------------------------
     # IMU

--- a/omotion/config.py
+++ b/omotion/config.py
@@ -159,6 +159,9 @@ DEBUG_FLAG_COMM_VERBOSE = 0x10  # Enable cmd id and "." response prints in uart_
 DEBUG_FLAG_CMD_VERBOSE = 0x20  # Enable printf in command handlers (if_commands.c)
 DEBUG_FLAG_SEND_DEFER = 0x80  # Defer per-frame histogram send out of the FSIN ISR into the main loop (sensor-fw#68)
 DEBUG_FLAG_HISTO_STALL = 0x100  # Stop sending histogram frames after ~45 s while USB stays alive — deterministic camera-stall repro (sensor-fw#75)
+DEBUG_FLAG_HISTO_SPARSE = 0x08  # Send histogram data in small chunks over ~15 s to reduce EMI
+DEBUG_FLAG_CAMERA_CROP = 0x200  # Crop camera output to 1720x1280 (drop right 200 columns) at camera (re)configure — misaligned-optic test (sensor-fw#86)
+DEBUG_FLAG_CAMERA_RAW = 0x400  # Raw "scientific sensor" mode: disable all on-sensor pixel corrections (BLC/DC-BLC/dither/OTP DPC) at camera (re)configure (sensor-fw#89)
 
 # Controller Commands
 OW_CTRL_I2C_SCAN = 0x10

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -125,6 +125,7 @@ from omotion.config import (
     DEBUG_FLAG_FAKE_DATA,
     DEBUG_FLAG_COMM_VERBOSE,
     DEBUG_FLAG_CMD_VERBOSE,
+    DEBUG_FLAG_CAMERA_RAW,
 )
 
 _ALL_DEBUG_FLAGS = (
@@ -246,6 +247,36 @@ def test_debug_flag_cmd_verbose(any_sensor):
         readback = any_sensor.get_debug_flags()
         assert not (readback & DEBUG_FLAG_CMD_VERBOSE), (
             f"CMD_VERBOSE bit still set after clear; readback=0x{readback:08X}"
+        )
+    finally:
+        any_sensor.set_debug_flags(original)
+
+
+def test_debug_flag_camera_raw(any_sensor):
+    """Bit 10 — DEBUG_FLAG_CAMERA_RAW via the set_camera_raw_mode() wrapper.
+
+    Only the flag bit is exercised (non-destructive): the register overrides
+    apply at the next camera configure, which this test never triggers. Also
+    verifies the wrapper preserves unrelated bits.
+    """
+    original = any_sensor.get_debug_flags()
+    try:
+        any_sensor.set_debug_flags(DEBUG_FLAG_USB_PRINTF)
+        assert any_sensor.set_camera_raw_mode(True) is True
+        readback = any_sensor.get_debug_flags()
+        assert readback & DEBUG_FLAG_CAMERA_RAW, (
+            f"CAMERA_RAW bit not set; readback=0x{readback:08X}"
+        )
+        assert readback & DEBUG_FLAG_USB_PRINTF, (
+            f"set_camera_raw_mode clobbered other bits; readback=0x{readback:08X}"
+        )
+        assert any_sensor.set_camera_raw_mode(False) is True
+        readback = any_sensor.get_debug_flags()
+        assert not (readback & DEBUG_FLAG_CAMERA_RAW), (
+            f"CAMERA_RAW bit still set after clear; readback=0x{readback:08X}"
+        )
+        assert readback & DEBUG_FLAG_USB_PRINTF, (
+            f"clearing raw mode clobbered other bits; readback=0x{readback:08X}"
         )
     finally:
         any_sensor.set_debug_flags(original)


### PR DESCRIPTION
SDK counterpart of the sensor-fw raw "scientific sensor" camera mode (OpenwaterHealth/openmotion-sensor-fw#89, PR OpenwaterHealth/openmotion-sensor-fw#90).

- `omotion/config.py`: adds `DEBUG_FLAG_CAMERA_RAW = 0x400`, plus the previously missing `DEBUG_FLAG_CAMERA_CROP = 0x200` (sensor-fw#86) and `DEBUG_FLAG_HISTO_SPARSE = 0x08` constants — config.py is the documented single source of truth for the bitmask.
- `MotionSensor.set_camera_raw_mode(enable)`: read-modify-write of the flag bit via existing `get_debug_flags()`/`set_debug_flags()`, preserving other bits. Docstring covers the apply semantics (takes effect only at a configure that actually runs — power-cycle cameras first) and the consequences (dark level = raw per-channel pedestal ~255 DN @1x / ~495 DN @16x; `PEDESTAL_HEIGHT`-based dark handling invalid; engineering captures only).
- `set_debug_flags` docstring: bits 9/10 documented.
- Hardware test `test_debug_flag_camera_raw` in the 3.4 Debug-flags section: flag-only toggle (non-destructive — no camera reconfigure), asserts unrelated bits preserved.

Verification: py_compile + import check pass; live left-sensor check to follow alongside the firmware hardware test (results will be posted on #154).

Refs #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)