### PR TITLE
docs: correct camera part number OV2312 -> OX02C1B in prose/comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ histogram streams into Blood Flow Index (BFI) / Blood Volume Index (BVI) plus a
 queryable scan database.
 
 It talks to an **Open-Motion Console** over UART and to up to **two sensor
-modules** (8 × OV2312 cameras each) over USB bulk. The console and sensor
+modules** (8 × OX02C1B cameras each) over USB bulk. The console and sensor
 firmware live in the `openmotion-console-fw` and `openmotion-sensor-fw` repos;
 this library just speaks their wire protocol.
 

--- a/docs/CameraArrangement.md
+++ b/docs/CameraArrangement.md
@@ -2,7 +2,7 @@
 
 ## Physical Layout
 
-Each sensor module contains 8 cameras (OV2312) arranged in a 4×2 grid. Cameras are numbered 1–8 (or 0–7 in software, i.e., `channel = camera_number - 1`).
+Each sensor module contains 8 cameras (OX02C1B) arranged in a 4×2 grid. Cameras are numbered 1–8 (or 0–7 in software, i.e., `channel = camera_number - 1`).
 
 The layout counts **down** the left column (1→4) then **hooks back up** the right column (5→8):
 

--- a/docs/SciencePipeline.md
+++ b/docs/SciencePipeline.md
@@ -140,7 +140,7 @@ Tee("live", filter=ft not in {"warmup","stale"})
 
 ## 4. Hardware context
 
-- **Cameras:** up to 8 OV2312 cameras per sensor module, up to 2 sensor modules (left + right), 16 cameras max.
+- **Cameras:** up to 8 OX02C1B cameras per sensor module, up to 2 sensor modules (left + right), 16 cameras max.
 - **Frame rate:** 40 Hz, frame sync controlled by the console MCU.
 - **Histogram:** 1024 bins per camera per frame, 32-bit counts. A valid frame's bin sum equals its pixel count plus a constant 6-count sentinel — **2,457,606** for the full 1920 × 1280 frame, or **2,201,606** for the debug-cropped 1720 × 1280 frame (`DEBUG_FLAG_CAMERA_CROP`, sensor-fw #86). The parser validates against the set `EXPECTED_HISTOGRAM_SUMS` in `omotion/MotionProcessing.py` (`EXPECTED_HISTOGRAM_SUM` remains the full-frame single value); frames matching none of the valid totals are dropped before they reach the pipeline. Science moments are normalized by the per-frame pixel count, so they are unaffected by which geometry is streaming.
 - **Dark frame protocol:** the firmware deterministically cuts laser illumination on a fixed schedule (see §5.2). The pipeline never has to infer dark/light from the data.

--- a/omotion/MotionSensor.py
+++ b/omotion/MotionSensor.py
@@ -622,7 +622,7 @@ class MotionSensor(SignalWrapper):
 
         The firmware verifies, at startup, that every expected I2C device is
         present: the TCA9548A mux, the ICM-20948 IMU, and all 8 cameras
-        (OV2312) + 8 FPGAs (CrossLink) behind the mux. The USB PHY is not on
+        (OX02C1B) + 8 FPGAs (CrossLink) behind the mux. The USB PHY is not on
         I2C (ULPI) and is excluded.
 
         Args:
@@ -636,7 +636,7 @@ class MotionSensor(SignalWrapper):
                 "version": int,
                 "mux": bool,             # TCA9548A 0x70
                 "imu": bool,             # ICM-20948 0x68
-                "cameras": [bool] * 8,   # OV2312 0x36 per mux channel
+                "cameras": [bool] * 8,   # OX02C1B 0x36 per mux channel
                 "fpgas":   [bool] * 8,   # CrossLink 0x40 per mux channel
                 "cameras_expected": int, # bitmask, 0xFF = all 8
                 "all_present": bool,

--- a/omotion/config.py
+++ b/omotion/config.py
@@ -32,7 +32,7 @@ HISTO_BLOCK_SIZE = 1 + (HISTO_SIZE_WORDS * 4) + 1  # HID + HISTO + EOH
 HISTO_BINS: np.ndarray = np.arange(HISTO_SIZE_WORDS, dtype=np.float64)
 HISTO_BINS_SQ: np.ndarray = HISTO_BINS * HISTO_BINS
 
-# Full-well capacity of the OV2312 sensor in electrons. Used to compute
+# Full-well capacity of the OX02C1B sensor in electrons. Used to compute
 # ADC gain (DN per electron) for shot-noise correction:
 #   ADC_GAIN = (HISTO_SIZE_WORDS - pedestal) / ELECTRON_WELL_CAPACITY
 ELECTRON_WELL_CAPACITY: int = 11_000
@@ -261,7 +261,7 @@ MODULES: int = 2
 """Number of sensor modules per device (left + right)."""
 
 CAMS_PER_MODULE: int = 8
-"""Cameras per sensor module (OV2312 array)."""
+"""Cameras per sensor module (OX02C1B array)."""
 
 CAPTURE_HZ: float = 40.0
 """Histogram capture rate per camera, in Hz."""


### PR DESCRIPTION
## Summary

The Open-Motion camera sensor is the OmniVision **OX02C1B** (global shutter, 1920x1280 RAW10); several SDK docs and code comments called it "OV2312", a different OmniVision part. This sweeps every stale reference:

- `README.md` — system overview
- `docs/SciencePipeline.md` — hardware context
- `docs/CameraArrangement.md` — physical layout
- `omotion/config.py` — full-well-capacity comment + `CAMS_PER_MODULE` docstring
- `omotion/MotionSensor.py` — `get_i2c_health()` docstring + inline comment

Prose/comments only — no identifiers, file names, or behavior change. All touched Python files compile clean.

Refs #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)
