### PR TITLE
fix: sensor-program script startup race, cp1252-safe output, post-flash version check

### DIFF
--- a/scripts/test_sensor_program.py
+++ b/scripts/test_sensor_program.py
@@ -16,6 +16,13 @@ from pathlib import Path
 from omotion import MotionInterface
 from omotion.DFUProgrammer import DFUProgrammer, DFUProgress
 
+# Sensors enumerate asynchronously after MotionInterface.start(); how long to
+# wait before declaring them absent.
+STARTUP_TIMEOUT_S = 20.0
+# How long the flashed sensor gets to re-enumerate after the DFU bootloader
+# leaves. It occasionally never comes back without a DUT mains power-cycle.
+REENUM_TIMEOUT_S = 30.0
+
 
 class _LiveStatus:
     def __init__(self, *, enabled: bool = True):
@@ -51,7 +58,7 @@ class _LiveStatus:
         ch = self._spinner[self._spinner_index % len(self._spinner)]
         self._spinner_index += 1
         pct = f" {self._percent:3d}%" if self._percent is not None else ""
-        sys.stderr.write(f"\r   … {self._phase} {ch}{pct}  ({p.elapsed_s:0.1f}s)")
+        sys.stderr.write(f"\r   ... {self._phase} {ch}{pct}  ({p.elapsed_s:0.1f}s)")
         sys.stderr.flush()
         self._last_render = now
 
@@ -118,46 +125,76 @@ def parse_cli() -> argparse.Namespace:
     return parser.parse_args()
 
 
+def _wait_for_sensor(interface, side: str | None, timeout_s: float) -> bool:
+    """Block until the requested sensor side is connected, or ``timeout_s``.
+
+    ``side`` is "left", "right", or None for either side. Unlike
+    ``MotionInterface.wait_for_ready(sensors=1)``, a specific side is not
+    satisfied by the other module being present.
+    """
+    deadline = time.monotonic() + timeout_s
+    while True:
+        _console, left, right = interface.is_device_connected()
+        if side == "left":
+            if left:
+                return True
+        elif side == "right":
+            if right:
+                return True
+        elif left or right:
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(0.2)
+
+
 def main() -> int:
     args = parse_cli()
 
-    print("[*] Starting MOTION interface …")
+    print("[*] Starting MOTION interface ...")
     interface = MotionInterface()
     interface.start()
 
     try:
+        # Enumeration is asynchronous - checking straight after start() races
+        # the connection monitor and reports healthy sensors as absent.
+        want = f"the {args.sensor.upper()} sensor" if args.sensor else "a sensor module"
+        print(f"[*] Waiting up to {STARTUP_TIMEOUT_S:.0f}s for {want} to connect ...")
+        _wait_for_sensor(interface, args.sensor, STARTUP_TIMEOUT_S)
+
         _console_connected, left_connected, right_connected = interface.is_device_connected()
 
         # Ensure at least one sensor module is present.
         if not (left_connected or right_connected):
-            print("❌  No sensor modules connected – cannot continue.")
+            print("[FAIL]  No sensor modules connected - cannot continue.")
             return 1
 
         selected_sensor = None
+        selected_side = None
         # If the user requested a specific side, honor it (fail if not present).
         if args.sensor == "left":
             if not left_connected:
-                print("❌  LEFT sensor not connected – cannot continue.")
+                print("[FAIL]  LEFT sensor not connected - cannot continue.")
                 return 1
             print("Running firmware update on LEFT sensor")
-            selected_sensor = interface.left
+            selected_sensor, selected_side = interface.left, "left"
         elif args.sensor == "right":
             if not right_connected:
-                print("❌  RIGHT sensor not connected – cannot continue.")
+                print("[FAIL]  RIGHT sensor not connected - cannot continue.")
                 return 1
             print("Running firmware update on RIGHT sensor")
-            selected_sensor = interface.right
+            selected_sensor, selected_side = interface.right, "right"
         else:
             # Auto-select: prefer left if present, otherwise right.
             if left_connected:
                 print("Running firmware update on LEFT sensor (auto-selected)")
-                selected_sensor = interface.left
+                selected_sensor, selected_side = interface.left, "left"
             elif right_connected:
                 print("Running firmware update on RIGHT sensor (auto-selected)")
-                selected_sensor = interface.right
+                selected_sensor, selected_side = interface.right, "right"
 
         if selected_sensor is None:
-            print("❌  Sensor module not connected – cannot continue.")
+            print("[FAIL]  Sensor module not connected - cannot continue.")
             return 1
 
         dfu = DFUProgrammer(vidpid=args.vidpid)
@@ -169,28 +206,28 @@ def main() -> int:
                 print("Aborted by user.")
                 return 0
 
-        print("\n[+] Requesting DFU mode from the Sensor module …")
+        print("\n[+] Requesting DFU mode from the Sensor module ...")
         try:
             ok = selected_sensor.enter_dfu()
         except Exception as exc:  # pragma: no cover
