### PR TITLE
feat: MotionConsole.get_boot_mode() via OW_CMD_BOOT_INFO (0x0B) (#45)

### DIFF
--- a/omotion/MotionConsole.py
+++ b/omotion/MotionConsole.py
@@ -11,6 +11,7 @@ import numpy as np
 
 from omotion import _log_root
 from omotion.MotionUart import MotionUart
+from omotion.boot_mode import BootMode, parse_boot_info
 from omotion.ConsoleTelemetry import ConsoleTelemetryPoller
 from omotion.connection_state import ConnectionState
 from omotion.signal_wrapper import SignalWrapper
@@ -42,7 +43,9 @@ from omotion.config import (
     OW_CMD_TOGGLE_LED,
     OW_CMD_USR_CFG,
     OW_CMD_VERSION,
+    OW_CMD_BOOT_INFO_CONSOLE,
     OW_CMD_MESSAGES,
+    OW_RESP,
     OW_CONTROLLER,
     OW_CTRL_BOARDID,
     OW_CTRL_GET_FAN,
@@ -480,6 +483,32 @@ class MotionConsole(SignalWrapper):
         except Exception as e:
             self._log_command_error("get_version", e)
             raise  # Re-raise the exception for the caller to handle
+
+    def get_boot_mode(self) -> BootMode:
+        """Whether this console runs a bare-metal or bootloader-slot image.
+
+        Queries OW_CMD_BOOT_INFO (0x0B on the console) over the normal command
+        interface — no DFU cycle — and classifies the reported ``SCB->VTOR``.
+        Firmware without the command replies with an error/NAK, which yields
+        :data:`BootMode.UNKNOWN`; so does any garbled/short reply or a
+        disconnected console. Never raises: callers treat UNKNOWN as "couldn't
+        determine" and must not make flashing decisions on it (the DFU
+        alt-setting check remains the authoritative gate before any write).
+        """
+        try:
+            if self.uart.demo_mode:
+                return BootMode.BARE_METAL
+            if not self.is_connected():
+                return BootMode.UNKNOWN
+            r = self.uart.send_packet(
+                id=None, packetType=OW_CMD, command=OW_CMD_BOOT_INFO_CONSOLE
+            )
+            self.uart.clear_buffer()
+        except Exception:
+            return BootMode.UNKNOWN
+        if r is None or r.packetType != OW_RESP:
+            return BootMode.UNKNOWN
+        return parse_boot_info(bytes(r.data[: r.data_len]) if r.data else b"")
 
     def echo(self, echo_data=None) -> tuple[bytes, int]:
         """

--- a/omotion/config.py
+++ b/omotion/config.py
@@ -144,6 +144,10 @@ OW_CMD_MESSAGES = 0x09
 # DFU cycle. The console equivalent will use a different ID (console-fw #45),
 # since 0x09 is taken there. See openmotion-sensor-fw #110.
 OW_CMD_BOOT_INFO = 0x09
+# Console-module BOOT_INFO. 0x0B because 0x09 is OW_CMD_MESSAGES on the console.
+# Same reply payload as the sensor's, so parse_boot_info covers both. See
+# openmotion-console-fw #45.
+OW_CMD_BOOT_INFO_CONSOLE = 0x0B
 OW_CMD_USR_CFG = 0x0A
 OW_CMD_DFU = 0x0D
 OW_CMD_NOP = 0x0E

--- a/tests/test_console_boot_mode.py
+++ b/tests/test_console_boot_mode.py
@@ -1,0 +1,65 @@
+"""Unit tests for MotionConsole.get_boot_mode over normal comms (no DFU).
+
+Mirrors MotionSensor.get_boot_mode, but the console command is OW_CMD_BOOT_INFO
+= 0x0B (0x09 is OW_CMD_MESSAGES there). Reply payload is byte-identical, so the
+same parse_boot_info handles both. Old firmware NAKs the unknown command, which
+must read as UNKNOWN, not raise.
+"""
+import struct
+from unittest.mock import MagicMock
+
+from omotion.boot_mode import BootMode
+from omotion.MotionConsole import MotionConsole
+from omotion.config import OW_CMD, OW_CMD_BOOT_INFO_CONSOLE, OW_RESP, OW_ERROR
+
+
+def _make_console(payload=b"", packet_type=OW_RESP, *, connected=True, demo=False):
+    console = MotionConsole.__new__(MotionConsole)
+    console.uart = MagicMock()
+    console.uart.demo_mode = demo
+    console.is_connected = MagicMock(return_value=connected)
+    resp = MagicMock()
+    resp.packetType = packet_type
+    resp.data = bytes(payload)
+    resp.data_len = len(payload)
+    console.uart.send_packet.return_value = resp
+    console.uart.clear_buffer = MagicMock()
+    return console
+
+
+def _boot_info(vtor):
+    return struct.pack("<B3sII", 1, b"\x00\x00\x00", vtor, vtor)
+
+
+def test_console_boot_mode_bare_metal():
+    c = _make_console(_boot_info(0x08000000))
+    assert c.get_boot_mode() is BootMode.BARE_METAL
+    kwargs = c.uart.send_packet.call_args.kwargs
+    assert kwargs["packetType"] == OW_CMD
+    assert kwargs["command"] == OW_CMD_BOOT_INFO_CONSOLE  # 0x0B, not the sensor's 0x09
+
+
+def test_console_boot_mode_bootloader():
+    c = _make_console(_boot_info(0x08020400))
+    assert c.get_boot_mode() is BootMode.BOOTLOADER
+
+
+def test_console_boot_mode_old_firmware_error_is_unknown():
+    c = _make_console(b"", packet_type=OW_ERROR)
+    assert c.get_boot_mode() is BootMode.UNKNOWN
+
+
+def test_console_boot_mode_not_connected_is_unknown():
+    c = _make_console(_boot_info(0x08020400), connected=False)
+    assert c.get_boot_mode() is BootMode.UNKNOWN
+
+
+def test_console_boot_mode_garbled_is_unknown():
+    c = _make_console(b"\x01\x02\x03")
+    assert c.get_boot_mode() is BootMode.UNKNOWN
+
+
+def test_console_boot_mode_demo_is_bare_metal():
+    c = _make_console(demo=True)
+    c.uart.send_packet.side_effect = AssertionError("must not hit the wire in demo mode")
+    assert c.get_boot_mode() is BootMode.BARE_METAL


### PR DESCRIPTION
Refs #45

Console counterpart to `MotionSensor.get_boot_mode` (#180). Reads the console firmware's new `OW_CMD_BOOT_INFO` (console-fw #46) over normal comms and classifies the reported `SCB->VTOR` — no DFU cycle.

- `config.OW_CMD_BOOT_INFO_CONSOLE = 0x0B` — the console's `0x09` is `OW_CMD_MESSAGES`, so it can't reuse the sensor's `0x09`. The reply payload is **byte-identical** to the sensor's, so `boot_mode.parse_boot_info` covers both boards unchanged.
- `MotionConsole.get_boot_mode()`: sends `0x0B`, returns `BootMode`. Old firmware errors/NAKs → UNKNOWN; disconnected/garbled/short → UNKNOWN; never raises.

Drives UI (the test app's console lock icon); not authoritative for flashing — the DFU alt-setting check stays the gate.

6 new unit tests; full suite green (733 passed). **Not yet HW-verified** — pending a console build with the command flashed (console-fw #46).

🤖 Generated with [Claude Code](https://claude.com/claude-code)