### PR TITLE
feat: MotionSensor.get_boot_mode() via OW_CMD_BOOT_INFO — no DFU cycle

### DIFF
--- a/omotion/MotionSensor.py
+++ b/omotion/MotionSensor.py
@@ -25,6 +25,7 @@ from omotion.config import (
     OW_CMD_HWID,
     OW_CMD_I2C_REG_READ,
     OW_CMD_I2C_STATUS,
+    OW_CMD_BOOT_INFO,
     OW_CMD_PING,
     OW_CMD_RESET,
     OW_CMD_TOGGLE_LED,
@@ -75,6 +76,7 @@ from omotion.config import (
     is_valid_serial,
 )
 from omotion.i2c_packet import I2C_Packet
+from omotion.boot_mode import BootMode, parse_boot_info
 from omotion.GitHubReleases import GitHubReleases
 from omotion.MotionProcessing import bytes_to_integers
 from omotion.utils import calculate_file_crc, log_i2c_health
@@ -570,6 +572,26 @@ class MotionSensor(SignalWrapper):
             )
             return ver_str or "v0.0.0"
         return "v0.0.0"
+
+    def get_boot_mode(self) -> BootMode:
+        """Whether this sensor runs a bare-metal or bootloader-slot image.
+
+        Queries OW_CMD_BOOT_INFO over the normal command interface — no DFU
+        cycle — and classifies the reported ``SCB->VTOR``. Firmware without the
+        command replies OW_UNKNOWN, which yields :data:`BootMode.UNKNOWN`; so
+        does any garbled/short reply. Never raises: callers treat UNKNOWN as
+        "couldn't determine" and must not make flashing decisions on it (the DFU
+        alt-setting check remains the authoritative gate before any write).
+        """
+        if self.demo_mode:
+            return BootMode.BARE_METAL
+        try:
+            r = self._send(packetType=OW_CMD, command=OW_CMD_BOOT_INFO)
+        except Exception:
+            return BootMode.UNKNOWN
+        if r is None or r.packetType in _ERROR_TYPES:
+            return BootMode.UNKNOWN
+        return parse_boot_info(bytes(r.data[: r.data_len]) if r.data else b"")
 
     def read_serial_number(self) -> str | None:
         """Read the sensor module hardware serial number (None if unprogrammed/error)."""

--- a/omotion/__init__.py
+++ b/omotion/__init__.py
@@ -59,7 +59,7 @@ from .CalibrationWorkflow import (
     CalibrationThresholds,
 )
 from .connection_state import ConnectionState