-            print(f"   ❌  Exception while calling enter_dfu(): {exc}")
+            print(f"   [FAIL]  Exception while calling enter_dfu(): {exc}")
             ok = False
 
         if ok:
-            print("   ✅  Sensor module reported success.")
+            print("   [OK]  Sensor module reported success.")
         else:
-            print("   ❌  Sensor module reported failure.")
-            print("❌  Failed to request DFU mode – aborting.")
+            print("   [FAIL]  Sensor module reported failure.")
+            print("[FAIL]  Failed to request DFU mode - aborting.")
             return 1
 
-        print(f"\n[*] Sleeping {args.wait:.1f}s to give the bootloader time to re‑enumerate …")
+        print(f"\n[*] Sleeping {args.wait:.1f}s to give the bootloader time to re-enumerate ...")
         time.sleep(args.wait)
 
-        print(f"[+] Waiting up to {args.timeout:.0f}s for DFU device …")
+        print(f"[+] Waiting up to {args.timeout:.0f}s for DFU device ...")
         if not dfu.wait_for_dfu_device(timeout_s=args.timeout):
-            print("❌  DFU device never appeared – aborting.")
+            print("[FAIL]  DFU device never appeared - aborting.")
             return 1
-        print("   ✅  DFU device detected.")
+        print("   [OK]  DFU device detected.")
 
         def on_line(line: str) -> None:
             # Ensure the status line doesn't collide with printed output.
@@ -198,7 +235,7 @@ def main() -> int:
             print("   |", line)
             status._last_render = 0.0
 
