### PR TITLE
feat: parse camera telemetry v2 — optical-black block

### DIFF
--- a/omotion/MotionSensor.py
+++ b/omotion/MotionSensor.py
@@ -128,11 +128,22 @@ def parse_camera_telemetry(data: bytes) -> dict | None:
     zero-line (dark row) averages, Bayer positions 00/01/10/11 — plus the
     derived ``z_avg_mean``/``z_avg_spread`` and the window, target, trigger
     and fault context that produced them (``zl_start``/``zl_end``,
-    ``blk_lvl_target``, ``blc_trig_ctrl``, ``blc_fault_latch``, ...). On this
-    mono sensor all four ``z_avg`` values sample the same physical dark rows,
-    so a nonzero ``z_avg_spread`` is itself the diagnostic. Note the BLC servo
-    only runs while ``blc_ctrl`` bit 0 (``blc_en``) is set: in raw mode
-    (sensor-fw#89 writes 0x4001 = 0x00) ``blc_offsets`` are frozen.
+    ``blk_lvl_target``, ``blc_trig_ctrl``, ``blc_fault_latch``, ...).
+
+    Bench-established (2026-07-20, left sensor): ``z_avg`` and ``blc_offsets``
+    update **only while the sensor is scanning rows** — they read 0 at idle
+    and populate within a sweep of stream-on, so judge them against
+    ``sc_state`` (0x9 = streaming), not ``updated_ms``. They are *not* gated
+    by ``blc_en``: raw mode (sensor-fw#89, ``blc_ctrl`` 0x00) yields the same
+    values, because the statistics engine runs whether or not the correction
+    is applied. ``z_avg`` carries 6 fractional bits — ``z_avg / 64`` is DN
+    (measured 121.7 DN against the sensor's own raw-mode ``yavg`` of 121).
+
+    The sensor is mono, so all four ``z_avg`` values average the same physical
+    dark rows, but they do **not** agree: Bayer positions 10/11 sit ~60 LSB
+    (~0.8 %) above 00/01 on every camera, a reproducible row-parity split.
+    ``z_avg_spread`` therefore has a nonzero floor — track it against that
+    baseline rather than against 0.
 
     ``fsin_pulse_count`` is the firmware's frame
     trigger counter — external (console-driven) FSIN edges only; the sensor's

--- a/omotion/MotionSensor.py
+++ b/omotion/MotionSensor.py
@@ -89,17 +89,18 @@ _ERROR_TYPES = frozenset({OW_ERROR, OW_BAD_CRC, OW_BAD_PARSE, OW_UNKNOWN})
 from omotion.firmware_update import parse_version as _parse_firmware_version
 
 
-# --- Camera telemetry (sensor-fw#94) ---------------------------------------
+# --- Camera telemetry (sensor-fw#94, OB/black-level block sensor-fw#103) ---
 # Wire format: cam_telemetry_response_t in sensor-fw Core/Inc/camera_telemetry.h
-# — 4-byte header {version, valid_mask, struct_size, reserved} followed by 8
-# packed 78-byte per-camera records (little-endian). The firmware sends raw
-# register values; this parser owns every engineering-unit conversion.
-CAM_TELEMETRY_VERSION = 1
+# — 12-byte header {version, valid_mask, struct_size, reserved,
+# fsin_pulse_count, uptime_ms} followed by 8 packed 110-byte per-camera
+# records (little-endian). The firmware sends raw register values; this parser
+# owns every engineering-unit conversion.
+CAM_TELEMETRY_VERSION = 2
 _CAM_TELEM_HDR_FMT = "<BBBBII"  # version, valid_mask, struct_size, rsvd, fsin_pulse_count, uptime_ms
-_CAM_TELEM_CAM_FMT = "<II22H22B"
-_CAM_TELEM_CAM_SIZE = struct.calcsize(_CAM_TELEM_CAM_FMT)  # 74
+_CAM_TELEM_CAM_FMT = "<II22H22B11H14B"
+_CAM_TELEM_CAM_SIZE = struct.calcsize(_CAM_TELEM_CAM_FMT)  # 110
 _CAM_TELEM_HDR_SIZE = struct.calcsize(_CAM_TELEM_HDR_FMT)  # 12
-_CAM_TELEM_SIZE = _CAM_TELEM_HDR_SIZE + 8 * _CAM_TELEM_CAM_SIZE  # 604
+_CAM_TELEM_SIZE = _CAM_TELEM_HDR_SIZE + 8 * _CAM_TELEM_CAM_SIZE  # 892
 
 
 def _vm_volts(raw: int) -> float:
@@ -121,7 +122,19 @@ def parse_camera_telemetry(data: bytes) -> dict | None:
     "cameras": [dict * 8]}`` where each camera dict carries converted values
     (``avdd_v``/``dovdd_v``/``dvdd_v`` volts, ``tpm_avg_c``/``tpm0_c``/``tpm1_c``
     degC, ``again_x``/``dgain_x`` gain factors) alongside the raw
-    fault/state/counter bytes. ``fsin_pulse_count`` is the firmware's frame
+    fault/state/counter bytes.
+
+    The optical-black block (sensor-fw#103) adds ``z_avg`` — the four
+    zero-line (dark row) averages, Bayer positions 00/01/10/11 — plus the
+    derived ``z_avg_mean``/``z_avg_spread`` and the window, target, trigger
+    and fault context that produced them (``zl_start``/``zl_end``,
+    ``blk_lvl_target``, ``blc_trig_ctrl``, ``blc_fault_latch``, ...). On this
+    mono sensor all four ``z_avg`` values sample the same physical dark rows,
+    so a nonzero ``z_avg_spread`` is itself the diagnostic. Note the BLC servo
+    only runs while ``blc_ctrl`` bit 0 (``blc_en``) is set: in raw mode
+    (sensor-fw#89 writes 0x4001 = 0x00) ``blc_offsets`` are frozen.
+
+    ``fsin_pulse_count`` is the firmware's frame
     trigger counter — external (console-driven) FSIN edges only; the sensor's
     own frame counter has no readable SCCB value register, and internal-FSIN
     frames don't increment this. ``valid`` is False for a camera the firmware
@@ -151,6 +164,14 @@ def parse_camera_telemetry(data: bytes) -> dict | None:
          wd_a, wd_b, wd_sticky, _wd_tpm_hi, _wd_tpm_lo, wd_state,
          sc_state, otp_crc0, otp_crc1, trig_error, yavg, aec_mode,
          dcg_state, blc_ctrl, isp_ctrl, i2c_err_count, sweep_count) = f[24:46]
+        # OB / black-level block (sensor-fw#103, DS table A-25). z_avg and the
+        # offsets are 15-bit in a 16-bit register; bit 15 is reserved.
+        z_avg = [v & 0x7FFF for v in f[46:50]]
+        blc_offsets_z = [v & 0x7FFF for v in f[50:54]]
+        blc_thres, blk_lvl_target, zero_ln_num = f[54:57]
+        (blc_trig_ctrl, bl_start, bl_end, blk_ln_num, blc_ln_mode,
+         zl_start, zl_end, zavg_ctrl, zl_start2, zl_end2,
+         blc_fault_latch, blc_fault_state, dig_test_fail, dtr_fault) = f[57:71]
 
         # Analog gain: 0x3508[4:0] = code[8:4], 0x3509[7:4] = code[3:0]; x = code/16.
         again_code = (((again_raw >> 8) & 0x1F) << 4) | ((again_raw >> 4) & 0x0F)
@@ -198,6 +219,33 @@ def parse_camera_telemetry(data: bytes) -> dict | None:
             "isp_blc": isp_blc,
             "isp_expo": isp_expo,
             "blc_offsets": blc_offsets,
+            # --- OB / black-level block (sensor-fw#103) ---
+            # z_avg_00/01/10/11 are the zero-line (dark row) averages per
+            # Bayer position. The OX02C1B is mono here, so all four sample the
+            # same physical dark rows and should agree — z_avg_spread is the
+            # per-camera sanity metric, z_avg_mean the dark pedestal estimate.
+            "z_avg": z_avg,
+            "z_avg_mean": sum(z_avg) / 4.0,
+            "z_avg_spread": max(z_avg) - min(z_avg),
+            "blc_offsets_z": blc_offsets_z,
+            "blc_thres": blc_thres & 0x07FF,
+            "blk_lvl_target": blk_lvl_target & 0x07FF,
+            "zero_ln_num": zero_ln_num & 0x03FF,
+            "blc_trig_ctrl": blc_trig_ctrl,
+            "bl_start": bl_start & 0x3F,
+            "bl_end": bl_end & 0x3F,
+            "blk_ln_num": blk_ln_num,
+            "blc_ln_mode": blc_ln_mode,
+            "zl_start": zl_start,
+            "zl_end": zl_end,
+            "zavg_ctrl": zavg_ctrl,
+            "z_avg_sel": zavg_ctrl & 0x03,
+            "zl_start2": zl_start2,
+            "zl_end2": zl_end2,
+            "blc_fault_latch": blc_fault_latch,
+            "blc_fault_state": blc_fault_state & 0x01,
+            "dig_test_fail": dig_test_fail,
+            "dtr_fault": dtr_fault,
         })
     return {"version": version, "valid_mask": valid_mask,
             "fsin_pulse_count": fsin_pulse_count, "uptime_ms": uptime_ms,
@@ -729,7 +777,9 @@ class MotionSensor(SignalWrapper):
         background (rails from the on-die voltage monitor, dual die temps,
         VM/watchdog fault latches, sensor state machine, OTP CRC status, MIPI
         frame counter, FSIN trigger errors, on-chip frame mean, commanded vs
-        applied exposure/gain, applied BLC offsets) and this command returns
+        applied exposure/gain, applied BLC offsets, and the optical-black
+        block: dark-row averages plus their window/target/fault context) and
+        this command returns
         the cached snapshot — no camera I2C happens at query time, so it is
         safe to poll during scans. Fleet refresh is ~1 s; per-camera
         ``updated_ms``/``sweep_count`` reveal staleness. See