-from .boot_mode import BootMode
+from .boot_mode import BootMode, parse_boot_info
 from .firmware_update import (
     FirmwareKind,
     FirmwareUpdater,
@@ -109,6 +109,7 @@ __all__ = [
     "check_latest",
     "download_firmware",
     "BootMode",
+    "parse_boot_info",
     "UnsupportedReleaseError",
     "is_update_available",
     "parse_version",

--- a/omotion/boot_mode.py
+++ b/omotion/boot_mode.py
@@ -21,9 +21,10 @@ flash rather than guess.
 from __future__ import annotations
 
 import re
+import struct
 from enum import Enum
 
-__all__ = ["BootMode", "parse_boot_mode", "flash_address_for"]
+__all__ = ["BootMode", "parse_boot_mode", "parse_boot_info", "flash_address_for"]
 
 
 class BootMode(Enum):
@@ -47,6 +48,34 @@ _FLASH_ADDRESS = {
     BootMode.BARE_METAL: BARE_METAL_FLASH_ADDRESS,
     BootMode.BOOTLOADER: BOOTLOADER_SLOT_ADDRESS,
 }
+
+# Runtime vector-table base (SCB->VTOR) each build reports via OW_CMD_BOOT_INFO.
+# These are the VECT_TAB_BASE_ADDRESS values system_stm32h7xx.c sets per build.
+_VTOR_BARE_METAL = 0x08000000
+_VTOR_BOOTLOADER_SLOT = 0x08020400   # slot base 0x08020000 + 0x400 image header
+
+_BOOT_MODE_BY_VTOR = {
+    _VTOR_BARE_METAL: BootMode.BARE_METAL,
+    _VTOR_BOOTLOADER_SLOT: BootMode.BOOTLOADER,
+}
+
+# OW_CMD_BOOT_INFO reply: u8 struct_version; u8 reserved[3]; u32 vtor; u32 flash_base
+_BOOT_INFO = struct.Struct("<B3sII")
+
+
+def parse_boot_info(payload) -> BootMode:
+    """Classify an ``OW_CMD_BOOT_INFO`` reply by its reported ``vtor``.
+
+    Never raises. Returns :data:`BootMode.UNKNOWN` for a missing/short/garbled
+    reply, or one whose vtor is neither the bare-metal base nor the slot vectors
+    — which is also what old firmware effectively yields, since it answers
+    OW_UNKNOWN (no payload) to command 0x09. The struct version is not enforced,
+    so a future reply that only appends fields still classifies.
+    """
+    if not payload or len(payload) < _BOOT_INFO.size:
+        return BootMode.UNKNOWN
+    _ver, _rsvd, vtor, _flash_base = _BOOT_INFO.unpack_from(payload)
+    return _BOOT_MODE_BY_VTOR.get(vtor, BootMode.UNKNOWN)
 
 # `Found DFU: [0483:df11] ver=..., ..., alt=0, name="@Internal Flash/...", serial="..."`
 _ALT_RE = re.compile(r"\balt=(\d+)\b")

--- a/omotion/config.py
+++ b/omotion/config.py
@@ -139,6 +139,11 @@ OW_CMD_HWID = 0x05
 OW_CMD_SERIAL = 0x07
 OW_CMD_I2C_REG_READ = 0x08
 OW_CMD_MESSAGES = 0x09
+# Sensor-module 0x09 (NOT console — there 0x09 is OW_CMD_MESSAGES above). Reports
+# runtime SCB->VTOR so a host can tell bare-metal from bootloader-slot without a
+# DFU cycle. The console equivalent will use a different ID (console-fw #45),
+# since 0x09 is taken there. See openmotion-sensor-fw #110.
+OW_CMD_BOOT_INFO = 0x09
 OW_CMD_USR_CFG = 0x0A
 OW_CMD_DFU = 0x0D
 OW_CMD_NOP = 0x0E

--- a/tests/test_boot_mode.py
+++ b/tests/test_boot_mode.py
@@ -90,3 +90,50 @@ def test_flash_address_for_unknown_mode_raises():
 
     with pytest.raises(ValueError):
         flash_address_for(BootMode.UNKNOWN)
+
+
+# ---------------------------------------------------------------------------
+# parse_boot_info: OW_CMD_BOOT_INFO reply -> BootMode, over normal comms
+# (no DFU cycle). Payload is packed little-endian:
+#   u8 struct_version=1; u8 reserved[3]; u32 vtor; u32 flash_base
+# ---------------------------------------------------------------------------
+import struct
+
+from omotion.boot_mode import parse_boot_info
+
+
+def _payload(vtor, *, version=1, flash_base=None):
+    return struct.pack("<B3sII", version, b"\x00\x00\x00", vtor,
+                       vtor if flash_base is None else flash_base)
+
+
+def test_boot_info_vtor_at_flash_base_is_bare_metal():
+    assert parse_boot_info(_payload(0x08000000)) is BootMode.BARE_METAL
+
+
+def test_boot_info_vtor_at_slot_vectors_is_bootloader():
+    assert parse_boot_info(_payload(0x08020400)) is BootMode.BOOTLOADER
+
+
+def test_boot_info_unrecognised_vtor_is_unknown():
+    assert parse_boot_info(_payload(0x24000000)) is BootMode.UNKNOWN  # RAM_D1, nonsense
+
+
+def test_boot_info_too_short_is_unknown():
+    assert parse_boot_info(b"\x01\x00\x00") is BootMode.UNKNOWN
+
+
+def test_boot_info_empty_is_unknown():
+    assert parse_boot_info(b"") is BootMode.UNKNOWN
+    assert parse_boot_info(None) is BootMode.UNKNOWN
+
+
+def test_boot_info_ignores_flash_base_and_uses_vtor():
+    # A future firmware might report a distinct flash_base; classification is on vtor.
+    assert parse_boot_info(_payload(0x08000000, flash_base=0x08000000)) is BootMode.BARE_METAL
+    assert parse_boot_info(_payload(0x08020400, flash_base=0x08020000)) is BootMode.BOOTLOADER
+
+
+def test_boot_info_unknown_struct_version_still_classifies_by_vtor():
+    # Be lenient on the struct version so a v2 that only appends fields still works.
+    assert parse_boot_info(_payload(0x08020400, version=2)) is BootMode.BOOTLOADER

--- a/tests/test_sensor_boot_mode.py
+++ b/tests/test_sensor_boot_mode.py
@@ -1,0 +1,64 @@
+"""Unit tests for MotionSensor.get_boot_mode over normal comms (no DFU).
+
+Sends OW_CMD_BOOT_INFO and classifies the reply. Old firmware NAKs the unknown
+command, which must read as UNKNOWN, not raise.
+"""
+import struct
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from omotion.boot_mode import BootMode
+from omotion.MotionSensor import MotionSensor
+from omotion.config import OW_CMD, OW_CMD_BOOT_INFO, OW_RESP, OW_UNKNOWN
+
+
+def _make_sensor(response):
+    s = MotionSensor.__new__(MotionSensor)
+    s._send = MagicMock(return_value=response)
+    s.demo_mode = False
+    return s
+
+
+def _resp(data=b"", packet_type=OW_RESP):
+    data = bytes(data)
+    return SimpleNamespace(packetType=packet_type, data=data, data_len=len(data))
+
+
+def _boot_info(vtor):
+    return struct.pack("<B3sII", 1, b"\x00\x00\x00", vtor, vtor)
+
+
+def test_get_boot_mode_bare_metal():
+    sensor = _make_sensor(_resp(_boot_info(0x08000000)))
+    assert sensor.get_boot_mode() is BootMode.BARE_METAL
+    kwargs = sensor._send.call_args.kwargs
+    assert kwargs["packetType"] == OW_CMD
+    assert kwargs["command"] == OW_CMD_BOOT_INFO
+
+
+def test_get_boot_mode_bootloader():
+    sensor = _make_sensor(_resp(_boot_info(0x08020400)))
+    assert sensor.get_boot_mode() is BootMode.BOOTLOADER
+
+
+def test_get_boot_mode_old_firmware_naks_unknown_command():
+    """Firmware without 0x09 replies OW_UNKNOWN — read as UNKNOWN, don't raise."""
+    sensor = _make_sensor(_resp(b"", packet_type=OW_UNKNOWN))
+    assert sensor.get_boot_mode() is BootMode.UNKNOWN
+
+
+def test_get_boot_mode_no_response_is_unknown():
+    sensor = _make_sensor(None)
+    assert sensor.get_boot_mode() is BootMode.UNKNOWN
+
+
+def test_get_boot_mode_garbled_payload_is_unknown():
+    sensor = _make_sensor(_resp(b"\x01\x02"))
+    assert sensor.get_boot_mode() is BootMode.UNKNOWN
+
+
+def test_get_boot_mode_demo_mode_is_bare_metal():
+    s = MotionSensor.__new__(MotionSensor)
+    s.demo_mode = True
+    s._send = MagicMock(side_effect=AssertionError("must not hit the wire in demo mode"))
+    assert s.get_boot_mode() is BootMode.BARE_METAL


### PR DESCRIPTION
Refs #110

Adds a host-side query for the sensor firmware's new `OW_CMD_BOOT_INFO` (sensor-fw #110), so the boot mode can be read over normal comms instead of only by entering DFU and counting alt settings.

## Change

- `config.OW_CMD_BOOT_INFO = 0x09` — sensor only (console 0x09 is `OW_CMD_MESSAGES`; the console equivalent will use a different ID, console-fw #45).
- `boot_mode.parse_boot_info(payload) -> BootMode`: classifies the packed reply (`u8 struct_version; u8 reserved[3]; u32 vtor; u32 flash_base`) by its `vtor` — `0x08000000` bare-metal, `0x08020400` slot, else UNKNOWN. Lenient on struct version (an appended-field v2 still classifies); never raises.
- `MotionSensor.get_boot_mode() -> BootMode`: sends `0x09`, parses. Old firmware NAKs the unknown command (`OW_UNKNOWN`) → UNKNOWN; garbled/short → UNKNOWN; never raises.

Drives UI (the test app's lock-state icon). **Not** authoritative for flashing — the DFU alt-setting check stays the gate before any write, because a slot image predating this command also answers `OW_UNKNOWN`.

## Verified on hardware

Flashed the bench right sensor's slot with `1.8.2-rc.4` (which carries the command) via `FirmwareUpdater`, power-cycled, then queried over normal comms — **no DFU cycle**:

```
before (rc.2, no command):  version=1.8.2-rc.2  get_boot_mode=BootMode.UNKNOWN
after  (rc.4):              version=1.8.2-rc.4  get_boot_mode=BootMode.BOOTLOADER
```

The install path itself also exercised the SDK's DFU-side detection end to end: `FirmwareUpdater.update` detected `BootMode.BOOTLOADER` and flashed the signed slot image.

13 new unit tests; full suite green (635 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