-        print("\n[+] Flashing with dfu-util …")
+        print("\n[+] Flashing with dfu-util ...")
         result = dfu.flash_bin(
             args.bin_file,
             address=args.addr,
@@ -213,7 +250,7 @@ def main() -> int:
 
         status.clear()
         if not result.success:
-            print(f"❌  Flash failed (exit code {result.returncode}).")
+            print(f"[FAIL]  Flash failed (exit code {result.returncode}).")
             # Print any non-progress lines from captured stdout for debugging.
             for ln in (result.stdout or "").splitlines():
                 t = ln.strip()
@@ -222,9 +259,23 @@ def main() -> int:
                 print("   |", ln)
             return 1
 
-        print("   ✅  Flash successful.")
-        print("   ℹ️  DFU bootloader already left – device should be running now.")
-        print("\n🎉  All done! The STM32 should now be running the newly‑flashed firmware.\n")
+        print("   [OK]  Flash successful.")
+        print("   [i]  DFU bootloader already left - device should be running now.")
+
+        side_label = selected_side.upper()
+        print(f"\n[+] Waiting up to {REENUM_TIMEOUT_S:.0f}s for the {side_label} sensor to re-enumerate ...")
+        if _wait_for_sensor(interface, selected_side, REENUM_TIMEOUT_S):
+            try:
+                version = selected_sensor.get_version()
+                print(f"   [OK]  {side_label} sensor is back on USB, firmware version {version}.")
+            except Exception as exc:
+                print(f"   [WARN]  {side_label} sensor re-enumerated but get_version() failed: {exc}")
+        else:
+            print(f"   [WARN]  {side_label} sensor did not re-enumerate within {REENUM_TIMEOUT_S:.0f}s.")
+            print("           If it stays missing from USB, power-cycle the DUT mains supply")
+            print("           (known STM32 DFU-leave quirk), then check the device re-appears.")
+
+        print("\n[OK]  All done! The STM32 should now be running the newly-flashed firmware.\n")
         return 0
     finally:
         interface.stop()

--- a/tests/test_sensor_program_script.py
+++ b/tests/test_sensor_program_script.py
@@ -1,0 +1,117 @@
+"""Unit tests for scripts/test_sensor_program.py (issue #160).
+
+Covers the two bench defects from 2026-07-17:
+- startup race: the script must wait for enumeration instead of checking
+  connectivity immediately after ``interface.start()``;
+- Unicode crash: the script must emit ASCII-only output so cp1252 Windows
+  consoles never raise ``UnicodeEncodeError``.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "test_sensor_program.py"
+
+
+def _load_script():
+    spec = importlib.util.spec_from_file_location("sensor_program_script", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeInterface:
+    """Minimal stand-in for MotionInterface connectivity polling.
+
+    ``states`` is a sequence of (console, left, right) tuples returned by
+    successive ``is_device_connected()`` calls; the last one repeats forever.
+    """
+
+    def __init__(self, states):
+        self._states = list(states)
+        self.poll_count = 0
+
+    def is_device_connected(self):
+        self.poll_count += 1
+        if len(self._states) > 1:
+            return self._states.pop(0)
+        return self._states[0]
+
+
+def test_script_source_is_ascii_only():
+    # cp1252 consoles crash on emoji and U+2011 hyphens; keep the script pure ASCII.
+    SCRIPT_PATH.read_bytes().decode("ascii")
+
+
+def test_wait_for_sensor_returns_immediately_when_any_side_connected():
+    mod = _load_script()
+    iface = FakeInterface([(False, True, False)])
+    assert mod._wait_for_sensor(iface, None, timeout_s=0.0) is True
+
+
+def test_wait_for_sensor_specific_side_not_satisfied_by_other_side():
+    mod = _load_script()
+    iface = FakeInterface([(True, True, False)])
+    assert mod._wait_for_sensor(iface, "right", timeout_s=0.3) is False
+
+
+def test_wait_for_sensor_sees_late_connection():
+    mod = _load_script()
+    iface = FakeInterface(
+        [(False, False, False), (False, False, False), (False, False, True)]
+    )
+    assert mod._wait_for_sensor(iface, "right", timeout_s=2.0) is True
+
+
+def test_main_polls_until_timeout_instead_of_single_check(monkeypatch, capsys):
+    mod = _load_script()
+
+    instances = []
+
+    class NeverConnects(FakeInterface):
+        def __init__(self):
+            super().__init__([(False, False, False)])
+            instances.append(self)
+
+        def start(self):
+            pass
+
+        def stop(self):
+            pass
+
+    monkeypatch.setattr(mod, "MotionInterface", NeverConnects)
+    monkeypatch.setattr(mod, "STARTUP_TIMEOUT_S", 0.5)
+    monkeypatch.setattr(sys, "argv", ["test_sensor_program.py", "fake.bin"])
+
+    assert mod.main() == 1
+    assert instances[0].poll_count >= 2, "main() must poll, not check connectivity once"
+    out = capsys.readouterr().out
+    assert "[FAIL]" in out
+
+
+def test_main_fails_for_missing_requested_side_despite_other_side(monkeypatch, capsys):
+    mod = _load_script()
+
+    class LeftOnly(FakeInterface):
+        def __init__(self):
+            super().__init__([(True, True, False)])
+
+        def start(self):
+            pass
+
+        def stop(self):
+            pass
+
+    monkeypatch.setattr(mod, "MotionInterface", LeftOnly)
+    monkeypatch.setattr(mod, "STARTUP_TIMEOUT_S", 0.3)
+    monkeypatch.setattr(sys, "argv", ["test_sensor_program.py", "fake.bin", "--sensor", "right"])
+
+    assert mod.main() == 1
+    out = capsys.readouterr().out
+    assert "RIGHT" in out
+    assert "[FAIL]" in out


### PR DESCRIPTION
Fixes two bench-observed defects (2026-07-17) in `scripts/test_sensor_program.py` and adds post-flash verification.

## Startup race

`main()` called `interface.is_device_connected()` immediately after `interface.start()`. Enumeration is asynchronous, so with normal latency the script printed "No sensor modules connected" and exited 1 even with healthy sensors attached. Now:

- A `_wait_for_sensor()` helper polls connectivity for up to `STARTUP_TIMEOUT_S` (20 s) before the check.
- With `--sensor left|right` the wait is for **that side** specifically — `wait_for_ready(console=False, sensors=1)` would be satisfied by the *other* module, so the script would still fail (or worse, a user could be misled about which board is up).

## Unicode crash on cp1252 consoles

The script printed emoji (❌ ✅ 🎉 ℹ️) plus U+2011 non-breaking hyphens; on a default Windows console (cp1252 stdout) `print` raised `UnicodeEncodeError`, so the failure path died with a traceback instead of its message. All output is now pure ASCII (`[OK]`/`[FAIL]`/`[WARN]`/`[i]`), and a unit test pins the script source to ASCII so it can't regress.

## Post-flash verification

After a successful flash the script now waits up to 30 s for the flashed **side** to re-enumerate and prints `get_version()`. If it never reappears it warns that a DUT mains power-cycle may be needed (known STM32 DFU-leave quirk, seen on the bench 2026-07-17).

## Verification (on the bench, real hardware)

- `pytest tests/test_sensor_program_script.py` — 6 new unit tests (marker `unit`, no hardware), written first and watched fail, all pass.
- Software-only subset (`-m "not console and not sensor and not destructive and not slow"`): 546 passed.
- Live runs with `PYTHONIOENCODING=cp1252` forced:
  - No `--sensor`: waited, auto-selected LEFT, aborted at DFU prompt, exit 0.
  - `--sensor right` / `--sensor left`: side-specific wait message, correct side selected, exit 0.
  - YKUSH port cut (no USB devices at all): waited 20 s, printed `[FAIL]  No sensor modules connected - cannot continue.`, exit 1, **no traceback** — this is the exact path that crashed on the bench.
  - After YKUSH restore, the sensor re-enumerated *during* the startup wait — live evidence the same helper absorbs post-flash re-enumeration latency.
- Not exercised live: the DFU flash itself (destructive to the DUT firmware); the post-flash block reuses the same `_wait_for_sensor` helper and `MotionSensor.get_version()`.

Refs #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)
