### PR TITLE
feat: bootloader-aware firmware flashing (#173)

### DIFF
--- a/omotion/DFUProgrammer.py
+++ b/omotion/DFUProgrammer.py
@@ -10,6 +10,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
 
+from omotion.boot_mode import BootMode, parse_boot_mode
+
 
 @dataclass(frozen=True)
 class DFUProgress:
@@ -120,6 +122,16 @@ class DFUProgrammer:
             check=False,
         )
         return r.stdout or ""
+
+    def detect_boot_mode(self) -> BootMode:
+        """Is the attached DFU device the ST ROM loader, or openmotion-bl?
+
+        Both enumerate as 0483:df11, so this reads the DFU alt-setting layout
+        instead. Returns :data:`BootMode.UNKNOWN` when nothing is attached or
+        the listing is unrecognisable — callers must refuse to flash on that,
+        since the two modes take different flash addresses.
+        """
+        return parse_boot_mode(self.list_devices())
 
     def wait_for_dfu_device(
         self,

--- a/omotion/__init__.py
+++ b/omotion/__init__.py
@@ -59,6 +59,7 @@ from .CalibrationWorkflow import (
     CalibrationThresholds,
 )
 from .connection_state import ConnectionState
+from .boot_mode import BootMode
 from .firmware_update import (
     FirmwareKind,
     FirmwareUpdater,
@@ -66,9 +67,15 @@ from .firmware_update import (
     LatestInfo,
     check_latest,
     download_firmware,
+    UnsupportedReleaseError,
     is_update_available,
     parse_version,
+    production_asset,
 )
+# NOTE: omotion.bootloader_install is deliberately NOT imported here. Converting
+# a device to bootloader mode is irreversible over USB, so reaching that code
+# must be a conscious submodule import, not something `from omotion import *`
+# hands you. See tests/test_bootloader_install.py.
 # Top-level handles + interface (deferred until after the leaf modules above
 # so MotionConsole/MotionSensor can do `from omotion import _log_root` during
 # their own module load without hitting the partially-loaded package).
@@ -101,6 +108,9 @@ __all__ = [
     "LatestInfo",
     "check_latest",
     "download_firmware",
+    "BootMode",
+    "UnsupportedReleaseError",
     "is_update_available",
     "parse_version",
+    "production_asset",
 ]

--- a/omotion/boot_mode.py
+++ b/omotion/boot_mode.py
@@ -1,0 +1,109 @@
+"""Which bootloader is a device running?
+
+An openmotion board in DFU is either sitting in the STM32 ROM loader (no custom
+bootloader installed — a "bare metal" unit) or in openmotion-bl / open-motion-
+console-bl (a converted unit). Both enumerate as **0483:df11**, so VID/PID tells
+you nothing. The DFU alt-setting layout does:
+
+  ROM loader      four alts — Internal Flash, Option Bytes, OTP Memory, Device
+                  Feature — and a fully-writable flash descriptor (``16*128Kg``).
+  openmotion-bl   one alt, whose descriptor carries read-only runs
+                  (``01*128Ka,04*128Kg,11*128Ka``) because everything outside the
+                  application slot is deliberately locked.
+
+That difference decides where a firmware update is written: ``0x08000000`` for a
+bare-metal image, ``0x08020000`` for a signed image in the bootloader's slot.
+Writing one to the other's address produces a brick, so when the evidence is
+ambiguous this module reports :data:`BootMode.UNKNOWN` and callers must refuse to
+flash rather than guess.
+"""
+
+from __future__ import annotations
+
+import re
+from enum import Enum
+
+__all__ = ["BootMode", "parse_boot_mode", "flash_address_for"]
+
+
+class BootMode(Enum):
+    BARE_METAL = "bare_metal"
+    """STM32 ROM loader: no custom bootloader installed."""
+
+    BOOTLOADER = "bootloader"
+    """openmotion-bl / open-motion-console-bl."""
+
+    UNKNOWN = "unknown"
+    """Could not tell. Never flash on this."""
+
+
+#: Bare-metal images link and flash at the base of flash.
+BARE_METAL_FLASH_ADDRESS = "0x08000000"
+
+#: Signed images live in the bootloader's active slot (vectors at +0x400).
+BOOTLOADER_SLOT_ADDRESS = "0x08020000"
+
+_FLASH_ADDRESS = {
+    BootMode.BARE_METAL: BARE_METAL_FLASH_ADDRESS,
+    BootMode.BOOTLOADER: BOOTLOADER_SLOT_ADDRESS,
+}
+
+# `Found DFU: [0483:df11] ver=..., ..., alt=0, name="@Internal Flash/...", serial="..."`
+_ALT_RE = re.compile(r"\balt=(\d+)\b")
+_NAME_RE = re.compile(r'\bname="([^"]*)"')
+
+# DfuSe sector spec: <count>*<size><multiplier><access>, access = 'a'+bitmask
+# where bit0=readable, bit1=erasable, bit2=writable. So 'a' is read-only and
+# 'g' is read/erase/write.
+_SECTOR_RE = re.compile(r"\d+\s*\*\s*\d+\s*[KMB]?\s*([a-g])")
+
+# Alt settings only the ST ROM loader exposes. Presence of any of these is
+# decisive: a listing containing them is the ROM loader regardless of what the
+# flash descriptor looks like.
+_ROM_ONLY_ALTS = ("option bytes", "otp memory", "device feature")
+
+
+def _alt_entries(dfu_util_output: str) -> list[tuple[int, str]]:
+    """Extract ``(alt, name)`` for each `Found DFU:` line."""
+    entries: list[tuple[int, str]] = []
+    for line in dfu_util_output.splitlines():
+        if "found dfu" not in line.lower():
+            continue
+        alt_m = _ALT_RE.search(line)
+        name_m = _NAME_RE.search(line)
+        if alt_m is None or name_m is None:
+            continue
+        entries.append((int(alt_m.group(1)), name_m.group(1)))
+    return entries
+
+
+def parse_boot_mode(dfu_util_output: str) -> BootMode:
+    """Classify a ``dfu-util -l`` listing. Never raises."""
+    entries = _alt_entries(dfu_util_output or "")
+    if not entries:
+        return BootMode.UNKNOWN
+
+    if any(marker in name.lower() for _, name in entries for marker in _ROM_ONLY_ALTS):
+        return BootMode.BARE_METAL
+
+    if len(entries) == 1:
+        _, name = entries[0]
+        if any(access == "a" for access in _SECTOR_RE.findall(name)):
+            return BootMode.BOOTLOADER
+
+    return BootMode.UNKNOWN
+
+
+def flash_address_for(mode: BootMode) -> str:
+    """Address a normal firmware update writes to under ``mode``.
+
+    Raises ``ValueError`` for :data:`BootMode.UNKNOWN` — there is no safe
+    default, and picking one is how a device gets bricked.
+    """
+    try:
+        return _FLASH_ADDRESS[mode]
+    except KeyError:
+        raise ValueError(
+            f"cannot choose a flash address for boot mode {mode.value!r}; "
+            "refusing to guess"
+        ) from None

--- a/omotion/bootloader_install.py
+++ b/omotion/bootloader_install.py
@@ -1,0 +1,98 @@
+"""Convert a bare-metal device to run the openmotion secure bootloader.
+
+**This is irreversible over USB.** Once installed, openmotion-bl clamps its DFU
+write window to the application slot and rejects erase of sector 0, so returning
+a device to bare metal requires SWD/ST-LINK or a BOOT0 strap into the ROM loader.
+The device also accepts only *signed* images from then on, and the bootloader's
+monotonic anti-rollback floor means it will permanently refuse any firmware older
+than the newest it has booted.
+
+Deliberately segregated from :mod:`omotion.firmware_update`:
+
+* this module is **not** re-exported from ``omotion``, so ``from omotion import
+  ...`` cannot reach it — importing it has to be a conscious act;
+* :func:`install_bootloader` requires ``acknowledge_irreversible=True``;
+* :meth:`omotion.firmware_update.FirmwareUpdater.update` has no code path that
+  selects a production image, so ordinary updates can never convert a device.
+
+Applications that must never convert a device (the bloodflow app) simply never
+import this module.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+
+from omotion.boot_mode import BARE_METAL_FLASH_ADDRESS, BootMode
+from omotion.DFUProgrammer import DFUProgrammer, DFUProgress, DFUResult
+from omotion.firmware_update import FirmwareKind, is_production_asset
+
+__all__ = ["BootloaderInstallError", "install_bootloader"]
+
+_STM32_DFU_VIDPID = "0483:df11"
+
+
+class BootloaderInstallError(RuntimeError):
+    """Raised when a bootloader install cannot or must not proceed."""
+
+
+def install_bootloader(
+    handle,
+    kind: FirmwareKind,
+    production_bin: Path,
+    *,
+    acknowledge_irreversible: bool,
+    programmer: DFUProgrammer | None = None,
+    dfu_wait_timeout_s: float = 30.0,
+    progress_cb: Callable[[DFUProgress], None] | None = None,
+) -> DFUResult:
+    """Flash a production image (bootloader + signed app) at ``0x08000000``.
+
+    ``acknowledge_irreversible`` is keyword-only and mandatory: omitting it is a
+    ``TypeError``, so this cannot be called by accident or by code that merely
+    forwards ``**kwargs``.
+
+    Aborts **without writing anything** if the device already has a bootloader,
+    or if its mode cannot be determined. Boot mode is only observable once the
+    device is in DFU, so this is where the "not already installed" guarantee is
+    actually enforced — a UI can grey the button out as a courtesy, but the
+    refusal has to happen here.
+    """
+    if acknowledge_irreversible is not True:
+        raise BootloaderInstallError(
+            "installing a bootloader is irreversible over USB (recovery needs "
+            "SWD or a BOOT0 strap); pass acknowledge_irreversible=True to proceed"
+        )
+
+    production_bin = Path(production_bin)
+    if not is_production_asset(production_bin.name):
+        raise BootloaderInstallError(
+            f"{production_bin.name} is not a production image. Installing a "
+            "bootloader needs the bootloader + signed app image "
+            f"({kind.value} builds publish it as motion-{kind.value}-production.bin)."
+        )
+    if not production_bin.is_file():
+        raise BootloaderInstallError(f"production image not found: {production_bin}")
+
+    dfu = programmer or DFUProgrammer(vidpid=_STM32_DFU_VIDPID)
+
+    if not handle.enter_dfu():
+        raise BootloaderInstallError("device did not accept enter_dfu()")
+    if not dfu.wait_for_dfu_device(timeout_s=dfu_wait_timeout_s):
+        raise BootloaderInstallError("DFU device did not appear after enter_dfu()")
+
+    mode = dfu.detect_boot_mode()
+    if mode is BootMode.BOOTLOADER:
+        raise BootloaderInstallError(
+            "this device already has the bootloader installed; nothing was written"
+        )
+    if mode is not BootMode.BARE_METAL:
+        raise BootloaderInstallError(
+            "could not confirm this device is bare metal; refusing to write a "
+            "production image, because doing so on the wrong device is not undoable"
+        )
+
+    return dfu.flash_bin(
+        production_bin, address=BARE_METAL_FLASH_ADDRESS, progress=progress_cb
+    )

--- a/omotion/firmware_update.py
+++ b/omotion/firmware_update.py
@@ -369,6 +369,11 @@ class FirmwareUpdater:
     ):
         self._dfu = programmer or DFUProgrammer(vidpid=_STM32_DFU_VIDPID)
         self._wait_timeout_s = dfu_wait_timeout_s
+        #: Boot mode observed by the most recent :meth:`update` call, or None
+        #: if it has not run (or never got as far as detecting). A device is
+        #: only classifiable while it sits in DFU, so this is the one chance a
+        #: UI gets to learn what it is talking to.
+        self.last_boot_mode: BootMode | None = None
 
     def update(
         self,
@@ -389,6 +394,7 @@ class FirmwareUpdater:
             raise FirmwareUpdateError("DFU device did not appear after enter_dfu()")
 
         mode = self._dfu.detect_boot_mode()
+        self.last_boot_mode = mode
         if mode is BootMode.UNKNOWN:
             raise FirmwareUpdateError(
                 "could not tell whether this device has the bootloader installed; "

--- a/omotion/firmware_update.py
+++ b/omotion/firmware_update.py
@@ -6,10 +6,11 @@ import re
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Callable
+from typing import Callable, Iterable
 
 from omotion.GitHubReleases import GitHubReleases
 from omotion.DFUProgrammer import DFUProgrammer, DFUProgress, DFUResult
+from omotion.boot_mode import BootMode, flash_address_for
 
 # ---------------------------------------------------------------------------
 # Version parsing
@@ -90,10 +91,140 @@ _REPO = {
     FirmwareKind.CONSOLE: ("OpenwaterHealth", "openmotion-console-fw"),
     FirmwareKind.SENSOR: ("OpenwaterHealth", "openmotion-sensor-fw"),
 }
-_ASSET = {
-    FirmwareKind.CONSOLE: "motion-console-fw.bin",
-    FirmwareKind.SENSOR: "motion-sensor-fw.bin",
+
+# ---------------------------------------------------------------------------
+# Release assets
+#
+# CI renamed every firmware asset on 2026-07-09, when the bootloader-slot build
+# was added alongside the bare-metal one. Releases before that carry a single
+# `motion-{sensor,console}-fw.bin`; releases after carry separate bare-metal,
+# signed and production images. Both eras have to keep working, so each slot
+# below is a preference list: newest name first, legacy name last.
+# ---------------------------------------------------------------------------
+
+# Bare-metal units. Sensor prefers the FPGA-merged image so the bitstream always
+# matches the firmware it shipped with — that is what the legacy single asset
+# was, so behaviour is unchanged for existing callers. Console has no merged
+# variant.
+_BARE_METAL_ASSETS = {
+    FirmwareKind.SENSOR: ("motion-sensor-fw-baremetal-fpga.bin", "motion-sensor-fw.bin"),
+    FirmwareKind.CONSOLE: ("motion-console-fw-baremetal.bin", "motion-console-fw.bin"),
 }
+
+# Bootloader units. Signed slot image only — there is no legacy equivalent,
+# which is why a pre-bootloader release cannot be installed on one.
+_SIGNED_ASSETS = {
+    FirmwareKind.SENSOR: ("motion-sensor-fw-signed.bin",),
+    FirmwareKind.CONSOLE: ("motion-console-fw-signed.bin",),
+}
+
+# bootloader + signed app, for converting a bare-metal unit. Never part of an
+# ordinary update — see omotion.bootloader_install.
+_PRODUCTION_ASSETS = {
+    FirmwareKind.SENSOR: "motion-sensor-production.bin",
+    FirmwareKind.CONSOLE: "motion-console-production.bin",
+}
+
+# First release of each firmware that ships a signed slot image.
+_MIN_BOOTLOADER_TAG = {
+    FirmwareKind.SENSOR: "1.8.2",
+    FirmwareKind.CONSOLE: "1.8.1",
+}
+
+_MODE_ASSETS = {
+    BootMode.BARE_METAL: _BARE_METAL_ASSETS,
+    BootMode.BOOTLOADER: _SIGNED_ASSETS,
+}
+
+
+class UnsupportedReleaseError(RuntimeError):
+    """The selected release has no asset that suits the device's boot mode."""
+
+
+def _first_present(preferences, available) -> str | None:
+    return next((name for name in preferences if name in available), None)
+
+
+def resolve_asset(
+    kind: FirmwareKind,
+    mode: BootMode,
+    asset_names: Iterable[str],
+) -> str:
+    """Pick the asset to flash onto a ``mode`` device from ``asset_names``.
+
+    Raises ``ValueError`` for :data:`BootMode.UNKNOWN` (guessing bricks devices)
+    and ``UnsupportedReleaseError`` when the release predates what the device
+    needs.
+    """
+    try:
+        preferences = _MODE_ASSETS[mode][kind]
+    except KeyError:
+        raise ValueError(
+            f"cannot choose a firmware asset for boot mode {mode.value!r}; "
+            "refusing to guess"
+        ) from None
+
+    available = set(asset_names)
+    name = _first_present(preferences, available)
+    if name is not None:
+        return name
+
+    if mode is BootMode.BOOTLOADER:
+        raise UnsupportedReleaseError(
+            f"this release has no signed image ({preferences[0]}), so it predates "
+            f"bootloader support; {kind.value} needs {_MIN_BOOTLOADER_TAG[kind]} "
+            "or newer to update a device that has the bootloader installed"
+        )
+    raise UnsupportedReleaseError(
+        f"this release has none of {', '.join(preferences)}; cannot update a "
+        f"bare-metal {kind.value}"
+    )
+
+
+def production_asset(kind: FirmwareKind) -> str:
+    """Name of the bootloader + signed app image used to convert a device."""
+    return _PRODUCTION_ASSETS[kind]
+
+
+def is_production_asset(name: str) -> bool:
+    """Does this filename look like a bootloader + signed app image?"""
+    return "production" in Path(name).name.lower()
+
+
+def classify_asset_name(name: str) -> BootMode | None:
+    """Boot mode an asset *filename* implies, or ``None`` if unrecognisable.
+
+    Used to sanity-check files the SDK did not download itself (the test app's
+    "Upload File..." path). A name we do not recognise yields ``None`` — the
+    caller then takes the file at face value rather than refusing outright.
+    Production images are not a boot mode; see :func:`is_production_asset`.
+    """
+    stem = Path(name).name.lower()
+    if "signed" in stem:
+        return BootMode.BOOTLOADER
+    if "baremetal" in stem:
+        return BootMode.BARE_METAL
+    # Legacy single-asset era: bare metal was the only thing that existed.
+    if stem in {"motion-sensor-fw.bin", "motion-console-fw.bin",
+                "motion-sensor-fw-raw.bin", "motion-console-fw-raw.bin"}:
+        return BootMode.BARE_METAL
+    return None
+
+
+def candidate_assets(kind: FirmwareKind, asset_names: Iterable[str]) -> list[str]:
+    """Every asset that might be flashed for an update, in any boot mode.
+
+    Boot mode cannot be known until the device is already in DFU, and by then
+    downloading is inconvenient — so the whole candidate set is fetched up front
+    and the right one picked at flash time. Excludes the production image.
+    """
+    available = set(asset_names)
+    names: list[str] = []
+    for table in (_BARE_METAL_ASSETS, _SIGNED_ASSETS):
+        name = _first_present(table[kind], available)
+        if name is not None and name not in names:
+            names.append(name)
+    return names
 
 
 @dataclass(frozen=True)
@@ -133,12 +264,17 @@ def check_latest(
         if not tag:
             return None
         names = [a.get("name", "") for a in gh.get_asset_list(release=rel, extension=".bin")]
-        if _ASSET[kind] in names:
-            asset_name = _ASSET[kind]
-        elif names:
-            asset_name = names[0]
-        else:
+        if not names:
             return None
+        # The bare-metal image is the primary: it is what the legacy single
+        # asset was, so this keeps LatestInfo.asset_name meaning what it always
+        # meant. download_firmware() fetches the signed sibling alongside it,
+        # and update() swaps to that if the device turns out to have the
+        # bootloader. An unrecognised release falls back to its first .bin.
+        try:
+            asset_name = resolve_asset(kind, BootMode.BARE_METAL, names)
+        except UnsupportedReleaseError:
+            asset_name = names[0]
         return LatestInfo(kind=kind, tag=tag, asset_name=asset_name,
                           published_at=rel.get("published_at"))
     except Exception:
@@ -156,17 +292,65 @@ class FirmwareUpdateError(RuntimeError):
     """Raised when a firmware flash cannot proceed (DFU entry/enumeration)."""
 
 
+# Downloaded-file provenance, so update() can find a sibling asset for whatever
+# boot mode the device turns out to be in. In-process only: callers download and
+# flash within one session, and a stale entry is harmless because the sibling
+# lookup is a directory listing, not a cache.
+_DOWNLOADS: dict[str, tuple[FirmwareKind, str]] = {}
+
+
+def register_download(path: Path, kind: FirmwareKind, tag: str) -> None:
+    """Record that ``path`` came from ``kind``'s release ``tag``."""
+    _DOWNLOADS[str(Path(path).resolve())] = (kind, tag)
+
+
+def _provenance(path: Path) -> tuple[FirmwareKind, str] | None:
+    return _DOWNLOADS.get(str(Path(path).resolve()))
+
+
 def download_firmware(
     info: LatestInfo,
     dest_dir: Path,
     *,
     releases: GitHubReleases | None = None,
 ) -> Path:
-    """Download ``info``'s ``.bin`` asset into ``dest_dir``; returns the path."""
+    """Download ``info``'s release into ``dest_dir``; returns the primary path.
+
+    Fetches **every** asset that could be flashed in any boot mode, not just
+    ``info.asset_name``. The device's mode is unknowable until it is already in
+    DFU, by which point downloading is inconvenient — so the candidate set comes
+    down up front and :meth:`FirmwareUpdater.update` picks from it.
+
+    The return value is unchanged (the primary asset), so existing callers are
+    unaffected.
+    """
     owner, repo = _REPO[info.kind]
     gh = releases or GitHubReleases(owner, repo)
     rel = gh.get_release_by_tag(info.tag)
-    return gh.download_asset(rel, info.asset_name, output_dir=Path(dest_dir))
+    dest_dir = Path(dest_dir)
+
+    available = [a.get("name", "") for a in gh.get_asset_list(release=rel, extension=".bin")]
+    wanted = candidate_assets(info.kind, available)
+    if info.asset_name not in wanted:
+        wanted.insert(0, info.asset_name)
+
+    primary: Path | None = None
+    for name in wanted:
+        try:
+            path = Path(gh.download_asset(rel, name, output_dir=dest_dir))
+        except Exception:
+            # A missing sibling is not fatal: only the primary has to arrive.
+            # update() re-checks what is actually on disk before flashing.
+            continue
+        register_download(path, info.kind, info.tag)
+        if name == info.asset_name:
+            primary = path
+
+    if primary is None:
+        raise FirmwareUpdateError(
+            f"could not download {info.asset_name} from {info.kind.value} release {info.tag}"
+        )
+    return primary
 
 
 class FirmwareUpdater:
@@ -192,8 +376,54 @@ class FirmwareUpdater:
         bin_path: Path,
         progress_cb: Callable[[DFUProgress], None] | None = None,
     ) -> DFUResult:
+        """Flash ``bin_path``, or its sibling suited to the device's boot mode.
+
+        Enters DFU, classifies the device, then flashes the right image at the
+        right address. Never installs a bootloader — see
+        :func:`omotion.bootloader_install.install_bootloader`.
+        """
+        bin_path = Path(bin_path)
         if not handle.enter_dfu():
             raise FirmwareUpdateError("device did not accept enter_dfu()")
         if not self._dfu.wait_for_dfu_device(timeout_s=self._wait_timeout_s):
             raise FirmwareUpdateError("DFU device did not appear after enter_dfu()")
-        return self._dfu.flash_bin(Path(bin_path), progress=progress_cb)
+
+        mode = self._dfu.detect_boot_mode()
+        if mode is BootMode.UNKNOWN:
+            raise FirmwareUpdateError(
+                "could not tell whether this device has the bootloader installed; "
+                "refusing to flash, because the wrong address would brick it"
+            )
+
+        target = self._select_image(bin_path, mode)
+        return self._dfu.flash_bin(
+            target, address=flash_address_for(mode), progress=progress_cb
+        )
+
+    def _select_image(self, bin_path: Path, mode: BootMode) -> Path:
+        if is_production_asset(bin_path.name):
+            raise FirmwareUpdateError(
+                f"{bin_path.name} is a production image (bootloader + signed app). "
+                "Updating cannot install a bootloader — use install_bootloader() "
+                "if that is what you want."
+            )
+
+        provenance = _provenance(bin_path)
+        if provenance is not None:
+            kind, _tag = provenance
+            siblings = [p.name for p in bin_path.parent.iterdir() if p.is_file()]
+            # Raises UnsupportedReleaseError if this release has nothing for
+            # the mode — e.g. a bootloader unit pointed at a legacy release.
+            return bin_path.parent / resolve_asset(kind, mode, siblings)
+
+        # Not something we downloaded (the test app's "Upload File..." path).
+        # We cannot look up siblings, but we can refuse an image whose name says
+        # it belongs at a different address.
+        implied = classify_asset_name(bin_path.name)
+        if implied is not None and implied is not mode:
+            raise FirmwareUpdateError(
+                f"{bin_path.name} looks like a {implied.value} image, but this "
+                f"device is in {mode.value} mode. Flashing it at "
+                f"{flash_address_for(mode)} would corrupt the device."
+            )
+        return bin_path

--- a/tests/test_boot_mode.py
+++ b/tests/test_boot_mode.py
@@ -1,0 +1,92 @@
+"""Boot-mode detection from `dfu-util -l` output.
+
+Both the ST ROM loader and openmotion-bl enumerate as 0483:df11, so VID/PID
+cannot tell them apart. The DFU alt-setting layout can:
+
+  * ROM loader  -> four alts (Internal Flash, Option Bytes, OTP, Device Feature)
+                   and a fully-writable flash descriptor ("16*128Kg")
+  * openmotion-bl -> one alt, with read-only runs ("01*128Ka,04*128Kg,11*128Ka")
+                     because everything outside the app slot is locked
+"""
+
+import pytest
+
+from omotion.boot_mode import BootMode, parse_boot_mode
+
+
+ROM_LISTING = """dfu-util 0.11
+
+Copyright 2005-2009 Weston Schmidt, Harald Welte and OpenMoko Inc.
+Copyright 2010-2021 Tormod Volden and Stefan Schmidt
+
+Found DFU: [0483:df11] ver=2200, devnum=27, cfg=1, intf=0, path="1-4", alt=3, name="@Device Feature/0xFFFF0000/01*004 e", serial="200364500000"
+Found DFU: [0483:df11] ver=2200, devnum=27, cfg=1, intf=0, path="1-4", alt=2, name="@OTP Memory /0x08FFF000/01*1024 e", serial="200364500000"
+Found DFU: [0483:df11] ver=2200, devnum=27, cfg=1, intf=0, path="1-4", alt=1, name="@Option Bytes /0x5200201C/01*128 e", serial="200364500000"
+Found DFU: [0483:df11] ver=2200, devnum=27, cfg=1, intf=0, path="1-4", alt=0, name="@Internal Flash /0x08000000/16*128Kg", serial="200364500000"
+"""
+
+BL_LISTING = """dfu-util 0.11
+
+Copyright 2005-2009 Weston Schmidt, Harald Welte and OpenMoko Inc.
+
+Found DFU: [0483:df11] ver=0200, devnum=31, cfg=1, intf=0, path="1-4", alt=0, name="@Internal Flash/0x08000000/01*128Ka,04*128Kg,11*128Ka", serial="OWSENSORBL"
+"""
+
+NO_DEVICE = """dfu-util 0.11
+
+Copyright 2005-2009 Weston Schmidt, Harald Welte and OpenMoko Inc.
+
+No DFU capable USB device available
+"""
+
+
+def test_rom_loader_listing_is_bare_metal():
+    assert parse_boot_mode(ROM_LISTING) is BootMode.BARE_METAL
+
+
+def test_openmotion_bl_listing_is_bootloader():
+    assert parse_boot_mode(BL_LISTING) is BootMode.BOOTLOADER
+
+
+def test_no_dfu_device_is_unknown():
+    assert parse_boot_mode(NO_DEVICE) is BootMode.UNKNOWN
+
+
+def test_empty_output_is_unknown():
+    assert parse_boot_mode("") is BootMode.UNKNOWN
+
+
+def test_option_bytes_alt_wins_even_if_flash_alt_looks_locked():
+    """A ROM listing must never be read as the custom bootloader. The
+    ROM-only alt settings are the decisive signal, not the sector layout."""
+    weird = ROM_LISTING.replace("16*128Kg", "01*128Ka,15*128Kg")
+    assert parse_boot_mode(weird) is BootMode.BARE_METAL
+
+
+def test_single_fully_writable_alt_is_unknown_not_bootloader():
+    """One alt with no read-only run is not openmotion-bl. Refuse to guess
+    rather than mis-detect and write to the wrong address."""
+    listing = BL_LISTING.replace("01*128Ka,04*128Kg,11*128Ka", "16*128Kg")
+    assert parse_boot_mode(listing) is BootMode.UNKNOWN
+
+
+def test_garbage_output_is_unknown():
+    assert parse_boot_mode("wharrgarbl\nnot a dfu listing at all\n") is BootMode.UNKNOWN
+
+
+@pytest.mark.parametrize("mode,expected", [
+    (BootMode.BARE_METAL, "0x08000000"),
+    (BootMode.BOOTLOADER, "0x08020000"),
+])
+def test_flash_address_for_mode(mode, expected):
+    """The whole point of detection: which address a normal update writes to."""
+    from omotion.boot_mode import flash_address_for
+
+    assert flash_address_for(mode) == expected
+
+
+def test_flash_address_for_unknown_mode_raises():
+    from omotion.boot_mode import flash_address_for
+
+    with pytest.raises(ValueError):
+        flash_address_for(BootMode.UNKNOWN)

--- a/tests/test_bootloader_install.py
+++ b/tests/test_bootloader_install.py
@@ -1,0 +1,142 @@
+"""Installing a bootloader is a separate, deliberately awkward operation.
+
+Converting a device to bootloader mode is irreversible over USB: openmotion-bl
+clamps its DFU write window to the application slot and rejects erase of sector
+0, so getting back to bare metal needs SWD or a BOOT0 strap. The bloodflow app
+must not be able to do it by accident, and neither must an ordinary update.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from omotion.boot_mode import BootMode
+from omotion.bootloader_install import (
+    BootloaderInstallError,
+    install_bootloader,
+)
+from omotion.DFUProgrammer import DFUProgrammer, DFUResult
+from omotion.firmware_update import FirmwareKind
+
+
+class FakeHandle:
+    def __init__(self, accepts_dfu=True):
+        self.accepts_dfu = accepts_dfu
+
+    def enter_dfu(self):
+        return self.accepts_dfu
+
+
+class FakeProgrammer:
+    def __init__(self, mode=BootMode.BARE_METAL, appears=True):
+        self._mode = mode
+        self._appears = appears
+        self.flashed = []
+
+    def wait_for_dfu_device(self, *, timeout_s=30.0):
+        return self._appears
+
+    def detect_boot_mode(self):
+        return self._mode
+
+    def flash_bin(self, bin_path, *, address, progress=None):
+        self.flashed.append((Path(bin_path), address))
+        return DFUResult(command=[], returncode=0, stdout="", success=True)
+
+
+@pytest.fixture
+def production_image(tmp_path):
+    p = tmp_path / "motion-sensor-production.bin"
+    p.write_bytes(b"\x00" * 32)
+    return p
+
+
+def test_requires_explicit_acknowledgement(production_image):
+    prog = FakeProgrammer()
+    with pytest.raises(TypeError):
+        install_bootloader(FakeHandle(), FirmwareKind.SENSOR, production_image,
+                           programmer=prog)          # no acknowledge_irreversible
+    assert prog.flashed == []
+
+
+def test_acknowledgement_must_be_true(production_image):
+    prog = FakeProgrammer()
+    with pytest.raises(BootloaderInstallError):
+        install_bootloader(FakeHandle(), FirmwareKind.SENSOR, production_image,
+                           acknowledge_irreversible=False, programmer=prog)
+    assert prog.flashed == []
+
+
+def test_installs_production_image_at_flash_base(production_image):
+    prog = FakeProgrammer(mode=BootMode.BARE_METAL)
+
+    install_bootloader(FakeHandle(), FirmwareKind.SENSOR, production_image,
+                       acknowledge_irreversible=True, programmer=prog)
+
+    assert prog.flashed == [(production_image, "0x08000000")]
+
+
+def test_aborts_without_writing_if_bootloader_already_present(production_image):
+    """The 'only available if not already installed' guarantee. The UI cannot
+    know the mode before entering DFU, so the refusal happens here."""
+    prog = FakeProgrammer(mode=BootMode.BOOTLOADER)
+
+    with pytest.raises(BootloaderInstallError) as exc:
+        install_bootloader(FakeHandle(), FirmwareKind.SENSOR, production_image,
+                           acknowledge_irreversible=True, programmer=prog)
+    assert "already" in str(exc.value).lower()
+    assert prog.flashed == []
+
+
+def test_aborts_when_mode_cannot_be_determined(production_image):
+    prog = FakeProgrammer(mode=BootMode.UNKNOWN)
+    with pytest.raises(BootloaderInstallError):
+        install_bootloader(FakeHandle(), FirmwareKind.SENSOR, production_image,
+                           acknowledge_irreversible=True, programmer=prog)
+    assert prog.flashed == []
+
+
+def test_refuses_an_image_that_is_not_a_production_image(tmp_path):
+    wrong = tmp_path / "motion-sensor-fw-signed.bin"
+    wrong.write_bytes(b"\x00" * 32)
+    prog = FakeProgrammer()
+
+    with pytest.raises(BootloaderInstallError):
+        install_bootloader(FakeHandle(), FirmwareKind.SENSOR, wrong,
+                           acknowledge_irreversible=True, programmer=prog)
+    assert prog.flashed == []
+
+
+def test_not_reachable_from_the_omotion_package_surface():
+    """The bloodflow app imports from `omotion`. Installation must not be there
+    — reaching it has to be a deliberate submodule import."""
+    import omotion
+
+    assert not hasattr(omotion, "install_bootloader")
+    assert "install_bootloader" not in getattr(omotion, "__all__", [])
+
+
+# ---------------------------------------------------------------------------
+# DFUProgrammer.detect_boot_mode delegates to the parser
+# ---------------------------------------------------------------------------
+
+BL_LISTING = (
+    'Found DFU: [0483:df11] ver=0200, devnum=31, cfg=1, intf=0, path="1-4", '
+    'alt=0, name="@Internal Flash/0x08000000/01*128Ka,04*128Kg,11*128Ka", serial="OWBL"\n'
+)
+
+
+def test_detect_boot_mode_uses_the_dfu_listing():
+    class Programmer(DFUProgrammer):
+        def list_devices(self):
+            return BL_LISTING
+
+    assert Programmer(vidpid="0483:df11").detect_boot_mode() is BootMode.BOOTLOADER
+
+
+def test_detect_boot_mode_unknown_when_nothing_is_listed():
+    class Programmer(DFUProgrammer):
+        def list_devices(self):
+            return "No DFU capable USB device available\n"
+
+    assert Programmer(vidpid="0483:df11").detect_boot_mode() is BootMode.UNKNOWN

--- a/tests/test_firmware_asset_resolution.py
+++ b/tests/test_firmware_asset_resolution.py
@@ -1,0 +1,96 @@
+"""Which release asset gets flashed, for a given device mode and release era.
+
+CI renamed every firmware asset on 2026-07-09 when the bootloader-slot build was
+added. Releases before that carry a single `motion-{sensor,console}-fw.bin`;
+releases after carry separate bare-metal, signed and production images. Both eras
+must keep working.
+"""
+
+import pytest
+
+from omotion.boot_mode import BootMode
+from omotion.firmware_update import (
+    FirmwareKind,
+    UnsupportedReleaseError,
+    candidate_assets,
+    production_asset,
+    resolve_asset,
+)
+
+LEGACY_SENSOR = ["motion-sensor-fw.bin", "motion-sensor-fw-raw.bin"]
+LEGACY_CONSOLE = ["motion-console-fw.bin"]
+
+NEW_SENSOR = [
+    "motion-sensor-fw-baremetal.bin",
+    "motion-sensor-fw-baremetal-fpga.bin",
+    "motion-sensor-fw-signed.bin",
+    "motion-sensor-production.bin",
+]
+NEW_CONSOLE = [
+    "motion-console-fw-baremetal.bin",
+    "motion-console-fw-signed.bin",
+    "motion-console-production.bin",
+]
+
+
+@pytest.mark.parametrize("kind,mode,names,expected", [
+    # Bare metal, new-style release. Sensor takes the FPGA-merged image so the
+    # bitstream always matches the firmware, matching pre-rename behaviour.
+    (FirmwareKind.SENSOR, BootMode.BARE_METAL, NEW_SENSOR,
+     "motion-sensor-fw-baremetal-fpga.bin"),
+    # Console has no merged variant.
+    (FirmwareKind.CONSOLE, BootMode.BARE_METAL, NEW_CONSOLE,
+     "motion-console-fw-baremetal.bin"),
+    # Bare metal, legacy release.
+    (FirmwareKind.SENSOR, BootMode.BARE_METAL, LEGACY_SENSOR, "motion-sensor-fw.bin"),
+    (FirmwareKind.CONSOLE, BootMode.BARE_METAL, LEGACY_CONSOLE, "motion-console-fw.bin"),
+    # Bootloader units take the signed slot image.
+    (FirmwareKind.SENSOR, BootMode.BOOTLOADER, NEW_SENSOR, "motion-sensor-fw-signed.bin"),
+    (FirmwareKind.CONSOLE, BootMode.BOOTLOADER, NEW_CONSOLE, "motion-console-fw-signed.bin"),
+])
+def test_resolve_asset(kind, mode, names, expected):
+    assert resolve_asset(kind, mode, names) == expected
+
+
+@pytest.mark.parametrize("kind,names,minimum", [
+    (FirmwareKind.SENSOR, LEGACY_SENSOR, "1.8.2"),
+    (FirmwareKind.CONSOLE, LEGACY_CONSOLE, "1.8.1"),
+])
+def test_bootloader_unit_rejects_prebootloader_release(kind, names, minimum):
+    """A legacy release has no signed image. Say so, and name the minimum
+    version, rather than silently flashing something else."""
+    with pytest.raises(UnsupportedReleaseError) as exc:
+        resolve_asset(kind, BootMode.BOOTLOADER, names)
+    assert minimum in str(exc.value)
+
+
+def test_unknown_mode_refuses_to_resolve():
+    with pytest.raises(ValueError):
+        resolve_asset(FirmwareKind.SENSOR, BootMode.UNKNOWN, NEW_SENSOR)
+
+
+def test_missing_expected_asset_raises():
+    with pytest.raises(UnsupportedReleaseError):
+        resolve_asset(FirmwareKind.SENSOR, BootMode.BARE_METAL, ["something-else.bin"])
+
+
+@pytest.mark.parametrize("kind,expected", [
+    (FirmwareKind.SENSOR, "motion-sensor-production.bin"),
+    (FirmwareKind.CONSOLE, "motion-console-production.bin"),
+])
+def test_production_asset(kind, expected):
+    assert production_asset(kind) == expected
+
+
+def test_candidate_assets_covers_every_mode():
+    """download_firmware() fetches all mode-candidates up front, because the
+    device's mode is not known until it is already in DFU."""
+    names = candidate_assets(FirmwareKind.SENSOR, NEW_SENSOR)
+    assert "motion-sensor-fw-baremetal-fpga.bin" in names
+    assert "motion-sensor-fw-signed.bin" in names
+    # The production image converts a device; it is never part of an update.
+    assert "motion-sensor-production.bin" not in names
+
+
+def test_candidate_assets_on_legacy_release_is_the_single_image():
+    assert candidate_assets(FirmwareKind.SENSOR, LEGACY_SENSOR) == ["motion-sensor-fw.bin"]

--- a/tests/test_firmware_update.py
+++ b/tests/test_firmware_update.py
@@ -116,10 +116,13 @@ def test_download_firmware_uses_release_by_tag(tmp_path):
 
 
 def test_updater_happy_path(tmp_path):
+    from omotion.boot_mode import BootMode
+
     handle = MagicMock()
     handle.enter_dfu.return_value = True
     dfu = MagicMock()
     dfu.wait_for_dfu_device.return_value = True
+    dfu.detect_boot_mode.return_value = BootMode.BARE_METAL
     dfu.flash_bin.return_value = MagicMock(success=True)
 
     updater = FirmwareUpdater(programmer=dfu)
@@ -128,6 +131,8 @@ def test_updater_happy_path(tmp_path):
     assert result.success is True
     handle.enter_dfu.assert_called_once()
     dfu.flash_bin.assert_called_once()
+    # A bare-metal device is flashed at the base of flash, never the slot.
+    assert dfu.flash_bin.call_args.kwargs["address"] == "0x08000000"
 
 
 def test_updater_raises_if_enter_dfu_rejected(tmp_path):

--- a/tests/test_firmware_update_flow.py
+++ b/tests/test_firmware_update_flow.py
@@ -177,3 +177,30 @@ def test_unregistered_unrecognisable_file_flashes_at_the_mode_address(tmp_path):
     FirmwareUpdater(programmer=prog).update(FakeHandle(), stray)
 
     assert prog.flashed == [(stray, "0x08020000")]
+
+
+def test_updater_records_the_mode_it_detected(release_dir):
+    """UIs need to show what the device turned out to be, and the only moment
+    it is observable is inside update() while the device sits in DFU."""
+    prog = FakeProgrammer(mode=BootMode.BOOTLOADER)
+    updater = FirmwareUpdater(programmer=prog)
+    primary = release_dir / "motion-sensor-fw-baremetal-fpga.bin"
+    register_download(primary, FirmwareKind.SENSOR, "1.8.2")
+
+    assert updater.last_boot_mode is None
+    updater.update(FakeHandle(), primary)
+    assert updater.last_boot_mode is BootMode.BOOTLOADER
+
+
+def test_updater_records_mode_even_when_the_flash_is_refused(release_dir):
+    """A refusal is still information about the device — don't discard it."""
+    legacy = release_dir / "motion-sensor-fw.bin"
+    legacy.write_bytes(b"\x00" * 16)
+    for stale in ("motion-sensor-fw-baremetal-fpga.bin", "motion-sensor-fw-signed.bin"):
+        (release_dir / stale).unlink()
+    register_download(legacy, FirmwareKind.SENSOR, "1.8.1")
+    updater = FirmwareUpdater(programmer=FakeProgrammer(mode=BootMode.BOOTLOADER))
+
+    with pytest.raises(UnsupportedReleaseError):
+        updater.update(FakeHandle(), legacy)
+    assert updater.last_boot_mode is BootMode.BOOTLOADER

--- a/tests/test_firmware_update_flow.py
+++ b/tests/test_firmware_update_flow.py
@@ -1,0 +1,179 @@
+"""FirmwareUpdater picks the asset and address from the device's boot mode.
+
+The device is only classifiable once it is already in DFU, so the flow is:
+enter DFU -> detect -> choose asset + address -> flash.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from omotion.boot_mode import BootMode
+from omotion.DFUProgrammer import DFUResult
+from omotion.firmware_update import (
+    FirmwareKind,
+    FirmwareUpdateError,
+    FirmwareUpdater,
+    UnsupportedReleaseError,
+    register_download,
+)
+
+
+class FakeHandle:
+    def __init__(self, accepts_dfu=True):
+        self.accepts_dfu = accepts_dfu
+        self.enter_dfu_calls = 0
+
+    def enter_dfu(self):
+        self.enter_dfu_calls += 1
+        return self.accepts_dfu
+
+
+class FakeProgrammer:
+    """Stands in for DFUProgrammer; records what would have been flashed."""
+
+    def __init__(self, mode=BootMode.BARE_METAL, appears=True):
+        self._mode = mode
+        self._appears = appears
+        self.flashed = []          # list of (path, address)
+
+    def wait_for_dfu_device(self, *, timeout_s=30.0):
+        return self._appears
+
+    def detect_boot_mode(self):
+        return self._mode
+
+    def flash_bin(self, bin_path, *, address, progress=None):
+        self.flashed.append((Path(bin_path), address))
+        return DFUResult(command=[], returncode=0, stdout="", success=True)
+
+
+@pytest.fixture
+def release_dir(tmp_path):
+    """A download directory holding every candidate for a new-style release."""
+    for name in (
+        "motion-sensor-fw-baremetal-fpga.bin",
+        "motion-sensor-fw-signed.bin",
+    ):
+        (tmp_path / name).write_bytes(b"\x00" * 16)
+    return tmp_path
+
+
+def test_bare_metal_device_flashes_baremetal_image_at_flash_base(release_dir):
+    prog = FakeProgrammer(mode=BootMode.BARE_METAL)
+    updater = FirmwareUpdater(programmer=prog)
+    primary = release_dir / "motion-sensor-fw-baremetal-fpga.bin"
+    register_download(primary, FirmwareKind.SENSOR, "1.8.2")
+
+    updater.update(FakeHandle(), primary)
+
+    assert prog.flashed == [(primary, "0x08000000")]
+
+
+def test_bootloader_device_flashes_signed_image_into_the_slot(release_dir):
+    """Same starting path as the bare-metal case — the detected mode, not the
+    caller, decides which sibling is used."""
+    prog = FakeProgrammer(mode=BootMode.BOOTLOADER)
+    updater = FirmwareUpdater(programmer=prog)
+    primary = release_dir / "motion-sensor-fw-baremetal-fpga.bin"
+    register_download(primary, FirmwareKind.SENSOR, "1.8.2")
+
+    updater.update(FakeHandle(), primary)
+
+    assert prog.flashed == [(release_dir / "motion-sensor-fw-signed.bin", "0x08020000")]
+
+
+def test_unknown_mode_refuses_to_flash_anything(release_dir):
+    prog = FakeProgrammer(mode=BootMode.UNKNOWN)
+    updater = FirmwareUpdater(programmer=prog)
+    primary = release_dir / "motion-sensor-fw-baremetal-fpga.bin"
+    register_download(primary, FirmwareKind.SENSOR, "1.8.2")
+
+    with pytest.raises(FirmwareUpdateError):
+        updater.update(FakeHandle(), primary)
+    assert prog.flashed == []
+
+
+def test_bootloader_device_with_legacy_release_refuses(tmp_path):
+    legacy = tmp_path / "motion-sensor-fw.bin"
+    legacy.write_bytes(b"\x00" * 16)
+    register_download(legacy, FirmwareKind.SENSOR, "1.8.1")
+    prog = FakeProgrammer(mode=BootMode.BOOTLOADER)
+
+    with pytest.raises(UnsupportedReleaseError) as exc:
+        FirmwareUpdater(programmer=prog).update(FakeHandle(), legacy)
+    assert "1.8.2" in str(exc.value)
+    assert prog.flashed == []
+
+
+def test_legacy_release_still_flashes_on_a_bare_metal_device(tmp_path):
+    legacy = tmp_path / "motion-sensor-fw.bin"
+    legacy.write_bytes(b"\x00" * 16)
+    register_download(legacy, FirmwareKind.SENSOR, "1.8.1")
+    prog = FakeProgrammer(mode=BootMode.BARE_METAL)
+
+    FirmwareUpdater(programmer=prog).update(FakeHandle(), legacy)
+
+    assert prog.flashed == [(legacy, "0x08000000")]
+
+
+def test_device_refusing_dfu_raises_before_flashing():
+    prog = FakeProgrammer()
+    with pytest.raises(FirmwareUpdateError):
+        FirmwareUpdater(programmer=prog).update(FakeHandle(accepts_dfu=False), Path("x.bin"))
+    assert prog.flashed == []
+
+
+def test_dfu_device_not_appearing_raises(release_dir):
+    prog = FakeProgrammer(appears=False)
+    primary = release_dir / "motion-sensor-fw-baremetal-fpga.bin"
+    with pytest.raises(FirmwareUpdateError):
+        FirmwareUpdater(programmer=prog).update(FakeHandle(), primary)
+    assert prog.flashed == []
+
+
+def test_unregistered_signed_image_refused_on_bare_metal_device(tmp_path):
+    """The 'Upload File...' path: an arbitrary file the SDK never downloaded.
+    A signed slot image at 0x08000000 would land on the bootloader sector."""
+    stray = tmp_path / "motion-sensor-fw-signed.bin"
+    stray.write_bytes(b"\x00" * 16)
+    prog = FakeProgrammer(mode=BootMode.BARE_METAL)
+
+    with pytest.raises(FirmwareUpdateError):
+        FirmwareUpdater(programmer=prog).update(FakeHandle(), stray)
+    assert prog.flashed == []
+
+
+def test_unregistered_baremetal_image_refused_on_bootloader_device(tmp_path):
+    stray = tmp_path / "motion-sensor-fw-baremetal-fpga.bin"
+    stray.write_bytes(b"\x00" * 16)
+    prog = FakeProgrammer(mode=BootMode.BOOTLOADER)
+
+    with pytest.raises(FirmwareUpdateError):
+        FirmwareUpdater(programmer=prog).update(FakeHandle(), stray)
+    assert prog.flashed == []
+
+
+def test_unregistered_production_image_refused_by_update(tmp_path):
+    """A production image converts a device to bootloader mode. That is never an
+    update, and update() must not be a back door to it."""
+    stray = tmp_path / "motion-sensor-production.bin"
+    stray.write_bytes(b"\x00" * 16)
+    prog = FakeProgrammer(mode=BootMode.BARE_METAL)
+
+    with pytest.raises(FirmwareUpdateError) as exc:
+        FirmwareUpdater(programmer=prog).update(FakeHandle(), stray)
+    assert "install_bootloader" in str(exc.value)
+    assert prog.flashed == []
+
+
+def test_unregistered_unrecognisable_file_flashes_at_the_mode_address(tmp_path):
+    """A file we cannot classify by name is taken at face value and written to
+    whatever the detected mode calls for."""
+    stray = tmp_path / "custom-build.bin"
+    stray.write_bytes(b"\x00" * 16)
+    prog = FakeProgrammer(mode=BootMode.BOOTLOADER)
+
+    FirmwareUpdater(programmer=prog).update(FakeHandle(), stray)
+
+    assert prog.flashed == [(stray, "0x08020000")]


### PR DESCRIPTION
Refs #173

Makes the flasher detect what it is talking to instead of assuming, so updates work against both release eras and both boot modes.

## The problem

CI split every firmware build in two on 2026-07-09 — bare-metal at `0x08000000`, plus a slot image at `0x08020400` signed for the secure bootloader — and renamed the assets. The flasher predated all of it:

- `firmware_update.py` looked for `motion-{sensor,console}-fw.bin`, which no release since publishes
- `DFUProgrammer` flashed at a hardcoded `0x08000000`

So updates failed outright, and the obvious workaround (rename an asset) risked writing a slot-linked image over sector 0.

## Detection

Both the ST ROM loader and `openmotion-bl` enumerate as **0483:df11**, so VID/PID is useless. The DFU alt-setting layout is not:

| | alts | flash descriptor |
|---|---|---|
| ROM loader | 4 — Internal Flash, Option Bytes, OTP, Device Feature | `16*128Kg`, fully writable |
| `openmotion-bl` | 1 | `01*128Ka,04*128Kg,11*128Ka` — read-only outside the slot |

New `omotion/boot_mode.py` parses that from `dfu-util -l`. `DFUProgrammer.list_devices()` already shelled out to it, so this is a parse, not new I/O.

The ROM-only alt names are decisive, checked *before* the sector layout — a ROM listing can never be misread as the bootloader even if its flash descriptor looks locked.

## What gets flashed

| Device | Release | Asset | Address |
|---|---|---|---|
| bare metal | legacy | `motion-{sensor,console}-fw.bin` | `0x08000000` |
| bare metal | current | `...-fw-baremetal-fpga.bin` (sensor) / `...-fw-baremetal.bin` (console) | `0x08000000` |
| bootloader | current | `motion-{sensor,console}-fw-signed.bin` | `0x08020000` |
| bootloader | legacy | **refused**, naming the minimum version | — |

Sensor bare-metal deliberately takes the **FPGA-merged** image: that is what the legacy single asset was, so an update never silently leaves a stale bitstream. Console has no merged variant.

`BootMode.UNKNOWN` always refuses to flash. There is no safe default address, and guessing is how a device gets bricked.

## Keeping the bloodflow app unchanged

`check_latest` / `download_firmware` / `FirmwareUpdater.update` keep their signatures — that app drives updates entirely through those three.

The awkward part is that mode is unknowable until the device is already in DFU, while `download_firmware` has no device contact. Resolution: it now fetches **every mode-candidate** for the release (signed ≈380 KB alongside the merged image) and registers each file's provenance, returning the same primary `Path` as before. `update()` then enters DFU, detects, and flashes the matching sibling from the same directory. No network needed at flash time.

Files the SDK did not download — the test app's "Upload File..." path — have no provenance, so they are checked by *name* and refused when the name says they belong at a different address (a `-signed` image on a bare-metal device, or vice versa). A name we cannot classify is taken at face value and written to the detected mode's address.

## Keeping bootloader installation out of reach

Three structural layers, not convention:

1. `omotion/bootloader_install.py` is **not** re-exported from `omotion` — `from omotion import ...` cannot reach it, and there is a test asserting that.
2. `install_bootloader(..., *, acknowledge_irreversible: bool)` is keyword-only and mandatory; omitting it is a `TypeError`, so no `**kwargs` forwarding can trip it.
3. `FirmwareUpdater.update()` has no code path that selects a production image, and refuses one explicitly if handed it.

It aborts **without writing** when a bootloader is already installed. Since boot mode is only observable inside DFU, that guarantee lives here rather than in a UI — a greyed-out button is a courtesy, this is the enforcement.

## Note on `check_latest`

Removing the old `_ASSET` table initially broke `check_latest` *silently*: the `NameError` was swallowed by its blanket `except Exception: return None`, turning a crash into "no update available". Caught by the existing tests. It now resolves the bare-metal asset through the same table as everything else, preserving its first-`.bin` fallback for unrecognised releases.

That blanket `except` is worth revisiting separately — it is very good at hiding bugs.

## Tests

44 new, across four files: alt-setting parsing (including "refuse rather than mis-detect" cases), the resolution table over {mode} × {era} × {kind}, the update flow end to end with an injected fake programmer, and the installation gate.

```
748 passed, 33 skipped, 29 deselected, 2 xfailed
```

One existing test was updated rather than added to: `test_updater_happy_path`'s mock programmer needed a `detect_boot_mode`, since `update()` legitimately does more than before. It now also asserts the flash address.

**Unrelated flaky test, pre-existing:** `tests/test_console.py` fails intermittently (`test_tec_voltage_read` / `test_telemetry_listener_fires`, timing-dependent). Reproduced on unmodified `next` at 1 failure in 4 runs of that file alone, so it is not from this change. Filed separately.

**Not verified on hardware** — no device here has a bootloader installed. The alt-setting fixtures are representative listings, and the ROM-loader shape should be confirmed against a real device before this is relied on in anger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
