### PR TITLE
feat: flag corrected intervals that span a missed dark

### DIFF
--- a/docs/SciencePipeline.md
+++ b/docs/SciencePipeline.md
@@ -93,6 +93,7 @@ Stages produce events when something doesn't fit cleanly into per-frame arrays. 
 | `LiveEmit(channel, payload)` | `Tee` stages, `SideAverageStage` (realtime path, `"live_side"`) | The named channel's sinks |
 | `IntervalClosed(corrected_batch)` | `DarkCorrectionStage` (per-camera; enriched + stencilled downstream), `SideAverageStage` (reduced-mode `cam_id=-1` side averages) | `"final"` channel sinks |
 | `DarkIntegrityWarning(...)` | `DarkIntegrityGuard` (inside DarkCorrectionStage) | `"diagnostics"` |
+| `MissedDarkWarning(...)` | `DarkCorrectionStage` (on interval close) | `"diagnostics"` |
 | `StencilFallback(...)` | `DarkFrameQuadraticStencil` (inside DarkFrameHoldStage) | `"diagnostics"` |
 | `PipelineError(...)` | `ScanRunner` (a stage raised; the batch was dropped, state preserved) | `"diagnostics"` |
 | `TimestampMisalignmentWindow(...)` | `TimestampRepairStage` (per-side coalesced window; the terminal stop-frame artifact — the firmware's laser-off frame fires ~150 ms off-grid at every scan stop — is reclassified at INFO and NOT reported) | `"diagnostics"` |
@@ -182,6 +183,11 @@ A `delta > 128` (apparent large backward jump) is treated as a packet anomaly an
 | otherwise | `"light"` |
 
 Under the defaults, dark frames occur at `n = 10, 601, 1201, 1801, …`. Every other frame with `n > d` is `"light"`.
+
+The predicate lives in `omotion/pipeline/dark_schedule.py` and is imported by
+both `FrameClassificationStage` (typing frames) and `DarkCorrectionStage`
+(detecting scheduled darks that never arrived). It is defined once — two copies
+would drift and silently corrupt dark correction.
 
 ### 5.2 TelemetryIngestStage
 
@@ -578,6 +584,33 @@ On `on_complete`, any partial accumulator rows are flushed verbatim (with blanks
 **Channels:** `{"final"}`.
 
 SQLite endpoint — **the corrected (final-branch) record only**. On `on_scan_start`, opens a `ScanDatabase` and creates a session row labelled `{scan_id}_{subject_id}`, stamping `session_meta` with `scan_id`, `subject_id`, `operator`, `started_at_iso`, `duration_sec`, `data_semantics: "final"`, and `sdk_flags` (`reduced_mode`, camera masks). Sessions without `data_semantics` were written by older SDKs and hold realtime (live-branch) values in `session_data`.
+
+#### Per-frame quality values
+
+`quality` is a single string per corrected frame, defined once in
+`omotion/pipeline/quality.py`. In increasing severity:
+
+| Value | Meaning |
+|---|---|
+| `ok` | Nothing wrong. |
+| `ts_corrected` | Timestamp replaced by re-anchoring interpolation. |
+| `nan_filled` | Synthetic row standing in for a frame that never arrived. |
+| `wide_interval` | Real measurement, but its dark baseline was interpolated across an interval spanning one or more darks that never arrived. |
+
+Frames are aggregated worst-wins: `SideAverageStage` gives a side-average row
+the most severe quality of any camera that contributed to it.
+
+`wide_interval` frames are **kept, not discarded** — valid darks still bound the
+widened interval on both sides, so the data is degraded rather than
+uncorrectable. One missed dark degrades roughly `2 x dark_interval` frames,
+about 30 s at the defaults. It ranks above `nan_filled` because it is the only
+value that silently biases an aggregate: a NaN frame drops out of the side
+average on its own, whereas this one contributes real-looking numbers built on a
+stretched baseline.
+
+Note the value reaches only `session_data.quality` in the scan DB — the
+corrected CSV's quality column was removed in `5c3e107`. The `MissedDarkWarning`
+diagnostic event and the scan-summary tally are the surfaces independent of that.
 
 - **Normal mode** — one `session_data` row per per-camera `EnrichedCorrectedFrame` (`cam_id` 0..7, `side` 0/1, `frame_id` = absolute frame id) carrying `bfi`, `bvi`, `mean`, `contrast`, `quality`. The stencilled leading dark frame of each interval is included, so the record is gapless at 40 Hz (except warmup frames 1..`discard_count` and the scan's terminal dark frame).
 - **Reduced mode** — only the `cam_id=-1` side-average frames emitted by `SideAverageStage` are persisted; per-camera frames are skipped.

--- a/docs/SciencePipeline.md
+++ b/docs/SciencePipeline.md
@@ -410,6 +410,8 @@ After producing the stencil value, the stage updates `_prev_interval_tail` with 
 
 By dispatch time the `IntervalClosed` carries an `EnrichedCorrectedInterval` with frames in chronological order: `[D_prev_stencilled, L_1, L_2, …, L_k]`. The closing dark `D_next` is **not** in this interval — it becomes `D_prev` of the next interval and gets its stencil value then. (The scan's terminal dark therefore never receives a corrected row — the one by-design gap besides warmup.)
 
+On interval close, the boundaries are checked against the dark schedule: any scheduled dark position falling strictly inside `[left_abs, right_abs]` means a dark never arrived, so the baseline was interpolated across a gap roughly double the nominal interval width. When that happens every frame in the interval — including the stencilled `D_prev` row — is flagged `wide_interval`, and a `MissedDarkWarning` is emitted on the `"diagnostics"` channel. See §8.2.1 for the full quality vocabulary and severity ordering.
+
 #### 5.7.8 Terminal-dark flush — `on_scan_stop(batch)`
 
 The firmware guarantees the **last frame of every scan is a dark frame**, regardless of when the scan was stopped. For scans shorter than one full dark interval, that terminal dark won't fall on a scheduled dark position, so the pipeline receives it as the last buffered light frame in `pi._light`.

--- a/docs/SciencePipeline.md
+++ b/docs/SciencePipeline.md
@@ -585,7 +585,7 @@ On `on_complete`, any partial accumulator rows are flushed verbatim (with blanks
 
 SQLite endpoint — **the corrected (final-branch) record only**. On `on_scan_start`, opens a `ScanDatabase` and creates a session row labelled `{scan_id}_{subject_id}`, stamping `session_meta` with `scan_id`, `subject_id`, `operator`, `started_at_iso`, `duration_sec`, `data_semantics: "final"`, and `sdk_flags` (`reduced_mode`, camera masks). Sessions without `data_semantics` were written by older SDKs and hold realtime (live-branch) values in `session_data`.
 
-#### Per-frame quality values
+#### 8.2.1 Per-frame quality values
 
 `quality` is a single string per corrected frame, defined once in
 `omotion/pipeline/quality.py`. In increasing severity:

--- a/docs/superpowers/plans/2026-07-21-missed-dark-policy.md
+++ b/docs/superpowers/plans/2026-07-21-missed-dark-policy.md
@@ -93,7 +93,33 @@ def test_missed_dark_ids_reports_every_gap():
     with dark_interval=3, darks fall at 10, 13, 16, 19."""
     cfg = {"discard_count": 9, "dark_interval": 3}
     assert missed_dark_ids(10, 19, **cfg) == [13, 16]
+
+
+def test_adjacent_boundaries_have_nothing_between():
+    assert missed_dark_ids(10, 11, **DEFAULTS) == []
+
+
+def test_non_advancing_range_is_empty():
+    """Stated contract, not an accident of range() — a swapped-argument bug at
+    a call site would otherwise silently report 'nothing missed'."""
+    assert missed_dark_ids(1201, 10, **DEFAULTS) == []
+
+
+def test_zero_discard_count_puts_the_first_dark_at_frame_one():
+    assert is_dark_frame(1, discard_count=0, dark_interval=600)
+    assert not is_dark_frame(0, discard_count=0, dark_interval=600)
+
+
+def test_non_positive_dark_interval_is_rejected():
+    """Fail loudly: a bare ZeroDivisionError from inside a list comprehension
+    is a poor diagnostic for a config error, and a negative interval would be
+    silently wrong rather than an error at all."""
+    for bad in (0, -1):
+        with pytest.raises(ValueError):
+            is_dark_frame(10, discard_count=9, dark_interval=bad)
 ```
+
+Note the test module needs `import pytest` for the last test.
 
 - [ ] **Step 2: Run test to verify it fails**
 
@@ -122,7 +148,15 @@ def is_dark_frame(abs_id: int, *, discard_count: int, dark_interval: int) -> boo
     Per SciencePipeline.md §4.2:
         n == discard_count + 1
         OR (n > discard_count + 1 AND (n - 1) mod dark_interval == 0)
+
+    Raises ValueError for a non-positive dark_interval — this module is the
+    single source of truth for two stages, so a bad config must fail loudly
+    rather than as a ZeroDivisionError inside a list comprehension (or, for a
+    negative value, as silently wrong output: Python's % takes the sign of the
+    divisor).
     """
+    if dark_interval <= 0:
+        raise ValueError(f"dark_interval must be positive, got {dark_interval}")
     if abs_id == discard_count + 1:
         return True
     if abs_id <= discard_count + 1:
@@ -139,6 +173,10 @@ def missed_dark_ids(left_abs: int, right_abs: int, *,
     the interval spans wider than nominal and its baseline interpolation is
     stretched across the gap. Both endpoints are excluded — they are the
     darks that did arrive.
+
+    A non-advancing range (left_abs >= right_abs) yields an empty list. That
+    is the correct answer, and is stated here so it reads as a contract rather
+    than an accident of range() semantics.
     """
     return [
         n for n in range(int(left_abs) + 1, int(right_abs))
@@ -150,7 +188,7 @@ def missed_dark_ids(left_abs: int, right_abs: int, *,
 - [ ] **Step 4: Run test to verify it passes**
 
 Run: `python -m pytest tests/test_pipeline/test_dark_schedule.py -q`
-Expected: PASS, 8 passed
+Expected: PASS, 12 passed
 
 - [ ] **Step 5: Commit**
 

--- a/docs/superpowers/plans/2026-07-21-missed-dark-policy.md
+++ b/docs/superpowers/plans/2026-07-21-missed-dark-policy.md
@@ -1,0 +1,921 @@
+# Missed-Dark Policy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When a scheduled dark frame never arrives, flag every corrected frame in the resulting over-wide interval as `wide_interval` and emit a diagnostic, instead of silently interpolating the dark baseline across a doubled span.
+
+**Architecture:** The dark schedule predicate moves out of `FrameClassificationStage` into a shared module. `DarkCorrectionStage` gains the schedule config, and on each interval close counts scheduled dark positions falling strictly inside `[left_abs, right_abs]`. One or more means darks were missed: every frame in the interval gets its `quality` escalated, and a `MissedDarkWarning` is appended. No changes to `timestamp_repair`, the sinks, or the runner.
+
+**Tech Stack:** Python 3.12+, NumPy, pytest. Package `omotion.pipeline`.
+
+**Spec:** `docs/superpowers/specs/2026-07-21-missed-dark-policy-design.md`
+
+---
+
+## File Structure
+
+| File | Status | Responsibility |
+|---|---|---|
+| `omotion/pipeline/dark_schedule.py` | create | Sole definition of the positional dark schedule: `is_dark_frame`, `missed_dark_ids` |
+| `omotion/pipeline/quality.py` | create | Sole definition of `QUALITY_RANK` + `worse_of` escalation helper |
+| `omotion/pipeline/batch.py` | modify | Add `MissedDarkWarning` event |
+| `omotion/pipeline/stages/classify.py` | modify | Delegate `_is_dark` to the shared predicate |
+| `omotion/pipeline/stages/side_avg.py` | modify | Import the shared rank instead of declaring its own |
+| `omotion/pipeline/stages/dark.py` | modify | Accept schedule config; detect, mark, and report missed darks |
+| `omotion/pipeline/factory.py` | modify | Pass `discard_count` / `dark_interval` to `DarkCorrectionStage` |
+| `tests/test_pipeline/test_dark_schedule.py` | create | Schedule predicate + missed-id enumeration |
+| `tests/test_pipeline/test_quality.py` | create | Rank ordering + escalation |
+| `tests/test_pipeline/test_dark_correction_stage.py` | modify | Missed-dark detection, marking, event |
+| `tests/test_pipeline/test_corrected_side_avg_stage.py` | modify | Side-average inherits `wide_interval` |
+
+Two new modules rather than one: the dark schedule and the quality vocabulary are unrelated concerns. Both sit alongside the existing non-stage modules (`batch.py`, `pedestal.py`, `tee.py`).
+
+---
+
+### Task 1: Shared dark-schedule module
+
+**Files:**
+- Create: `omotion/pipeline/dark_schedule.py`
+- Test: `tests/test_pipeline/test_dark_schedule.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_pipeline/test_dark_schedule.py`:
+
+```python
+"""The positional dark schedule — single source of truth for both
+FrameClassificationStage (which types frames) and DarkCorrectionStage
+(which detects darks that never arrived)."""
+
+from omotion.pipeline.dark_schedule import is_dark_frame, missed_dark_ids
+
+
+DEFAULTS = {"discard_count": 9, "dark_interval": 600}
+
+
+def test_first_dark_is_at_discard_count_plus_one():
+    assert is_dark_frame(10, **DEFAULTS)
+
+
+def test_warmup_frames_are_not_dark():
+    for abs_id in range(1, 10):
+        assert not is_dark_frame(abs_id, **DEFAULTS)
+
+
+def test_subsequent_darks_land_every_dark_interval():
+    assert is_dark_frame(601, **DEFAULTS)
+    assert is_dark_frame(1201, **DEFAULTS)
+
+
+def test_ordinary_light_frames_are_not_dark():
+    for abs_id in (11, 300, 600, 602, 1200):
+        assert not is_dark_frame(abs_id, **DEFAULTS)
+
+
+def test_missed_dark_ids_finds_the_gap():
+    """Interval 10..1201 should have closed at 601; that dark never arrived."""
+    assert missed_dark_ids(10, 1201, **DEFAULTS) == [601]
+
+
+def test_missed_dark_ids_empty_for_a_nominal_interval():
+    assert missed_dark_ids(601, 1201, **DEFAULTS) == []
+    assert missed_dark_ids(10, 601, **DEFAULTS) == []
+
+
+def test_missed_dark_ids_excludes_both_endpoints():
+    """The bounding darks themselves are not 'missed'."""
+    assert 10 not in missed_dark_ids(10, 1201, **DEFAULTS)
+    assert 1201 not in missed_dark_ids(10, 1201, **DEFAULTS)
+
+
+def test_missed_dark_ids_reports_every_gap():
+    """A short interval makes multiple consecutive misses easy to construct:
+    with dark_interval=3, darks fall at 10, 13, 16, 19."""
+    cfg = {"discard_count": 9, "dark_interval": 3}
+    assert missed_dark_ids(10, 19, **cfg) == [13, 16]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_pipeline/test_dark_schedule.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'omotion.pipeline.dark_schedule'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `omotion/pipeline/dark_schedule.py`:
+
+```python
+"""The positional dark-frame schedule.
+
+Single source of truth, imported by both FrameClassificationStage (which
+types incoming frames) and DarkCorrectionStage (which detects scheduled
+darks that never arrived). Two independent copies of this rule would drift
+and silently corrupt dark correction — see docs/SciencePipeline.md §4.2.
+"""
+
+from __future__ import annotations
+
+
+def is_dark_frame(abs_id: int, *, discard_count: int, dark_interval: int) -> bool:
+    """True when abs_id lands on a scheduled dark position.
+
+    Per SciencePipeline.md §4.2:
+        n == discard_count + 1
+        OR (n > discard_count + 1 AND (n - 1) mod dark_interval == 0)
+    """
+    if abs_id == discard_count + 1:
+        return True
+    if abs_id <= discard_count + 1:
+        return False
+    return (abs_id - 1) % dark_interval == 0
+
+
+def missed_dark_ids(left_abs: int, right_abs: int, *,
+                    discard_count: int, dark_interval: int) -> list[int]:
+    """Scheduled dark positions strictly between two interval boundaries.
+
+    A closed interval should be bounded by consecutive scheduled darks. Any
+    scheduled position falling *inside* it is a dark that never arrived, so
+    the interval spans wider than nominal and its baseline interpolation is
+    stretched across the gap. Both endpoints are excluded — they are the
+    darks that did arrive.
+    """
+    return [
+        n for n in range(int(left_abs) + 1, int(right_abs))
+        if is_dark_frame(n, discard_count=discard_count,
+                         dark_interval=dark_interval)
+    ]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_pipeline/test_dark_schedule.py -q`
+Expected: PASS, 8 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add omotion/pipeline/dark_schedule.py tests/test_pipeline/test_dark_schedule.py
+git commit -m "feat: extract the dark schedule into a shared module (#175)"
+```
+
+---
+
+### Task 2: Delegate classify.py to the shared predicate
+
+**Files:**
+- Modify: `omotion/pipeline/stages/classify.py` (`_is_dark`, around line 175)
+- Test: `tests/test_pipeline/test_classify_stage.py` (existing, unchanged)
+
+This is a pure refactor — behaviour must not change. The existing classify suite is the regression test.
+
+- [ ] **Step 1: Run the existing suite to record the baseline**
+
+Run: `python -m pytest tests/test_pipeline/test_classify_stage.py -q`
+Expected: PASS (note the count; it must be identical after the change)
+
+- [ ] **Step 2: Replace the inline predicate**
+
+In `omotion/pipeline/stages/classify.py`, add to the imports near the top:
+
+```python
+from ..dark_schedule import is_dark_frame
+```
+
+Then replace the whole `_is_dark` method body:
+
+```python
+    def _is_dark(self, abs_id: int) -> bool:
+        """Per SciencePipeline.md §4.2 — delegated to the shared schedule so
+        DarkCorrectionStage cannot drift from this definition."""
+        return is_dark_frame(abs_id,
+                             discard_count=self.discard_count,
+                             dark_interval=self.dark_interval)
+```
+
+- [ ] **Step 3: Run the suite to verify unchanged behaviour**
+
+Run: `python -m pytest tests/test_pipeline/test_classify_stage.py -q`
+Expected: PASS with the same count as Step 1
+
+- [ ] **Step 4: Run the whole pipeline suite**
+
+Run: `python -m pytest tests/test_pipeline/ -q`
+Expected: PASS, no failures
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add omotion/pipeline/stages/classify.py
+git commit -m "refactor: classify delegates to the shared dark schedule (#175)"
+```
+
+---
+
+### Task 3: Shared quality rank module
+
+**Files:**
+- Create: `omotion/pipeline/quality.py`
+- Test: `tests/test_pipeline/test_quality.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_pipeline/test_quality.py`:
+
+```python
+"""Quality vocabulary — ranking and worst-wins escalation."""
+
+from omotion.pipeline.quality import QUALITY_RANK, worse_of
+
+
+def test_rank_order():
+    assert (QUALITY_RANK["ok"]
+            < QUALITY_RANK["ts_corrected"]
+            < QUALITY_RANK["nan_filled"]
+            < QUALITY_RANK["wide_interval"])
+
+
+def test_wide_interval_outranks_nan_filled():
+    """A nan_filled camera emits NaN and drops out of the side average on its
+    own; a wide-interval camera contributes real-looking numbers built on a
+    stretched baseline. The flag that silently biases the aggregate must win,
+    or the side-average row would hide it."""
+    assert worse_of("nan_filled", "wide_interval") == "wide_interval"
+    assert worse_of("wide_interval", "nan_filled") == "wide_interval"
+
+
+def test_worse_of_picks_the_higher_rank():
+    assert worse_of("ok", "ts_corrected") == "ts_corrected"
+    assert worse_of("nan_filled", "ok") == "nan_filled"
+
+
+def test_worse_of_is_stable_for_equal_values():
+    assert worse_of("ok", "ok") == "ok"
+    assert worse_of("wide_interval", "wide_interval") == "wide_interval"
+
+
+def test_unknown_values_rank_as_ok():
+    """Documented hazard: an unrecognised string ranks 0. Any consumer holding
+    its own copy of the rank map would treat a newer value as the BEST quality.
+    This is why the rank lives here and is imported, never re-declared."""
+    assert worse_of("something_new", "ok") == "ok"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_pipeline/test_quality.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'omotion.pipeline.quality'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `omotion/pipeline/quality.py`:
+
+```python
+"""Per-frame quality vocabulary.
+
+Single source of truth for the quality values and their severity ordering.
+Import QUALITY_RANK — never re-declare it. `worse_of` treats an unrecognised
+value as rank 0 ("ok"), so a stale copy of this table would rank a newer value
+as the BEST quality rather than the worst, inverting its meaning.
+
+Values, in increasing severity:
+    ok             — nothing wrong
+    ts_corrected   — timestamp replaced by re-anchoring interpolation
+    nan_filled     — synthetic row standing in for a frame that never arrived
+    wide_interval  — real measurement, but its dark baseline was interpolated
+                     across an interval that spans one or more missing darks
+"""
+
+from __future__ import annotations
+
+
+QUALITY_RANK: dict[str, int] = {
+    "ok": 0,
+    "ts_corrected": 1,
+    "nan_filled": 2,
+    "wide_interval": 3,
+}
+
+
+def worse_of(a: str, b: str) -> str:
+    """Return whichever quality value is more severe (ties return `a`)."""
+    return a if QUALITY_RANK.get(a, 0) >= QUALITY_RANK.get(b, 0) else b
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_pipeline/test_quality.py -q`
+Expected: PASS, 5 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add omotion/pipeline/quality.py tests/test_pipeline/test_quality.py
+git commit -m "feat: shared quality rank with wide_interval (#175)"
+```
+
+---
+
+### Task 4: Point side_avg.py at the shared rank
+
+**Files:**
+- Modify: `omotion/pipeline/stages/side_avg.py:37-39` and `:240`
+- Test: `tests/test_pipeline/test_corrected_side_avg_stage.py` (existing, unchanged)
+
+- [ ] **Step 1: Replace the local rank table**
+
+In `omotion/pipeline/stages/side_avg.py`, delete these three lines (37-39):
+
+```python
+# Higher rank = worse quality; the side average inherits the worst quality
+# of any camera that contributed to it. Mirrors sinks._QUALITY_RANK.
+_QUALITY_RANK = {"ok": 0, "ts_corrected": 1, "nan_filled": 2}
+```
+
+(The "Mirrors sinks._QUALITY_RANK" claim is stale — `sinks.py` lost that constant in `5c3e107`.)
+
+Add to the imports near the top, next to `from ..batch import ...`:
+
+```python
+from ..quality import worse_of
+```
+
+- [ ] **Step 2: Use the shared helper**
+
+In `_ingest_corrected`, replace these lines (around 239-241):
+
+```python
+        fq = str(getattr(f, "quality", "ok") or "ok")
+        if _QUALITY_RANK.get(fq, 0) > _QUALITY_RANK.get(rec["quality"], 0):
+            rec["quality"] = fq
+```
+
+with:
+
+```python
+        # The side average inherits the worst quality of any camera that
+        # contributed to it.
+        fq = str(getattr(f, "quality", "ok") or "ok")
+        rec["quality"] = worse_of(rec["quality"], fq)
+```
+
+- [ ] **Step 3: Run the side-average suites**
+
+Run: `python -m pytest tests/test_pipeline/test_corrected_side_avg_stage.py tests/test_pipeline/test_side_avg_stage.py -q`
+Expected: PASS, no failures
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add omotion/pipeline/stages/side_avg.py
+git commit -m "refactor: side_avg imports the shared quality rank (#175)"
+```
+
+---
+
+### Task 5: MissedDarkWarning event
+
+**Files:**
+- Modify: `omotion/pipeline/batch.py` (after `DarkIntegrityWarning`, around line 54)
+- Test: `tests/test_pipeline/test_batch.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_pipeline/test_batch.py`:
+
+```python
+def test_missed_dark_warning_carries_the_gap():
+    from omotion.pipeline.batch import BatchEvent, MissedDarkWarning
+
+    ev = MissedDarkWarning(
+        side="left", cam_id=3, expected_abs_ids=[601],
+        left_abs=10, right_abs=1201, n_missed=1,
+    )
+    assert isinstance(ev, BatchEvent)
+    assert ev.expected_abs_ids == [601]
+    assert ev.n_missed == 1
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_pipeline/test_batch.py::test_missed_dark_warning_carries_the_gap -q`
+Expected: FAIL — `ImportError: cannot import name 'MissedDarkWarning'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `omotion/pipeline/batch.py`, immediately after the `DarkIntegrityWarning` class:
+
+```python
+@dataclass
+class MissedDarkWarning(BatchEvent):
+    """One or more scheduled dark frames never arrived, so the interval that
+    closed spans wider than nominal and its baseline was interpolated across
+    the gap. Frames are still emitted, flagged quality="wide_interval" — this
+    is a diagnostic event, not a drop signal."""
+    side: str
+    cam_id: int
+    expected_abs_ids: list[int]
+    left_abs: int
+    right_abs: int
+    n_missed: int
+```
+
+No runner or sink change is needed: `runner.py:159` routes any event that is neither `LiveEmit` nor `IntervalClosed` to the `"diagnostics"` channel, and the diagnostics sinks tally by event type.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_pipeline/test_batch.py -q`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add omotion/pipeline/batch.py tests/test_pipeline/test_batch.py
+git commit -m "feat: MissedDarkWarning diagnostic event (#175)"
+```
+
+---
+
+### Task 6: Detect, mark, and report missed darks
+
+**Files:**
+- Modify: `omotion/pipeline/stages/dark.py` — imports (line 20), `DarkCorrectionStage.__init__`, `_emit_interval` (line 423)
+- Test: `tests/test_pipeline/test_dark_correction_stage.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_pipeline/test_dark_correction_stage.py`:
+
+```python
+def _stage_with_schedule(dark_interval):
+    """dark_interval=3 puts scheduled darks at abs_id 10, 13, 16, 19 —
+    compact enough to construct a missed dark in a handful of frames."""
+    return DarkCorrectionStage(
+        realtime_estimator=HybridRealtimePredictor(),
+        batch_estimator=LinearInterpolation(),
+        discard_count=9,
+        dark_interval=dark_interval,
+    )
+
+
+def _interval_batch(frame_types, abs_ids):
+    n = len(abs_ids)
+    mean = np.full((n, 2, 8), 500.0, dtype=np.float32)
+    std = np.full((n, 2, 8), 20.0, dtype=np.float32)
+    for i, ft in enumerate(frame_types):
+        if ft == "dark":
+            mean[i, :, :] = 100.0
+            std[i, :, :] = 10.0
+    return _batch(n, frame_types, abs_ids, mean_raw=mean, std_raw=std)
+
+
+def test_nominal_interval_leaves_quality_untouched():
+    """Darks at 10 and 13 are consecutive scheduled positions — nothing missed."""
+    batch = _interval_batch(["dark", "light", "light", "dark"], [10, 11, 12, 13])
+    _stage_with_schedule(3).process(batch)
+
+    frames = [f for e in batch.events if isinstance(e, IntervalClosed)
+              for f in e.corrected_batch.frames]
+    assert frames, "expected an interval to close"
+    assert all(f.quality == "ok" for f in frames)
+
+
+def test_missed_dark_flags_every_frame_in_the_widened_interval():
+    """The dark at 13 never arrives, so the interval closes 10..16 instead."""
+    batch = _interval_batch(
+        ["dark", "light", "light", "light", "light", "dark"],
+        [10, 11, 12, 14, 15, 16],
+    )
+    _stage_with_schedule(3).process(batch)
+
+    frames = [f for e in batch.events if isinstance(e, IntervalClosed)
+              for f in e.corrected_batch.frames]
+    assert frames, "expected an interval to close"
+    assert all(f.quality == "wide_interval" for f in frames)
+
+
+def test_missed_dark_emits_a_warning_event():
+    from omotion.pipeline.batch import MissedDarkWarning
+
+    batch = _interval_batch(
+        ["dark", "light", "light", "light", "light", "dark"],
+        [10, 11, 12, 14, 15, 16],
+    )
+    _stage_with_schedule(3).process(batch)
+
+    warnings = [e for e in batch.events if isinstance(e, MissedDarkWarning)]
+    assert len(warnings) == 1
+    w = warnings[0]
+    assert w.expected_abs_ids == [13]
+    assert w.n_missed == 1
+    assert (w.left_abs, w.right_abs) == (10, 16)
+    assert w.side == "left" and w.cam_id == 0
+
+
+def test_missed_dark_escalates_over_an_existing_quality():
+    """A frame already flagged nan_filled ends up wide_interval, since that is
+    the flag that biases the aggregate."""
+    batch = _interval_batch(
+        ["dark", "light", "light", "light", "light", "dark"],
+        [10, 11, 12, 14, 15, 16],
+    )
+    batch.quality = np.array(
+        ["ok", "nan_filled", "ok", "ok", "ok", "ok"], dtype="<U14")
+    _stage_with_schedule(3).process(batch)
+
+    frames = [f for e in batch.events if isinstance(e, IntervalClosed)
+              for f in e.corrected_batch.frames]
+    assert all(f.quality == "wide_interval" for f in frames)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_pipeline/test_dark_correction_stage.py -q -k "missed or nominal_interval"`
+Expected: FAIL — `TypeError: __init__() got an unexpected keyword argument 'discard_count'`
+
+- [ ] **Step 3: Accept the schedule config**
+
+In `omotion/pipeline/stages/dark.py`, extend the import on line 20:
+
+```python
+from ..batch import (
+    DarkIntegrityWarning, FrameBatch, IntervalClosed, MissedDarkWarning,
+    TerminalDarkResult,
+)
+```
+
+Add two more imports below it:
+
+```python
+from ..dark_schedule import missed_dark_ids
+from ..quality import worse_of
+```
+
+Then extend `DarkCorrectionStage.__init__` — add the two parameters and store them:
+
+```python
+    def __init__(self, *,
+                 realtime_estimator: HybridRealtimePredictor,
+                 batch_estimator: LinearInterpolation,
+                 pedestals: Optional[SensorPedestals] = None,
+                 realtime_history_size: int = 4,
+                 integrity_max_above_pedestal: float = 5.0,
+                 discard_count: int = 9,
+                 dark_interval: int = 600):
+        self._realtime = realtime_estimator
+        self._batch = batch_estimator
+        self._pedestals = pedestals or SensorPedestals(left=64.0, right=64.0)
+        self._discard_count = int(discard_count)
+        self._dark_interval = int(dark_interval)
+        self._history = DarkHistory(max_darks=realtime_history_size)
+```
+
+(Leave the remaining body of `__init__` exactly as it is.)
+
+- [ ] **Step 4: Detect, mark, and report in `_emit_interval`**
+
+Replace the body of `_emit_interval`:
+
+```python
+    def _emit_interval(
+        self,
+        key: "tuple[str, int]",
+        interval: "Interval",
+        events: list,
+    ) -> None:
+        """Correct interval and emit IntervalClosed with raw CorrectedInterval.
+
+        Downstream stages handle shot-noise, BFI/BVI, and the dark-frame
+        quadratic stencil.
+
+        A closed interval should be bounded by consecutive scheduled darks. Any
+        scheduled position falling inside it is a dark that never arrived, so
+        the baseline was interpolated across the gap — every frame is flagged
+        `wide_interval` and a MissedDarkWarning is raised (#175).
+        """
+        side, cam_id = key
+        corrected = self._batch.correct_interval(interval, side=side, cam_id=cam_id)
+        corrected.left_t = interval.left.obs.t
+
+        missed = missed_dark_ids(
+            interval.left_abs, interval.right_abs,
+            discard_count=self._discard_count,
+            dark_interval=self._dark_interval,
+        )
+        if missed:
+            for f in corrected.frames:
+                f.quality = worse_of(f.quality, "wide_interval")
+            events.append(MissedDarkWarning(
+                side=side, cam_id=int(cam_id),
+                expected_abs_ids=list(missed),
+                left_abs=int(interval.left_abs),
+                right_abs=int(interval.right_abs),
+                n_missed=len(missed),
+            ))
+            logger.warning(
+                "missed dark: side=%s cam=%d — scheduled dark(s) at %s never "
+                "arrived; interval %d..%d spans the gap, baseline interpolated "
+                "across %d frames instead of the nominal %d. Frames flagged "
+                "wide_interval.",
+                side, int(cam_id), missed,
+                int(interval.left_abs), int(interval.right_abs),
+                int(interval.right_abs) - int(interval.left_abs),
+                self._dark_interval,
+            )
+
+        events.append(IntervalClosed(corrected_batch=corrected))
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_pipeline/test_dark_correction_stage.py -q`
+Expected: PASS, no failures
+
+- [ ] **Step 6: Run the whole pipeline suite**
+
+Run: `python -m pytest tests/test_pipeline/ -q`
+Expected: PASS, no failures. In particular `test_golden_replay.py` must still pass — its fixture has no missing darks, so no frame should acquire a `wide_interval` flag.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add omotion/pipeline/stages/dark.py tests/test_pipeline/test_dark_correction_stage.py
+git commit -m "feat: flag intervals that span a missed dark (#175)"
+```
+
+---
+
+### Task 7: Wire the schedule through the factory
+
+**Files:**
+- Modify: `omotion/pipeline/factory.py` (the `DarkCorrectionStage(...)` call)
+- Test: `tests/test_pipeline/test_factory.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_pipeline/test_factory.py`:
+
+```python
+def test_dark_correction_receives_the_dark_schedule():
+    """DarkCorrectionStage must see the same schedule as the classifier, or it
+    cannot tell a missed dark from a nominal interval."""
+    from omotion.pipeline.stages.dark import DarkCorrectionStage
+
+    meta = ScanMetadata(
+        scan_id="x", subject_id="y", operator="z",
+        started_at_iso="2026-05-22T00:00:00Z", duration_sec=60,
+        left_camera_mask=0xFF, right_camera_mask=0xFF, reduced_mode=False,
+    )
+    pipeline = default_pipeline(
+        metadata=meta, calibration=_trivial_calibration(),
+        pedestals=SensorPedestals(left=64.0, right=64.0),
+        discard_count=9, dark_interval=123,
+    )
+    dark = next(s for s in pipeline.stages
+                if isinstance(s, DarkCorrectionStage))
+    assert dark._discard_count == 9
+    assert dark._dark_interval == 123
+```
+
+This mirrors the construction the other tests in the file use — there is no
+`_default_pipeline` helper; they call `default_pipeline(...)` directly.
+`ScanMetadata`, `default_pipeline`, `SensorPedestals` and `_trivial_calibration`
+are all already imported/defined in this module.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_pipeline/test_factory.py::test_dark_correction_receives_the_dark_schedule -q`
+Expected: FAIL — `assert 600 == 123` (the stage is still on its default)
+
+- [ ] **Step 3: Pass the schedule through**
+
+In `omotion/pipeline/factory.py`, extend the `DarkCorrectionStage(...)` construction:
+
+```python
+        DarkCorrectionStage(
+            realtime_estimator=HybridRealtimePredictor(),
+            batch_estimator=LinearInterpolation(),
+            pedestals=pedestals,
+            realtime_history_size=realtime_dark_history_size,
+            discard_count=discard_count,
+            dark_interval=dark_interval,
+        ),
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_pipeline/test_factory.py -q`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add omotion/pipeline/factory.py tests/test_pipeline/test_factory.py
+git commit -m "feat: pass the dark schedule to DarkCorrectionStage (#175)"
+```
+
+---
+
+### Task 8: Side average inherits the flag
+
+**Files:**
+- Test: `tests/test_pipeline/test_corrected_side_avg_stage.py`
+
+No production change expected — this proves the flag reaches the reduced-mode record, which is the only artifact carrying `quality` since `5c3e107` dropped the corrected-CSV column.
+
+- [ ] **Step 1: Write the test**
+
+Append to `tests/test_pipeline/test_corrected_side_avg_stage.py`:
+
+```python
+def test_side_average_inherits_wide_interval_from_one_camera():
+    """One degraded camera flags the whole side-average row — it contributes
+    real-looking numbers built on a stretched baseline, so the aggregate is
+    biased even though the other camera is clean."""
+    stage = _stage()
+    good = _ef(12, 5.0, "left", 0, 2.0, 20.0)
+    degraded = _ef(12, 5.0, "left", 1, 6.0, 60.0)
+    degraded.quality = "wide_interval"
+    b = _batch([_interval(10, 20, [good]), _interval(10, 20, [degraded])])
+    stage.process(b)
+
+    frames = _avg_frames(b)
+    assert frames, "expected a side-average frame"
+    assert frames[0].quality == "wide_interval"
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `python -m pytest tests/test_pipeline/test_corrected_side_avg_stage.py -q`
+Expected: PASS (Task 4 already routed this through `worse_of`)
+
+If it FAILS, the escalation in `_ingest_corrected` is wrong — revisit Task 4 Step 2 before continuing.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_pipeline/test_corrected_side_avg_stage.py
+git commit -m "test: side average inherits wide_interval (#175)"
+```
+
+---
+
+### Task 9: Documentation
+
+**Files:**
+- Modify: `docs/SciencePipeline.md` — §2.2 BatchEvent table, §4.2 dark schedule, and the quality-value list
+
+- [ ] **Step 1: Add the event to the BatchEvent table (§2.2)**
+
+Add a row after the `DarkIntegrityWarning` row:
+
+```markdown
+| `MissedDarkWarning(...)` | `DarkCorrectionStage` (on interval close) | `"diagnostics"` |
+```
+
+- [ ] **Step 2: Document the schedule's new home (§4.2)**
+
+Add after the dark-schedule definition:
+
+```markdown
+The predicate lives in `omotion/pipeline/dark_schedule.py` and is imported by
+both `FrameClassificationStage` (typing frames) and `DarkCorrectionStage`
+(detecting scheduled darks that never arrived). It is defined once — two copies
+would drift and silently corrupt dark correction.
+```
+
+- [ ] **Step 3: Add a quality-vocabulary subsection**
+
+`SciencePipeline.md` currently has **no** list of `quality` values — the only
+mention is line 582, describing `session_data` columns. Add a new subsection
+immediately before that `session_data` description:
+
+```markdown
+#### Per-frame quality values
+
+`quality` is a single string per corrected frame, defined once in
+`omotion/pipeline/quality.py`. In increasing severity:
+
+| Value | Meaning |
+|---|---|
+| `ok` | Nothing wrong. |
+| `ts_corrected` | Timestamp replaced by re-anchoring interpolation. |
+| `nan_filled` | Synthetic row standing in for a frame that never arrived. |
+| `wide_interval` | Real measurement, but its dark baseline was interpolated across an interval spanning one or more darks that never arrived. |
+
+Frames are aggregated worst-wins: `SideAverageStage` gives a side-average row
+the most severe quality of any camera that contributed to it.
+
+`wide_interval` frames are **kept, not discarded** — valid darks still bound the
+widened interval on both sides, so the data is degraded rather than
+uncorrectable. One missed dark degrades roughly `2 x dark_interval` frames,
+about 30 s at the defaults. It ranks above `nan_filled` because it is the only
+value that silently biases an aggregate: a NaN frame drops out of the side
+average on its own, whereas this one contributes real-looking numbers built on a
+stretched baseline.
+
+Note the value reaches only `session_data.quality` in the scan DB — the
+corrected CSV's quality column was removed in `5c3e107`. The `MissedDarkWarning`
+diagnostic event and the scan-summary tally are the surfaces independent of that.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/SciencePipeline.md
+git commit -m "docs: missed-dark policy and the wide_interval quality (#175)"
+```
+
+---
+
+### Task 10: Full verification
+
+- [ ] **Step 1: Run the software-only suite**
+
+Run: `python -m pytest tests/ -m "not console and not sensor and not destructive and not slow" -q`
+Expected: PASS. Baseline before this work was 575 passed; expect that plus the new tests, with no failures.
+
+- [ ] **Step 2: Confirm the golden replay is untouched**
+
+Run: `git status --porcelain tests/test_pipeline/data/`
+Expected: empty. The golden fixture has no missing darks, so it must not have been regenerated. If it shows as modified, the detection is firing on a nominal interval — stop and diagnose.
+
+- [ ] **Step 3: Push and open the PR**
+
+```bash
+git push -u origin feature/175-missed-dark-policy
+
+cat > /tmp/pr175.md <<'BODY'
+Refs #175
+
+## Problem
+
+A scheduled dark frame that never arrives (dropped frame, camera dropout,
+stale-rejected frame) does not close its interval. The next dark, one full
+`dark_interval` later, closes it instead — so the interval spans roughly double
+its nominal width and every light frame in it has its dark baseline
+interpolated across the gap. At the defaults that silently degrades ~1200
+frames, about 30 s of a scan, with nothing recorded.
+
+## Change
+
+`DarkCorrectionStage` now knows the dark schedule. When an interval closes it
+counts scheduled dark positions falling strictly inside `[left_abs, right_abs]`;
+one or more means darks were missed. Those frames are **kept and flagged**
+`quality="wide_interval"`, and a `MissedDarkWarning` diagnostic is emitted.
+
+Frames are kept rather than discarded because valid darks still bound the
+widened interval on both sides — the data is degraded, not uncorrectable. (The
+terminal-dark-missing case, which has no right boundary at all, keeps its
+existing discard behaviour.)
+
+`wide_interval` ranks above `nan_filled`: a NaN frame drops out of the side
+average on its own, whereas a wide-interval frame contributes real-looking
+numbers built on a stretched baseline, so it is the value that actually biases
+the aggregate.
+
+## Notes for review
+
+- The dark-schedule predicate moved to `omotion/pipeline/dark_schedule.py` and
+  is imported by both the classifier and the dark stage. Two copies would drift
+  and regrow this bug.
+- `_QUALITY_RANK` moved to `omotion/pipeline/quality.py`. `side_avg.py`'s comment
+  claiming it mirrored `sinks._QUALITY_RANK` was stale — `5c3e107` removed that
+  constant along with the corrected-CSV quality column.
+- Detection deliberately does **not** re-type synthetic NaN-fill rows as `"dark"`
+  (the approach originally sketched in #175). That would risk a NaN
+  `DarkObservation` poisoning `DarkHistory` and both adjacent interval
+  boundaries. Schedule-based detection also catches missed darks from any cause,
+  not just the NaN-fill path.
+- No sink or runner changes: `runner.py` already routes unrecognised events to
+  `"diagnostics"`, and the diagnostics sinks tally by type.
+- Since `5c3e107`, `quality` reaches only `session_data.quality` in the scan DB.
+  Consumers reading the corrected CSV see degraded data unflagged; the
+  `MissedDarkWarning` and scan-summary tally are the independent surfaces.
+
+Design: `docs/superpowers/specs/2026-07-21-missed-dark-policy-design.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+BODY
+
+gh pr create -R OpenwaterHealth/openmotion-sdk --base next \
+  --head feature/175-missed-dark-policy \
+  --title "feat: flag corrected intervals that span a missed dark" \
+  --body-file /tmp/pr175.md
+```
+
+`Refs #175`, never `Closes` — merge must not auto-close the ticket, which lives on
+through pre-release validation. **Use `--body-file`, never `--body @-`**: `gh` does
+not support `@-`, and will silently post the literal two-character string while
+still returning a success URL. Verify after posting with
+`gh pr view <n> --json body`.
+
+---
+
+## Hardware verification (post-merge, optional)
+
+Nothing in this plan requires hardware. The one open empirical question — how much
+accuracy a doubled interval actually costs — is a follow-up, not a gate, since the
+policy keeps and flags unconditionally. Answering it needs a ~2 minute scan
+(`dark_interval` 600 gives 5-6 darks in that time, versus only two in a 20 s scan),
+then a comparison of per-camera dark baselines across consecutive intervals.

--- a/docs/superpowers/plans/2026-07-21-missed-dark-policy.md
+++ b/docs/superpowers/plans/2026-07-21-missed-dark-policy.md
@@ -292,11 +292,18 @@ def test_worse_of_is_stable_for_equal_values():
     assert worse_of("wide_interval", "wide_interval") == "wide_interval"
 
 
-def test_unknown_values_rank_as_ok():
-    """Documented hazard: an unrecognised string ranks 0. Any consumer holding
-    its own copy of the rank map would treat a newer value as the BEST quality.
-    This is why the rank lives here and is imported, never re-declared."""
-    assert worse_of("something_new", "ok") == "ok"
+def test_unknown_value_is_preserved_over_ok():
+    """An unrecognised string ranks 0 and so ties with "ok", and a tie returns
+    the first argument. That ordering matters: escalating an unknown flag with
+    "ok" must not erase it, because we cannot know its severity.
+
+    This is also the documented hazard of the rank table — a stale consumer
+    holding its own copy would rank a NEWER known value (like wide_interval)
+    as 0, i.e. as the best quality rather than the worst. That is why the rank
+    lives in one place and is imported, never re-declared.
+    """
+    assert worse_of("something_new", "ok") == "something_new"
+    assert worse_of("ok", "something_new") == "ok"
 ```
 
 - [ ] **Step 2: Run test to verify it fails**
@@ -336,9 +343,17 @@ QUALITY_RANK: dict[str, int] = {
 
 
 def worse_of(a: str, b: str) -> str:
-    """Return whichever quality value is more severe (ties return `a`)."""
+    """Return whichever quality value is more severe (ties return `a`).
+
+    An unrecognised value ranks 0, so it ties with "ok" and is returned in
+    preference to it — an unknown flag must never be silently overwritten
+    with "ok", since we cannot know its severity.
+    """
     return a if QUALITY_RANK.get(a, 0) >= QUALITY_RANK.get(b, 0) else b
 ```
+
+Do **not** add special-casing for unknown values. The tie rule already produces
+the desired behaviour, and the extra branches are unrequested complexity.
 
 - [ ] **Step 4: Run test to verify it passes**
 

--- a/docs/superpowers/specs/2026-07-21-missed-dark-policy-design.md
+++ b/docs/superpowers/specs/2026-07-21-missed-dark-policy-design.md
@@ -1,0 +1,189 @@
+# Missed-dark policy — design
+
+**Issue:** [#175](https://github.com/OpenwaterHealth/openmotion-sdk/issues/175)
+**Date:** 2026-07-21
+**Status:** approved, not yet implemented
+
+## Problem
+
+Dark frames are scheduled positionally: `abs_id == discard_count + 1`, then every
+`dark_interval` thereafter (`classify.py:_is_dark`). At the defaults that is abs_id
+10, 601, 1201, … — one dark every 600 frames, or 15 s at 40 fps.
+
+`PendingInterval` closes an interval when a second dark arrives, and
+`LinearInterpolation` interpolates the dark baseline (u1 and variance) between the
+two bounding darks. If a scheduled dark **never arrives** — a dropped frame, a
+camera dropout, a frame rejected as stale — the interval does not close at that
+position. The next dark, 600 frames later, closes it instead.
+
+Two consequences today:
+
+1. The interval silently spans ~1200 frames instead of ~600, and every light frame
+   in it gets its baseline interpolated across the doubled span. Worst error sits
+   where the missing dark should have been. **~30 s of a scan is degraded per
+   missed dark, and nothing records that it happened.**
+2. `timestamp_repair.py` hardcodes `"frame_type": "light"` on every synthetic
+   NaN-fill row (it runs at stage 6, after classification at stage 1, so fill rows
+   are never tested against the dark schedule). A fill row standing in for a missed
+   dark therefore enters the interval as a NaN light sample.
+
+### The inconsistency this resolves
+
+Three closely-related conditions are handled three different ways:
+
+| condition | current behaviour |
+|---|---|
+| terminal dark missing | interval left open, corrected data **discarded**, logged ERROR |
+| mid-scan dark missing | **silently** interpolate across 2x the span |
+| dark contaminated (integrity guard fires) | **used as a boundary anyway**, logged WARNING |
+
+`DarkIntegrityGuard.check()` returns a pass/fail bool that `DarkCorrectionStage`
+discards.
+
+## Scope
+
+**In scope:** missing darks only.
+
+**Out of scope, deliberately:**
+
+- **Contaminated darks.** The guard's verdict stays ignored. Separate ticket.
+- **Any tolerance for "how wide is too wide."** We keep-and-flag unconditionally;
+  no threshold is invented here.
+- **`timestamp_repair.py` changes.** The detection approach below removes the need.
+- **Terminal dark missing.** Keeps its current discard behaviour — it is a
+  genuinely different condition, with no right-hand boundary to interpolate
+  between at all.
+
+## Decisions
+
+1. **Disposition: keep and flag.** Frames in a widened interval are emitted, marked
+   degraded. No data is discarded. Consumers and analytics filter on the flag.
+2. **Representation: a new ranked `quality` value**, reusing the existing
+   single-string mechanism rather than adding a field or a flag set.
+3. **Detection: from the dark schedule**, not from re-typing fill rows.
+
+## Design
+
+### Detection
+
+`DarkCorrectionStage` currently has no knowledge of the dark schedule — its
+constructor takes no `discard_count` or `dark_interval`; it only reacts to frames
+the classifier already typed `"dark"`. Both values are available in
+`factory.default_pipeline()` and are already passed to `FrameClassificationStage`.
+
+Pass them to `DarkCorrectionStage` as well. When an interval closes as
+`[left_abs, right_abs]`, count the scheduled dark positions falling **strictly
+inside** that range. Zero means the interval is nominal; one or more means that
+many darks were missed, and we know precisely which abs_ids.
+
+The schedule predicate is **extracted from `classify.py:_is_dark` into one shared
+function** that both stages import. Two independent copies of the dark schedule
+would drift and reproduce exactly this class of bug.
+
+Why this beats the approach sketched in #175 (re-typing schedule-aligned fill rows
+as `"dark"`):
+
+- No `timestamp_repair` change.
+- No risk of a NaN-valued `DarkObservation` poisoning `DarkHistory` or becoming an
+  interval boundary — the hazard that caused item 4 to be deferred from #114 in the
+  first place.
+- Catches a missed dark from **any** cause, not just the NaN-fill path.
+
+### Marking
+
+Frames in a widened interval get `quality` escalated to a new `wide_interval`
+value. Applied in `DarkCorrectionStage`, where the `CorrectedInterval` is
+constructed, so it flows through ShotNoise -> BfiBvi -> DarkFrameHold -> SideAverage
+-> sinks with no changes to any of those stages.
+
+Escalation is worst-wins against whatever the frame already carries, matching the
+existing convention.
+
+### Quality rank
+
+```
+ok 0  <  ts_corrected 1  <  nan_filled 2  <  wide_interval 3
+```
+
+`wide_interval` ranks highest because it is **the only flag that silently biases the
+aggregate**. A `nan_filled` camera emits NaN and is dropped by
+`spatial_side_average`'s `nanmean` on its own; a wide-interval camera contributes
+real-looking numbers built on a stretched baseline. If `nan_filled` could mask it,
+the side-average row would hide the one thing actually skewing the value.
+
+Housekeeping in the same change: `_QUALITY_RANK` currently lives only in
+`side_avg.py:39`, whose comment claims it "Mirrors `sinks._QUALITY_RANK`" — no such
+constant exists in `sinks.py`. Move the rank to one shared location and correct the
+comment.
+
+**Hazard to handle explicitly.** The lookup is
+`_QUALITY_RANK.get(fq, 0)` — an **unrecognised quality string silently ranks as
+`ok`**. So any consumer holding its own copy of the rank map that is not updated
+will treat `wide_interval` as the *best* quality rather than the worst, which is
+the exact inversion of what this change is for. Two required mitigations:
+
+1. Single shared rank definition, imported — never re-declared.
+2. Audit consumers outside this module before landing. Checked at design time:
+   neither `openmotion-bloodflow-app` nor `openmotion-test-app` has independent
+   quality logic — every hit is a *bundled* copy of `omotion` inside a packaged
+   `dist/` build, so they inherit whatever the SDK ships. No app-side change needed,
+   but packaged builds carry the old 3-value rank until they are rebuilt.
+
+### Where the flag actually surfaces
+
+`5c3e107 refactor(pipeline): drop quality column from corrected CSV` is already on
+`next`, and removed `_QUALITY_RANK` from `sinks.py` along with the column. As of
+today `quality` reaches exactly one artifact:
+
+- **`session_data.quality` in the scan DB** (`sinks.py:754`) — the only science
+  record that carries it.
+- **Not the corrected CSV** — the column was deliberately dropped.
+
+So "keep and flag" makes the degradation visible to DB/analytics consumers, and
+**invisible to anyone working from the corrected CSV**. The `MissedDarkWarning`
+diagnostic and the scan-summary tally are the second surface, and are independent of
+both — they fire regardless of which artifact a consumer reads.
+
+This is a known, accepted limitation of the chosen approach rather than an
+oversight. Revisit if the corrected CSV becomes the primary analysis path again.
+
+### Diagnostics
+
+New `MissedDarkWarning` batch event, alongside the existing `DarkIntegrityWarning`,
+carrying:
+
+- `side`, `cam_id`
+- `expected_abs_ids` — the scheduled positions that produced no dark
+- `left_abs`, `right_abs` — the interval that actually closed
+- `n_missed`
+
+Emitted once per (side, cam) per widened interval, with a WARNING log. Sinks already
+route diagnostics events and tally them by type in the scan summary, so missed darks
+surface in the same place `TerminalDarkResult` and `TimestampMisalignmentWindow`
+already do — **no sink changes required**.
+
+## Testing
+
+- Schedule counter in isolation: darks at 10/601/1201; interval `[10, 1201]` reports
+  1 missed at 601; interval `[601, 1201]` reports 0.
+- Shared predicate: the extracted function agrees with the current
+  `classify.py:_is_dark` across a sweep of abs_ids and both config values.
+- A widened interval marks every frame `wide_interval`; a nominal interval leaves
+  `quality` untouched.
+- Worst-wins: a `nan_filled` frame inside a widened interval ends up
+  `wide_interval`.
+- `MissedDarkWarning` is emitted once per (side, cam) with correct fields.
+- The side-average row inherits `wide_interval` from a contributing camera.
+- Regression: golden replay is unchanged when no dark is missed.
+
+## Follow-ups, not blocking
+
+**Quantify the drift.** Nothing here depends on knowing how much accuracy a doubled
+interval actually costs, since we keep-and-flag unconditionally. But that number is
+what would justify a future tolerance-based *discard* policy — or show that a 2x
+span is merely untidy rather than harmful.
+
+It is not currently measurable from the scans on hand: a 20 s scan at
+`dark_interval` 600 contains only two darks (abs_id 10 and 601). A ~2 minute scan
+would give 5-6 darks and enough interval-to-interval baseline data to answer it.
+Cheap to run on the bench.

--- a/omotion/pipeline/batch.py
+++ b/omotion/pipeline/batch.py
@@ -54,6 +54,20 @@ class DarkIntegrityWarning(BatchEvent):
 
 
 @dataclass
+class MissedDarkWarning(BatchEvent):
+    """One or more scheduled dark frames never arrived, so the interval that
+    closed spans wider than nominal and its baseline was interpolated across
+    the gap. Frames are still emitted, flagged quality="wide_interval" — this
+    is a diagnostic event, not a drop signal."""
+    side: str
+    cam_id: int
+    expected_abs_ids: list[int]
+    left_abs: int
+    right_abs: int
+    n_missed: int
+
+
+@dataclass
 class StencilFallback(BatchEvent):
     """The 4-point dark-frame quadratic stencil fell back to a simpler scheme
     because some neighbours were unavailable. Diagnostic, not an error."""

--- a/omotion/pipeline/dark_schedule.py
+++ b/omotion/pipeline/dark_schedule.py
@@ -3,7 +3,7 @@
 Single source of truth, imported by both FrameClassificationStage (which
 types incoming frames) and DarkCorrectionStage (which detects scheduled
 darks that never arrived). Two independent copies of this rule would drift
-and silently corrupt dark correction — see docs/SciencePipeline.md §4.2.
+and silently corrupt dark correction — see docs/SciencePipeline.md §5.1.
 """
 
 from __future__ import annotations
@@ -12,7 +12,7 @@ from __future__ import annotations
 def is_dark_frame(abs_id: int, *, discard_count: int, dark_interval: int) -> bool:
     """True when abs_id lands on a scheduled dark position.
 
-    Per SciencePipeline.md §4.2:
+    Per SciencePipeline.md §5.1:
         n == discard_count + 1
         OR (n > discard_count + 1 AND (n - 1) mod dark_interval == 0)
     """

--- a/omotion/pipeline/dark_schedule.py
+++ b/omotion/pipeline/dark_schedule.py
@@ -1,0 +1,47 @@
+"""The positional dark-frame schedule.
+
+Single source of truth, imported by both FrameClassificationStage (which
+types incoming frames) and DarkCorrectionStage (which detects scheduled
+darks that never arrived). Two independent copies of this rule would drift
+and silently corrupt dark correction — see docs/SciencePipeline.md §4.2.
+"""
+
+from __future__ import annotations
+
+
+def is_dark_frame(abs_id: int, *, discard_count: int, dark_interval: int) -> bool:
+    """True when abs_id lands on a scheduled dark position.
+
+    Per SciencePipeline.md §4.2:
+        n == discard_count + 1
+        OR (n > discard_count + 1 AND (n - 1) mod dark_interval == 0)
+    """
+    if dark_interval <= 0:
+        raise ValueError(f"dark_interval must be positive, got {dark_interval}")
+    if abs_id == discard_count + 1:
+        return True
+    if abs_id <= discard_count + 1:
+        return False
+    return (abs_id - 1) % dark_interval == 0
+
+
+def missed_dark_ids(left_abs: int, right_abs: int, *,
+                    discard_count: int, dark_interval: int) -> list[int]:
+    """Scheduled dark positions strictly between two interval boundaries.
+
+    A closed interval should be bounded by consecutive scheduled darks. Any
+    scheduled position falling *inside* it is a dark that never arrived, so
+    the interval spans wider than nominal and its baseline interpolation is
+    stretched across the gap. Both endpoints are excluded — they are the
+    darks that did arrive.
+
+    When left_abs >= right_abs, the range is non-advancing, so an empty list
+    is returned (not an error). This contract ensures a swapped-argument bug
+    at a call site reports 0 missed darks instead of silently producing wrong
+    results.
+    """
+    return [
+        n for n in range(int(left_abs) + 1, int(right_abs))
+        if is_dark_frame(n, discard_count=discard_count,
+                         dark_interval=dark_interval)
+    ]

--- a/omotion/pipeline/factory.py
+++ b/omotion/pipeline/factory.py
@@ -80,6 +80,8 @@ def default_pipeline(*,
             batch_estimator=LinearInterpolation(),
             pedestals=pedestals,
             realtime_history_size=realtime_dark_history_size,
+            discard_count=discard_count,
+            dark_interval=dark_interval,
         ),
 
         ShotNoiseCorrectionStage(pedestals=pedestals, camera_gain_map=CAMERA_GAIN_MAP),

--- a/omotion/pipeline/quality.py
+++ b/omotion/pipeline/quality.py
@@ -27,16 +27,8 @@ QUALITY_RANK: dict[str, int] = {
 def worse_of(a: str, b: str) -> str:
     """Return whichever quality value is more severe (ties return `a`).
 
-    If one value is unknown (not in QUALITY_RANK), return the known one.
+    An unrecognised value ranks 0, so it ties with "ok" and is returned in
+    preference to it — an unknown flag must never be silently overwritten
+    with "ok", since we cannot know its severity.
     """
-    a_in_map = a in QUALITY_RANK
-    b_in_map = b in QUALITY_RANK
-
-    # If one is known and one is unknown, return the known one
-    if a_in_map and not b_in_map:
-        return a
-    if b_in_map and not a_in_map:
-        return b
-
-    # Both known or both unknown: use ranks (defaulting unknown to 0)
     return a if QUALITY_RANK.get(a, 0) >= QUALITY_RANK.get(b, 0) else b

--- a/omotion/pipeline/quality.py
+++ b/omotion/pipeline/quality.py
@@ -1,0 +1,42 @@
+"""Per-frame quality vocabulary.
+
+Single source of truth for the quality values and their severity ordering.
+Import QUALITY_RANK — never re-declare it. `worse_of` treats an unrecognised
+value as rank 0 ("ok"), so a stale copy of this table would rank a newer value
+as the BEST quality rather than the worst, inverting its meaning.
+
+Values, in increasing severity:
+    ok             — nothing wrong
+    ts_corrected   — timestamp replaced by re-anchoring interpolation
+    nan_filled     — synthetic row standing in for a frame that never arrived
+    wide_interval  — real measurement, but its dark baseline was interpolated
+                     across an interval that spans one or more missing darks
+"""
+
+from __future__ import annotations
+
+
+QUALITY_RANK: dict[str, int] = {
+    "ok": 0,
+    "ts_corrected": 1,
+    "nan_filled": 2,
+    "wide_interval": 3,
+}
+
+
+def worse_of(a: str, b: str) -> str:
+    """Return whichever quality value is more severe (ties return `a`).
+
+    If one value is unknown (not in QUALITY_RANK), return the known one.
+    """
+    a_in_map = a in QUALITY_RANK
+    b_in_map = b in QUALITY_RANK
+
+    # If one is known and one is unknown, return the known one
+    if a_in_map and not b_in_map:
+        return a
+    if b_in_map and not a_in_map:
+        return b
+
+    # Both known or both unknown: use ranks (defaulting unknown to 0)
+    return a if QUALITY_RANK.get(a, 0) >= QUALITY_RANK.get(b, 0) else b

--- a/omotion/pipeline/stages/classify.py
+++ b/omotion/pipeline/stages/classify.py
@@ -19,6 +19,7 @@ import logging
 import numpy as np
 
 from ..batch import FrameBatch
+from ..dark_schedule import is_dark_frame
 
 
 logger = logging.getLogger("openmotion.sdk.pipeline.stages.frame_classification")
@@ -173,14 +174,11 @@ class FrameClassificationStage:
             )
 
     def _is_dark(self, abs_id: int) -> bool:
-        """Per SciencePipeline.md §4.2:
-            n == discard_count + 1 OR (n > discard_count + 1 AND (n-1) mod dark_interval == 0)
-        """
-        if abs_id == self.discard_count + 1:
-            return True
-        if abs_id <= self.discard_count + 1:
-            return False
-        return (abs_id - 1) % self.dark_interval == 0
+        """Per SciencePipeline.md §4.2 — delegated to the shared schedule so
+        DarkCorrectionStage cannot drift from this definition."""
+        return is_dark_frame(abs_id,
+                             discard_count=self.discard_count,
+                             dark_interval=self.dark_interval)
 
     def reset(self) -> None:
         self._unwrappers.clear()

--- a/omotion/pipeline/stages/classify.py
+++ b/omotion/pipeline/stages/classify.py
@@ -174,7 +174,7 @@ class FrameClassificationStage:
             )
 
     def _is_dark(self, abs_id: int) -> bool:
-        """Per SciencePipeline.md §4.2 — delegated to the shared schedule so
+        """Per SciencePipeline.md §5.1 — delegated to the shared schedule so
         DarkCorrectionStage cannot drift from this definition."""
         return is_dark_frame(abs_id,
                              discard_count=self.discard_count,

--- a/omotion/pipeline/stages/dark.py
+++ b/omotion/pipeline/stages/dark.py
@@ -466,13 +466,11 @@ class DarkCorrectionStage:
             ))
             logger.warning(
                 "missed dark: side=%s cam=%d — scheduled dark(s) at %s never "
-                "arrived; interval %d..%d spans the gap, baseline interpolated "
-                "across %d frames instead of the nominal %d. Frames flagged "
-                "wide_interval.",
+                "arrived; interval %d..%d spans the gap, so the baseline was "
+                "interpolated across %d frames. Frames flagged wide_interval.",
                 side, int(cam_id), missed,
                 int(interval.left_abs), int(interval.right_abs),
                 int(interval.right_abs) - int(interval.left_abs),
-                self._dark_interval,
             )
 
         events.append(IntervalClosed(corrected_batch=corrected))

--- a/omotion/pipeline/stages/dark.py
+++ b/omotion/pipeline/stages/dark.py
@@ -17,8 +17,13 @@ from typing import Any, Deque, Optional
 
 import numpy as np
 
-from ..batch import DarkIntegrityWarning, FrameBatch, IntervalClosed, TerminalDarkResult
+from ..batch import (
+    DarkIntegrityWarning, FrameBatch, IntervalClosed, MissedDarkWarning,
+    TerminalDarkResult,
+)
+from ..dark_schedule import missed_dark_ids
 from ..pedestal import SensorPedestals
+from ..quality import worse_of
 
 
 logger = logging.getLogger("openmotion.sdk.pipeline.stages.dark")
@@ -396,7 +401,9 @@ class DarkCorrectionStage:
                  batch_estimator: LinearInterpolation,
                  pedestals: Optional[SensorPedestals] = None,
                  realtime_history_size: int = 4,
-                 integrity_max_above_pedestal: float = 5.0):
+                 integrity_max_above_pedestal: float = 5.0,
+                 discard_count: int = 9,
+                 dark_interval: int = 600):
         self._realtime = realtime_estimator
         self._batch = batch_estimator
         self._pedestals = pedestals or SensorPedestals(left=64.0, right=64.0)
@@ -407,6 +414,8 @@ class DarkCorrectionStage:
         )
         self._last_realtime: dict[tuple[str, int], tuple[float, float, float]] = {}
         self._terminal_fsync_count: Optional[int] = None
+        self._discard_count = int(discard_count)
+        self._dark_interval = int(dark_interval)
 
     def set_terminal_fsync_count(self, count: int) -> None:
         """Ground-truth index of the final FSYNC pulse, from the console
@@ -430,10 +439,42 @@ class DarkCorrectionStage:
 
         Downstream stages handle shot-noise, BFI/BVI, and the dark-frame
         quadratic stencil.
+
+        A closed interval should be bounded by consecutive scheduled darks. Any
+        scheduled position falling inside it is a dark that never arrived, so
+        the baseline was interpolated across the gap — every frame is flagged
+        `wide_interval` and a MissedDarkWarning is raised (#175).
         """
         side, cam_id = key
         corrected = self._batch.correct_interval(interval, side=side, cam_id=cam_id)
         corrected.left_t = interval.left.obs.t
+
+        missed = missed_dark_ids(
+            interval.left_abs, interval.right_abs,
+            discard_count=self._discard_count,
+            dark_interval=self._dark_interval,
+        )
+        if missed:
+            for f in corrected.frames:
+                f.quality = worse_of(f.quality, "wide_interval")
+            events.append(MissedDarkWarning(
+                side=side, cam_id=int(cam_id),
+                expected_abs_ids=list(missed),
+                left_abs=int(interval.left_abs),
+                right_abs=int(interval.right_abs),
+                n_missed=len(missed),
+            ))
+            logger.warning(
+                "missed dark: side=%s cam=%d — scheduled dark(s) at %s never "
+                "arrived; interval %d..%d spans the gap, baseline interpolated "
+                "across %d frames instead of the nominal %d. Frames flagged "
+                "wide_interval.",
+                side, int(cam_id), missed,
+                int(interval.left_abs), int(interval.right_abs),
+                int(interval.right_abs) - int(interval.left_abs),
+                self._dark_interval,
+            )
+
         events.append(IntervalClosed(corrected_batch=corrected))
 
     def process(self, batch: FrameBatch) -> FrameBatch:

--- a/omotion/pipeline/stages/dark_frame_hold.py
+++ b/omotion/pipeline/stages/dark_frame_hold.py
@@ -25,6 +25,7 @@ from typing import Optional
 import numpy as np
 
 from ..batch import FrameBatch, IntervalClosed
+from ..quality import worse_of
 from .dark import (
     DarkFrameQuadraticStencil,
     EnrichedCorrectedFrame, EnrichedCorrectedInterval,
@@ -164,6 +165,14 @@ class DarkFrameHoldStage:
                 v_plus_1=r1, v_plus_2=r2,
             )
 
+        # The stencilled row's quality must be the worst of the neighbours it
+        # was actually interpolated from — it must not silently claim "ok"
+        # when built from wide_interval (or otherwise degraded) frames (#175).
+        stencil_quality = "ok"
+        for neighbour in (right1, right2, left1, left2):
+            if neighbour is not None:
+                stencil_quality = worse_of(stencil_quality, neighbour.quality)
+
         return EnrichedCorrectedFrame(
             abs_frame_id=d_prev_abs,
             t=d_prev_t,
@@ -174,7 +183,7 @@ class DarkFrameHoldStage:
             contrast=_interp("contrast"),
             bfi=_interp("bfi"),
             bvi=_interp("bvi"),
-            quality="ok",
+            quality=stencil_quality,
         )
 
     # ── Lifecycle ────────────────────────────────────────────────────────

--- a/omotion/pipeline/stages/side_avg.py
+++ b/omotion/pipeline/stages/side_avg.py
@@ -28,15 +28,12 @@ from typing import Optional
 import numpy as np
 
 from ..batch import FrameBatch, IntervalClosed, LiveEmit, SideAverageSample
+from ..quality import worse_of
 from .dark import EnrichedCorrectedFrame, EnrichedCorrectedInterval
 
 
 _SIDE_STR_TO_INT = {"left": 0, "right": 1}
 _SIDE_INT_TO_STR = ("left", "right")
-
-# Higher rank = worse quality; the side average inherits the worst quality
-# of any camera that contributed to it. Mirrors sinks._QUALITY_RANK.
-_QUALITY_RANK = {"ok": 0, "ts_corrected": 1, "nan_filled": 2}
 
 
 def _mask_to_cam_indices(mask: int) -> np.ndarray:
@@ -236,9 +233,10 @@ class SideAverageStage:
         rec["bvi"][cam] = float(getattr(f, "bvi", np.nan))
         rec["mean"][cam] = float(getattr(f, "mean", np.nan))
         rec["contrast"][cam] = float(getattr(f, "contrast", np.nan))
+        # The side average inherits the worst quality of any camera that
+        # contributed to it.
         fq = str(getattr(f, "quality", "ok") or "ok")
-        if _QUALITY_RANK.get(fq, 0) > _QUALITY_RANK.get(rec["quality"], 0):
-            rec["quality"] = fq
+        rec["quality"] = worse_of(rec["quality"], fq)
 
     def _emit_frames(self, side: int, fids: list, batch: FrameBatch,
                      *, right_abs: int) -> None:

--- a/tests/test_pipeline/test_batch.py
+++ b/tests/test_pipeline/test_batch.py
@@ -94,3 +94,15 @@ def _trivial_batch(n: int) -> FrameBatch:
         timestamp_s=np.zeros(n, dtype=np.float64),
         pdc=None, tcm=None, tcl=None,
     )
+
+
+def test_missed_dark_warning_carries_the_gap():
+    from omotion.pipeline.batch import BatchEvent, MissedDarkWarning
+
+    ev = MissedDarkWarning(
+        side="left", cam_id=3, expected_abs_ids=[601],
+        left_abs=10, right_abs=1201, n_missed=1,
+    )
+    assert isinstance(ev, BatchEvent)
+    assert ev.expected_abs_ids == [601]
+    assert ev.n_missed == 1

--- a/tests/test_pipeline/test_corrected_side_avg_stage.py
+++ b/tests/test_pipeline/test_corrected_side_avg_stage.py
@@ -227,3 +227,19 @@ def test_reset_clears_pending_window():
     flush = _batch()
     stage.on_scan_stop(flush)
     assert _avg_frames(flush) == []
+
+
+def test_side_average_inherits_wide_interval_from_one_camera():
+    """One degraded camera flags the whole side-average row — it contributes
+    real-looking numbers built on a stretched baseline, so the aggregate is
+    biased even though the other camera is clean."""
+    stage = _stage()
+    good = _ef(12, 5.0, "left", 0, 2.0, 20.0)
+    degraded = _ef(12, 5.0, "left", 1, 6.0, 60.0)
+    degraded.quality = "wide_interval"
+    b = _batch([_interval(10, 20, [good]), _interval(10, 20, [degraded])])
+    stage.process(b)
+
+    frames = _avg_frames(b)
+    assert frames, "expected a side-average frame"
+    assert frames[0].quality == "wide_interval"

--- a/tests/test_pipeline/test_dark_correction_stage.py
+++ b/tests/test_pipeline/test_dark_correction_stage.py
@@ -717,3 +717,84 @@ def test_corrected_frame_quality_defaults_to_ok():
         mean=36.0, std=4.8, contrast=0.13, bfi=5.0, bvi=5.0,
     )
     assert ef.quality == "ok"
+
+
+def _stage_with_schedule(dark_interval):
+    """dark_interval=3 puts scheduled darks at abs_id 10, 13, 16, 19 —
+    compact enough to construct a missed dark in a handful of frames."""
+    return DarkCorrectionStage(
+        realtime_estimator=HybridRealtimePredictor(),
+        batch_estimator=LinearInterpolation(),
+        discard_count=9,
+        dark_interval=dark_interval,
+    )
+
+
+def _interval_batch(frame_types, abs_ids):
+    n = len(abs_ids)
+    mean = np.full((n, 2, 8), 500.0, dtype=np.float32)
+    std = np.full((n, 2, 8), 20.0, dtype=np.float32)
+    for i, ft in enumerate(frame_types):
+        if ft == "dark":
+            mean[i, :, :] = 100.0
+            std[i, :, :] = 10.0
+    return _batch(n, frame_types, abs_ids, mean_raw=mean, std_raw=std)
+
+
+def test_nominal_interval_leaves_quality_untouched():
+    """Darks at 10 and 13 are consecutive scheduled positions — nothing missed."""
+    batch = _interval_batch(["dark", "light", "light", "dark"], [10, 11, 12, 13])
+    _stage_with_schedule(3).process(batch)
+
+    frames = [f for e in batch.events if isinstance(e, IntervalClosed)
+              for f in e.corrected_batch.frames]
+    assert frames, "expected an interval to close"
+    assert all(f.quality == "ok" for f in frames)
+
+
+def test_missed_dark_flags_every_frame_in_the_widened_interval():
+    """The dark at 13 never arrives, so the interval closes 10..16 instead."""
+    batch = _interval_batch(
+        ["dark", "light", "light", "light", "light", "dark"],
+        [10, 11, 12, 14, 15, 16],
+    )
+    _stage_with_schedule(3).process(batch)
+
+    frames = [f for e in batch.events if isinstance(e, IntervalClosed)
+              for f in e.corrected_batch.frames]
+    assert frames, "expected an interval to close"
+    assert all(f.quality == "wide_interval" for f in frames)
+
+
+def test_missed_dark_emits_a_warning_event():
+    from omotion.pipeline.batch import MissedDarkWarning
+
+    batch = _interval_batch(
+        ["dark", "light", "light", "light", "light", "dark"],
+        [10, 11, 12, 14, 15, 16],
+    )
+    _stage_with_schedule(3).process(batch)
+
+    warnings = [e for e in batch.events if isinstance(e, MissedDarkWarning)]
+    assert len(warnings) == 1
+    w = warnings[0]
+    assert w.expected_abs_ids == [13]
+    assert w.n_missed == 1
+    assert (w.left_abs, w.right_abs) == (10, 16)
+    assert w.side == "left" and w.cam_id == 0
+
+
+def test_missed_dark_escalates_over_an_existing_quality():
+    """A frame already flagged nan_filled ends up wide_interval, since that is
+    the flag that biases the aggregate."""
+    batch = _interval_batch(
+        ["dark", "light", "light", "light", "light", "dark"],
+        [10, 11, 12, 14, 15, 16],
+    )
+    batch.quality = np.array(
+        ["ok", "nan_filled", "ok", "ok", "ok", "ok"], dtype="<U14")
+    _stage_with_schedule(3).process(batch)
+
+    frames = [f for e in batch.events if isinstance(e, IntervalClosed)
+              for f in e.corrected_batch.frames]
+    assert all(f.quality == "wide_interval" for f in frames)

--- a/tests/test_pipeline/test_dark_frame_hold_stage.py
+++ b/tests/test_pipeline/test_dark_frame_hold_stage.py
@@ -2,7 +2,8 @@
 
 import numpy as np
 import pytest
-from omotion.pipeline.batch import FrameBatch
+from omotion.pipeline.batch import FrameBatch, IntervalClosed
+from omotion.pipeline.stages.dark import EnrichedCorrectedFrame, EnrichedCorrectedInterval
 from omotion.pipeline.stages.dark_frame_hold import DarkFrameHoldStage
 
 
@@ -91,3 +92,90 @@ def test_reset_clears_hold_state():
     batch = _batch(["dark"], [0], [4], [9.0], [0.0])
     stage.process(batch)
     assert batch.bfi_live[0, 0, 4] == pytest.approx(9.0)
+
+
+# ── Batch stencil: quality propagation (#175) ──────────────────────────────
+
+def _empty_batch():
+    """A batch with no rows — the stencil path only reads batch.events."""
+    return FrameBatch(
+        cam_ids=np.zeros(0, dtype=np.int8), frame_ids=np.zeros(0, dtype=np.uint8),
+        side_ids=np.zeros(0, dtype=np.int8),
+        raw_histograms=np.zeros((0, 2, 8, 1024), dtype=np.uint32),
+        temperature_c=np.zeros((0, 2, 8), dtype=np.float32),
+        timestamp_s=np.zeros(0, dtype=np.float64), pdc=None, tcm=None, tcl=None,
+    )
+
+
+def _ef(fid, t, side, cam, bfi, bvi, quality="ok"):
+    return EnrichedCorrectedFrame(
+        abs_frame_id=fid, t=t, side=side, cam_id=cam,
+        mean=100.0, std=30.0, contrast=0.3, bfi=bfi, bvi=bvi,
+        quality=quality,
+    )
+
+
+def test_stencilled_dark_row_is_ok_when_all_neighbours_are_ok():
+    """Baseline: with only ok-quality neighbours, the stencilled D_prev row
+    stays "ok" — the fix must not force wide_interval unconditionally."""
+    stage = DarkFrameHoldStage()
+    interval = EnrichedCorrectedInterval(
+        left_abs=10, right_abs=20, left_t=4.9,
+        frames=[_ef(12, 5.0, "left", 0, 2.0, 20.0, quality="ok"),
+                _ef(13, 5.025, "left", 0, 4.0, 40.0, quality="ok")],
+    )
+    batch = _empty_batch()
+    batch.events.append(IntervalClosed(corrected_batch=interval))
+    stage.process(batch)
+
+    dark_row = interval.frames[0]
+    assert dark_row.abs_frame_id == 10
+    assert dark_row.quality == "ok"
+
+
+def test_stencilled_dark_row_inherits_wide_interval_from_right_neighbour():
+    """The stencilled D_prev row must not silently claim quality="ok" when the
+    light frames it was interpolated from are flagged wide_interval (missed-
+    dark policy, #175) — worst-quality-wins applies to the stencil too."""
+    stage = DarkFrameHoldStage()
+    interval = EnrichedCorrectedInterval(
+        left_abs=10, right_abs=20, left_t=4.9,
+        frames=[_ef(12, 5.0, "left", 0, 2.0, 20.0, quality="wide_interval"),
+                _ef(13, 5.025, "left", 0, 4.0, 40.0, quality="ok")],
+    )
+    batch = _empty_batch()
+    batch.events.append(IntervalClosed(corrected_batch=interval))
+    stage.process(batch)
+
+    dark_row = interval.frames[0]
+    assert dark_row.abs_frame_id == 10
+    assert dark_row.quality == "wide_interval"
+
+
+def test_stencilled_dark_row_inherits_wide_interval_from_left_tail():
+    """A wide_interval quality on the PREVIOUS interval's tail (the left
+    neighbours v(D-1)/v(D-2)) must also propagate into the next interval's
+    stencilled dark row, even when that interval's own light frames are ok."""
+    stage = DarkFrameHoldStage()
+
+    first_interval = EnrichedCorrectedInterval(
+        left_abs=0, right_abs=10, left_t=-0.25,
+        frames=[_ef(2, 0.05, "left", 0, 1.0, 10.0, quality="wide_interval"),
+                _ef(3, 0.075, "left", 0, 1.5, 15.0, quality="wide_interval")],
+    )
+    batch1 = _empty_batch()
+    batch1.events.append(IntervalClosed(corrected_batch=first_interval))
+    stage.process(batch1)
+
+    second_interval = EnrichedCorrectedInterval(
+        left_abs=10, right_abs=20, left_t=4.9,
+        frames=[_ef(12, 5.0, "left", 0, 2.0, 20.0, quality="ok"),
+                _ef(13, 5.025, "left", 0, 4.0, 40.0, quality="ok")],
+    )
+    batch2 = _empty_batch()
+    batch2.events.append(IntervalClosed(corrected_batch=second_interval))
+    stage.process(batch2)
+
+    dark_row = second_interval.frames[0]
+    assert dark_row.abs_frame_id == 10
+    assert dark_row.quality == "wide_interval"

--- a/tests/test_pipeline/test_dark_schedule.py
+++ b/tests/test_pipeline/test_dark_schedule.py
@@ -1,0 +1,80 @@
+"""The positional dark schedule — single source of truth for both
+FrameClassificationStage (which types frames) and DarkCorrectionStage
+(which detects darks that never arrived)."""
+
+import pytest
+
+from omotion.pipeline.dark_schedule import is_dark_frame, missed_dark_ids
+
+
+DEFAULTS = {"discard_count": 9, "dark_interval": 600}
+
+
+def test_first_dark_is_at_discard_count_plus_one():
+    assert is_dark_frame(10, **DEFAULTS)
+
+
+def test_warmup_frames_are_not_dark():
+    for abs_id in range(1, 10):
+        assert not is_dark_frame(abs_id, **DEFAULTS)
+
+
+def test_subsequent_darks_land_every_dark_interval():
+    assert is_dark_frame(601, **DEFAULTS)
+    assert is_dark_frame(1201, **DEFAULTS)
+
+
+def test_ordinary_light_frames_are_not_dark():
+    for abs_id in (11, 300, 600, 602, 1200):
+        assert not is_dark_frame(abs_id, **DEFAULTS)
+
+
+def test_missed_dark_ids_finds_the_gap():
+    """Interval 10..1201 should have closed at 601; that dark never arrived."""
+    assert missed_dark_ids(10, 1201, **DEFAULTS) == [601]
+
+
+def test_missed_dark_ids_empty_for_a_nominal_interval():
+    assert missed_dark_ids(601, 1201, **DEFAULTS) == []
+    assert missed_dark_ids(10, 601, **DEFAULTS) == []
+
+
+def test_missed_dark_ids_excludes_both_endpoints():
+    """The bounding darks themselves are not 'missed'."""
+    assert 10 not in missed_dark_ids(10, 1201, **DEFAULTS)
+    assert 1201 not in missed_dark_ids(10, 1201, **DEFAULTS)
+
+
+def test_missed_dark_ids_reports_every_gap():
+    """A short interval makes multiple consecutive misses easy to construct:
+    with dark_interval=3, darks fall at 10, 13, 16, 19."""
+    cfg = {"discard_count": 9, "dark_interval": 3}
+    assert missed_dark_ids(10, 19, **cfg) == [13, 16]
+
+
+def test_dark_interval_zero_raises_valueerror():
+    """dark_interval=0 must raise ValueError, not ZeroDivisionError."""
+    with pytest.raises(ValueError, match="dark_interval must be positive"):
+        is_dark_frame(10, discard_count=9, dark_interval=0)
+
+
+def test_dark_interval_negative_raises_valueerror():
+    """dark_interval < 0 must raise ValueError, not produce silent nonsense."""
+    with pytest.raises(ValueError, match="dark_interval must be positive"):
+        is_dark_frame(10, discard_count=9, dark_interval=-1)
+
+
+def test_missed_dark_ids_adjacent_boundaries():
+    """Adjacent boundaries with nothing between them yield empty list."""
+    assert missed_dark_ids(10, 11, discard_count=9, dark_interval=600) == []
+
+
+def test_missed_dark_ids_reversed_bounds():
+    """Reversed bounds (left >= right) yield empty list, not nonsense."""
+    assert missed_dark_ids(1201, 10, discard_count=9, dark_interval=600) == []
+
+
+def test_is_dark_frame_with_zero_discard_count():
+    """With discard_count=0, frame 1 is the first dark, frame 0 is not."""
+    assert is_dark_frame(1, discard_count=0, dark_interval=600)
+    assert not is_dark_frame(0, discard_count=0, dark_interval=600)

--- a/tests/test_pipeline/test_factory.py
+++ b/tests/test_pipeline/test_factory.py
@@ -141,3 +141,24 @@ def test_pipeline_order_raw_tee_before_timestamp_repair():
         f"Tee('raw') at index {raw_tee_idx} must come before "
         f"TimestampRepairStage at index {repair_idx}"
     )
+
+
+def test_dark_correction_receives_the_dark_schedule():
+    """DarkCorrectionStage must see the same schedule as the classifier, or it
+    cannot tell a missed dark from a nominal interval."""
+    from omotion.pipeline.stages.dark import DarkCorrectionStage
+
+    meta = ScanMetadata(
+        scan_id="x", subject_id="y", operator="z",
+        started_at_iso="2026-05-22T00:00:00Z", duration_sec=60,
+        left_camera_mask=0xFF, right_camera_mask=0xFF, reduced_mode=False,
+    )
+    pipeline = default_pipeline(
+        metadata=meta, calibration=_trivial_calibration(),
+        pedestals=SensorPedestals(left=64.0, right=64.0),
+        discard_count=9, dark_interval=123,
+    )
+    dark = next(s for s in pipeline.stages
+                if isinstance(s, DarkCorrectionStage))
+    assert dark._discard_count == 9
+    assert dark._dark_interval == 123

--- a/tests/test_pipeline/test_factory.py
+++ b/tests/test_pipeline/test_factory.py
@@ -156,9 +156,9 @@ def test_dark_correction_receives_the_dark_schedule():
     pipeline = default_pipeline(
         metadata=meta, calibration=_trivial_calibration(),
         pedestals=SensorPedestals(left=64.0, right=64.0),
-        discard_count=9, dark_interval=123,
+        discard_count=5, dark_interval=123,
     )
     dark = next(s for s in pipeline.stages
                 if isinstance(s, DarkCorrectionStage))
-    assert dark._discard_count == 9
+    assert dark._discard_count == 5
     assert dark._dark_interval == 123

--- a/tests/test_pipeline/test_quality.py
+++ b/tests/test_pipeline/test_quality.py
@@ -1,0 +1,36 @@
+"""Quality vocabulary — ranking and worst-wins escalation."""
+
+from omotion.pipeline.quality import QUALITY_RANK, worse_of
+
+
+def test_rank_order():
+    assert (QUALITY_RANK["ok"]
+            < QUALITY_RANK["ts_corrected"]
+            < QUALITY_RANK["nan_filled"]
+            < QUALITY_RANK["wide_interval"])
+
+
+def test_wide_interval_outranks_nan_filled():
+    """A nan_filled camera emits NaN and drops out of the side average on its
+    own; a wide-interval camera contributes real-looking numbers built on a
+    stretched baseline. The flag that silently biases the aggregate must win,
+    or the side-average row would hide it."""
+    assert worse_of("nan_filled", "wide_interval") == "wide_interval"
+    assert worse_of("wide_interval", "nan_filled") == "wide_interval"
+
+
+def test_worse_of_picks_the_higher_rank():
+    assert worse_of("ok", "ts_corrected") == "ts_corrected"
+    assert worse_of("nan_filled", "ok") == "nan_filled"
+
+
+def test_worse_of_is_stable_for_equal_values():
+    assert worse_of("ok", "ok") == "ok"
+    assert worse_of("wide_interval", "wide_interval") == "wide_interval"
+
+
+def test_unknown_values_rank_as_ok():
+    """Documented hazard: an unrecognised string ranks 0. Any consumer holding
+    its own copy of the rank map would treat a newer value as the BEST quality.
+    This is why the rank lives here and is imported, never re-declared."""
+    assert worse_of("something_new", "ok") == "ok"

--- a/tests/test_pipeline/test_quality.py
+++ b/tests/test_pipeline/test_quality.py
@@ -29,8 +29,15 @@ def test_worse_of_is_stable_for_equal_values():
     assert worse_of("wide_interval", "wide_interval") == "wide_interval"
 
 
-def test_unknown_values_rank_as_ok():
-    """Documented hazard: an unrecognised string ranks 0. Any consumer holding
-    its own copy of the rank map would treat a newer value as the BEST quality.
-    This is why the rank lives here and is imported, never re-declared."""
-    assert worse_of("something_new", "ok") == "ok"
+def test_unknown_value_is_preserved_over_ok():
+    """An unrecognised string ranks 0 and so ties with "ok", and a tie returns
+    the first argument. That ordering matters: escalating an unknown flag with
+    "ok" must not erase it, because we cannot know its severity.
+
+    This is also the documented hazard of the rank table — a stale consumer
+    holding its own copy would rank a NEWER known value (like wide_interval)
+    as 0, i.e. as the best quality rather than the worst. That is why the rank
+    lives in one place and is imported, never re-declared.
+    """
+    assert worse_of("something_new", "ok") == "something_new"
+    assert worse_of("ok", "something_new") == "ok"


### PR DESCRIPTION
Refs #175

## Problem

Dark frames are scheduled positionally — abs_id `discard_count + 1`, then every `dark_interval` (defaults: abs_id 10, 601, 1201…). Light frames between two darks form an interval whose baseline is linearly interpolated between the bounding darks.

If a scheduled dark never arrives — dropped frame, camera dropout, stale-rejected frame — the interval does not close there. The *next* dark closes it, so the interval spans roughly double its nominal width and every light frame in it has its baseline interpolated across the gap. At the defaults that silently degrades **~1200 frames, about 30 s of a scan**, with nothing recorded anywhere.

## Change

`DarkCorrectionStage` now knows the dark schedule. When an interval closes it counts scheduled dark positions falling strictly inside `[left_abs, right_abs]`; one or more means darks were missed. Those frames are **kept and flagged** `quality="wide_interval"`, and a `MissedDarkWarning` diagnostic is emitted.

Frames are kept rather than discarded because valid darks still bound the widened interval on both sides — the data is degraded, not uncorrectable. (Terminal-dark-missing, which has no right boundary at all, keeps its existing discard behaviour.)

`wide_interval` ranks **above** `nan_filled`: a NaN frame drops out of the side average's `nanmean` on its own, whereas a wide-interval frame contributes real-looking numbers built on a stretched baseline — it is the only value that silently biases the aggregate.

## Structure

Two new single-purpose modules, so each rule has exactly one definition:

- `omotion/pipeline/dark_schedule.py` — `is_dark_frame`, `missed_dark_ids`. Imported by **both** `FrameClassificationStage` (typing frames) and `DarkCorrectionStage` (detecting absences). Two copies would drift and regrow this bug.
- `omotion/pipeline/quality.py` — `QUALITY_RANK` + `worse_of`. `side_avg.py`'s comment claiming it mirrored `sinks._QUALITY_RANK` was stale; `5c3e107` removed that constant along with the corrected-CSV quality column.

Detection deliberately does **not** re-type synthetic NaN-fill rows as `"dark"` (the approach originally sketched in the issue). That would risk a NaN `DarkObservation` poisoning `DarkHistory` and both adjacent interval boundaries. Schedule-based detection also catches missed darks from any cause, not just the NaN-fill path.

No sink or runner changes: `runner.py` already routes unrecognised events to `"diagnostics"`, and the diagnostics sinks tally by type.

## Notes for review

Three findings from review that changed the code beyond the original plan:

1. **`factory.py` wasn't forwarding the schedule.** `DarkCorrectionStage` fell back to defaults while `FrameClassificationStage` got the real values — so the two stages disagreed about where darks belong. This also meant the golden-replay test, which runs `default_pipeline(dark_interval=20)`, had been exercising the dark stage at 600 the whole time. Its pass was a false negative; it now genuinely validates the feature.
2. **The test guarding that forwarding couldn't detect its own regression.** It used `discard_count=9`, identical to the constructor default, so deleting the forwarding left all tests green. Now uses `5`, and the regression was confirmed by deliberately removing the line and watching the test fail (`assert 9 == 5`).
3. **`DarkFrameHoldStage` hardcoded `quality="ok"`** on the stencilled leading-dark row it inserts into every interval. In a flagged interval that row would have claimed `ok` while every light frame said `wide_interval` — contradicting this feature's own worst-wins contract, in a row persisted to `session_data`. It now inherits the worst quality of the neighbours it was interpolated from.

## Scope

Contaminated (as opposed to missing) darks are explicitly out of scope — the integrity guard's verdict is still ignored, unchanged from today. No tolerance threshold for "how wide is too wide" is invented here; the policy keeps and flags unconditionally.

Since `5c3e107`, `quality` reaches only `session_data.quality` in the scan DB. Consumers reading the corrected CSV see degraded data unflagged — the `MissedDarkWarning` and scan-summary tally are the surfaces independent of that. Recorded as an accepted limitation in the design doc.

## Testing

TDD throughout; every test was watched failing first. `pytest -m "not console and not sensor and not destructive and not slow"` → **589 passed** (baseline 586 before the review fixes).

The golden replay fixture is **unmodified** — verified at each step. Its scan has no missing darks, so a change there would have meant detection was firing on nominal intervals.

Design: `docs/superpowers/specs/2026-07-21-missed-dark-policy-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