@@ -753,6 +803,15 @@ class MotionSensor(SignalWrapper):
                 "isp_real_gain": 0x10, "isp_dig_gain": 0x400,
                 "isp_blc": 0x80, "isp_expo": 0x48,
                 "blc_offsets": [0] * 8,
+                "z_avg": [128] * 4, "z_avg_mean": 128.0, "z_avg_spread": 0,
+                "blc_offsets_z": [0] * 4,
+                "blc_thres": 0, "blk_lvl_target": 128, "zero_ln_num": 2,
+                "blc_trig_ctrl": 0xF9, "bl_start": 4, "bl_end": 0x1B,
+                "blk_ln_num": 4, "blc_ln_mode": 0x50,
+                "zl_start": 2, "zl_end": 0x0D,
+                "zavg_ctrl": 0, "z_avg_sel": 0, "zl_start2": 8, "zl_end2": 0x0D,
+                "blc_fault_latch": 0, "blc_fault_state": 0,
+                "dig_test_fail": 0, "dtr_fault": 0,
             }
             return {"version": CAM_TELEMETRY_VERSION, "valid_mask": 0xFF,
                     "fsin_pulse_count": 0, "uptime_ms": 1000,

--- a/omotion/camera_telemetry_csv.py
+++ b/omotion/camera_telemetry_csv.py
@@ -57,7 +57,19 @@ CAMERA_TELEMETRY_HEADERS: List[str] = [
     "expo_cmd", "expo_applied", "again_x", "dgain_x",
     "aec_mode", "dcg_state", "blc_ctrl", "isp_ctrl",
     "isp_real_gain", "isp_dig_gain", "isp_blc", "isp_expo",
-] + [f"blc_offset_{i}" for i in range(8)]
+] + [f"blc_offset_{i}" for i in range(8)] + [
+    # --- optical-black block (sensor-fw#103) ---
+    # z_avg_00/01/10/11 are the zero-line (dark row) averages per Bayer
+    # position; mono sensor, so all four should agree (z_avg_spread == 0).
+    "z_avg_00", "z_avg_01", "z_avg_10", "z_avg_11",
+    "z_avg_mean", "z_avg_spread",
+    "blc_thres", "blk_lvl_target",
+    "bl_start", "bl_end", "blk_ln_num", "blc_ln_mode",
+    "zl_start", "zl_end", "zero_ln_num",
+    "zavg_ctrl", "z_avg_sel", "zl_start2", "zl_end2",
+    "blc_trig_ctrl", "blc_fault_latch", "blc_fault_state",
+    "dig_test_fail", "dtr_fault",
+] + [f"blc_offset_z_{i}" for i in range(4)]
 
 
 def _cam_row(host_time: float, side: str, cam_id: int,
@@ -98,6 +110,25 @@ def _cam_row(host_time: float, side: str, cam_id: int,
     offsets = c.get("blc_offsets") or []
     for i in range(8):
         row.append(offsets[i] if i < len(offsets) else "")
+
+    # Optical-black block (sensor-fw#103).
+    z_avg = c.get("z_avg") or []
+    row += [z_avg[i] if i < len(z_avg) else "" for i in range(4)]
+    row += [
+        round(c.get("z_avg_mean", 0.0), 2) if z_avg else "",
+        c.get("z_avg_spread", ""),
+        c.get("blc_thres", ""), c.get("blk_lvl_target", ""),
+        c.get("bl_start", ""), c.get("bl_end", ""),
+        c.get("blk_ln_num", ""), c.get("blc_ln_mode", ""),
+        c.get("zl_start", ""), c.get("zl_end", ""), c.get("zero_ln_num", ""),
+        c.get("zavg_ctrl", ""), c.get("z_avg_sel", ""),
+        c.get("zl_start2", ""), c.get("zl_end2", ""),
+        c.get("blc_trig_ctrl", ""), c.get("blc_fault_latch", ""),
+        c.get("blc_fault_state", ""),
+        c.get("dig_test_fail", ""), c.get("dtr_fault", ""),
+    ]
+    offsets_z = c.get("blc_offsets_z") or []
+    row += [offsets_z[i] if i < len(offsets_z) else "" for i in range(4)]
     return row
 
 

--- a/tests/test_camera_telemetry_csv_unit.py
+++ b/tests/test_camera_telemetry_csv_unit.py
@@ -31,8 +31,18 @@ def _fake_telem(uptime=5000):
         "isp_real_gain": 0x100, "isp_dig_gain": 0x400,
         "isp_blc": 0x80, "isp_expo": 0x48,
         "blc_offsets": [256] * 8,
+        # OB / black-level block (sensor-fw#103) — base config values.
+        "z_avg": [128] * 4, "z_avg_mean": 128.0, "z_avg_spread": 0,
+        "blc_offsets_z": [256] * 4,
+        "blc_thres": 0, "blk_lvl_target": 128, "zero_ln_num": 2,
+        "blc_trig_ctrl": 0xF9, "bl_start": 4, "bl_end": 0x1B,
+        "blk_ln_num": 4, "blc_ln_mode": 0x50,
+        "zl_start": 2, "zl_end": 0x0D,
+        "zavg_ctrl": 0, "z_avg_sel": 0, "zl_start2": 8, "zl_end2": 0x0D,
+        "blc_fault_latch": 0, "blc_fault_state": 0,
+        "dig_test_fail": 0, "dtr_fault": 0,
     }
-    return {"version": 1, "valid_mask": 0xFF, "fsin_pulse_count": 3,
+    return {"version": 2, "valid_mask": 0xFF, "fsin_pulse_count": 3,
             "uptime_ms": uptime, "cameras": [dict(cam) for _ in range(8)]}
 
 
@@ -72,6 +82,12 @@ def test_writes_one_csv_per_camera_with_samples(tmp_path):
         rows = _read_csv(path)
         assert rows[0] == CAMERA_TELEMETRY_HEADERS
         assert len(rows) >= 3, f"expected >=2 samples in {path.name}"
+        # dict(zip(...)) below truncates silently on a width mismatch, so the
+        # row width has to be asserted on its own.
+        for n, row in enumerate(rows[1:], start=1):
+            assert len(row) == len(CAMERA_TELEMETRY_HEADERS), (
+                f"{path.name} row {n}: {len(row)} cols, "
+                f"expected {len(CAMERA_TELEMETRY_HEADERS)}")
         r = dict(zip(CAMERA_TELEMETRY_HEADERS, rows[1]))
         assert r["side"] == "left" and int(r["cam"]) == cam_id
         assert int(r["read_ok"]) == 1 and r["error"] == ""
@@ -81,6 +97,12 @@ def test_writes_one_csv_per_camera_with_samples(tmp_path):
         assert float(r["again_x"]) == 16.0
         assert int(r["blc_offset_7"]) == 256
         assert int(r["fsin_pulse_count"]) == 3
+        # OB block (sensor-fw#103): last column group must land intact.
+        assert int(r["z_avg_00"]) == 128 and int(r["z_avg_11"]) == 128
+        assert int(r["z_avg_spread"]) == 0
+        assert int(r["zl_start"]) == 2 and int(r["zl_end"]) == 0x0D
+        assert int(r["blk_lvl_target"]) == 128
+        assert int(r["blc_offset_z_3"]) == 256
     assert sensor.calls >= 2
 
 
@@ -92,10 +114,12 @@ def test_failure_rows_and_survival(tmp_path):
     log.stop()
     rows = _read_csv(tmp_path / "s2_x_right_cam0_telemetry.csv")
     assert len(rows) >= 2
+    assert len(rows[1]) == len(CAMERA_TELEMETRY_HEADERS)
     r = dict(zip(CAMERA_TELEMETRY_HEADERS, rows[1]))
     assert int(r["read_ok"]) == 0
     assert "usb detached" in r["error"]
     assert r["avdd_v"] == ""  # blank data columns on failed reads
+    assert r["z_avg_00"] == "" and r["dtr_fault"] == ""
 
 
 def test_two_sensors_get_sixteen_files(tmp_path):

--- a/tests/test_camera_telemetry_unit.py
+++ b/tests/test_camera_telemetry_unit.py
@@ -1,4 +1,4 @@
-"""Unit tests for parse_camera_telemetry (sensor-fw#94 / #162).
+"""Unit tests for parse_camera_telemetry (sensor-fw#94 / #162, OB block #103).
 
 Builds synthetic cam_telemetry_response_t blobs byte-for-byte against the wire
 format in sensor-fw Core/Inc/camera_telemetry.h and checks the parser's
@@ -26,6 +26,13 @@ NOMINAL = dict(
     wd=[0, 0, 0, 0x2D, 0x80, 0], sc_state=0x07, otp=[0xAA, 0x55],
     trig=0, yavg=42, aec=0xA8, dcg=0x40, blc_ctrl=0x23, isp_ctrl=0x34,
     err=0, sweeps=5,
+    # OB / black-level block (#103). Config values are the base config table's.
+    z_avg=[0x0080] * 4, blc_z=[0x0100] * 4,
+    blc_thres=0x0000, blk_lvl_target=0x0080, zero_ln_num=0x0002,
+    blc_trig_ctrl=0xF9, bl_start=0x04, bl_end=0x1B, blk_ln_num=0x04,
+    blc_ln_mode=0x50, zl_start=0x02, zl_end=0x0D, zavg_ctrl=0x00,
+    zl_start2=0x08, zl_end2=0x0D, blc_fault_latch=0x00, blc_fault_state=0x00,
+    dig_test_fail=0x00, dtr_fault=0x00,
 )
 
 
@@ -44,6 +51,12 @@ def make_cam(**overrides):
         v["vm_cp_latched"], *v["wd"], v["sc_state"], *v["otp"],
         v["trig"], v["yavg"], v["aec"], v["dcg"], v["blc_ctrl"],
         v["isp_ctrl"], v["err"], v["sweeps"],
+        *v["z_avg"], *v["blc_z"],
+        v["blc_thres"], v["blk_lvl_target"], v["zero_ln_num"],
+        v["blc_trig_ctrl"], v["bl_start"], v["bl_end"], v["blk_ln_num"],
+        v["blc_ln_mode"], v["zl_start"], v["zl_end"], v["zavg_ctrl"],
+        v["zl_start2"], v["zl_end2"], v["blc_fault_latch"],
+        v["blc_fault_state"], v["dig_test_fail"], v["dtr_fault"],
     )
 
 
@@ -56,14 +69,15 @@ def make_blob(cams=None, version=CAM_TELEMETRY_VERSION, valid=0xFF, size=None,
 
 
 def test_wire_sizes_match_firmware():
-    assert _CAM_TELEM_CAM_SIZE == 74
-    assert _CAM_TELEM_SIZE == 604
+    # Must track the _Static_asserts in sensor-fw Core/Inc/camera_telemetry.h.
+    assert _CAM_TELEM_CAM_SIZE == 110
+    assert _CAM_TELEM_SIZE == 892
 
 
 def test_nominal_conversions():
     t = parse_camera_telemetry(make_blob())
     assert t is not None
-    assert t["version"] == 1 and t["valid_mask"] == 0xFF
+    assert t["version"] == 2 and t["valid_mask"] == 0xFF
     assert t["fsin_pulse_count"] == 42 and t["uptime_ms"] == 99000
     c = t["cameras"][0]
     assert c["valid"] is True
@@ -116,6 +130,49 @@ def test_vm_raw_masking_and_blc_msb_mask():
     assert t["cameras"][0]["blc_offsets"][0] == 0x0123
 
 
+def test_ob_block_nominal():
+    """OB block decodes at the right offsets with the base config's values."""
+    c = parse_camera_telemetry(make_blob())["cameras"][0]
+    assert c["z_avg"] == [0x80] * 4
+    assert c["z_avg_mean"] == 128.0
+    assert c["z_avg_spread"] == 0
+    assert c["blc_offsets_z"] == [0x0100] * 4
+    assert c["blk_lvl_target"] == 0x080      # base config 0x4005 = 0x80
+    assert c["bl_start"] == 4 and c["bl_end"] == 0x1B    # 0x4008/09
+    assert c["zl_start"] == 2 and c["zl_end"] == 0x0D    # 0x4050/51
+    assert c["blk_ln_num"] == 4 and c["zero_ln_num"] == 2
+    assert c["blc_trig_ctrl"] == 0xF9        # base config 0x4000
+    assert c["z_avg_sel"] == 0
+    assert c["blc_fault_latch"] == 0 and c["blc_fault_state"] == 0
+
+
+def test_z_avg_spread_flags_channel_mismatch():
+    """Mono sensor: the four dark-row averages should agree; spread is the tell."""
+    cam = make_cam(z_avg=[0x0080, 0x0082, 0x0080, 0x0091])
+    c = parse_camera_telemetry(make_blob([cam] + [make_cam()] * 7))["cameras"][0]
+    assert c["z_avg"] == [0x80, 0x82, 0x80, 0x91]
+    assert c["z_avg_spread"] == 0x11
+    assert c["z_avg_mean"] == (0x80 + 0x82 + 0x80 + 0x91) / 4.0
+
+
+def test_ob_field_masking():
+    """z_avg / offsets are 15-bit; the reserved MSB must not leak into values."""
+    cam = make_cam(z_avg=[0x8123] * 4, blc_z=[0xFFFF] * 4,
+                   blc_thres=0xF801, blk_lvl_target=0xF900,
+                   zero_ln_num=0xFC05, bl_start=0xC4, bl_end=0xC1,
+                   zavg_ctrl=0x3E, blc_fault_state=0xFE)
+    c = parse_camera_telemetry(make_blob([cam] + [make_cam()] * 7))["cameras"][0]
+    assert c["z_avg"] == [0x0123] * 4                 # bit 15 reserved
+    assert c["blc_offsets_z"] == [0x7FFF] * 4
+    assert c["blc_thres"] == 0x001                    # thres_l is 11-bit
+    assert c["blk_lvl_target"] == 0x100               # 11-bit
+    assert c["zero_ln_num"] == 0x005                  # 10-bit
+    assert c["bl_start"] == 4 and c["bl_end"] == 1    # 0x4008/09 are [5:0]
+    assert c["z_avg_sel"] == 2                        # 0x40E8[1:0]
+    assert c["zavg_ctrl"] == 0x3E                     # raw byte preserved too
+    assert c["blc_fault_state"] == 0                  # 0x40F2[0]
+
+
 def test_valid_mask_bits():
     t = parse_camera_telemetry(make_blob(valid=0b00000101))
     valids = [c["valid"] for c in t["cameras"]]
@@ -126,5 +183,6 @@ def test_rejects_malformed():
     assert parse_camera_telemetry(None) is None
     assert parse_camera_telemetry(b"") is None
     assert parse_camera_telemetry(make_blob()[:-1]) is None          # short
-    assert parse_camera_telemetry(make_blob(version=2)) is None      # future version
-    assert parse_camera_telemetry(make_blob(size=73)) is None        # struct drift
+    assert parse_camera_telemetry(make_blob(version=3)) is None      # future version
+    assert parse_camera_telemetry(make_blob(version=1)) is None      # pre-OB firmware
+    assert parse_camera_telemetry(make_blob(size=109)) is None       # struct drift


### PR DESCRIPTION
Refs #169 · host side of OpenwaterHealth/openmotion-sensor-fw#103 (PR OpenwaterHealth/openmotion-sensor-fw#104)

**These must ship together** — the firmware bumps the telemetry wire version to 2, and `parse_camera_telemetry` rejects any snapshot whose version or struct size doesn't match.

## Change

- `_CAM_TELEM_CAM_FMT` `<II22H22B>` -> `<II22H22B11H14B>` (74 -> 110 B per camera, 604 -> 892 B response); `CAM_TELEMETRY_VERSION` 1 -> 2.
- New per-camera keys: `z_avg` (the four zero-line / dark-row averages, Bayer 00/01/10/11) plus derived `z_avg_mean` / `z_avg_spread`, `blc_offsets_z`, `blc_thres`, `blk_lvl_target`, `zero_ln_num`, `blc_trig_ctrl`, `bl_start`/`bl_end`, `blk_ln_num`, `blc_ln_mode`, `zl_start`/`zl_end`, `zavg_ctrl`/`z_avg_sel`, `zl_start2`/`zl_end2`, `blc_fault_latch`/`blc_fault_state`, `dig_test_fail`, `dtr_fault`.
- `CameraTelemetryCsvLogger` gains the matching columns.

The sensor is mono, so all four `z_avg` values average the same physical dark rows and should agree — `z_avg_spread` is the diagnostic, `z_avg_mean` the dark pedestal estimate.

## Verification

- **Field-order cross-check against the C struct:** all 71 fields of `cam_telemetry_t` compared by byte offset against the Python format string, 0 mismatches — this catches a transposition that a size-only check would miss. Backed by a distinct-value round trip where every OB field carries a unique value.
- New unit tests: nominal OB decode against the config table's values, `z_avg_spread` on a channel mismatch, and reserved-bit masking (`z_avg` 15-bit, `thres_l` 11-bit, `zero_ln_num` 10-bit, `bl_start`/`bl_end` 6-bit).
- **CSV width regression closed:** the CSV tests read rows via `dict(zip(headers, row))`, which truncates silently when the two disagree — a dropped or extra column would have passed. Row width is now asserted on its own, for both success and failure rows.
- Full suite: **562 passed, 177 skipped** (HIL).

Bench validation of the values themselves happens through the firmware PR's HIL test.