### PR TITLE
fix: actionable error when the encryption extra is missing

### DIFF
--- a/omotion/db_key.py
+++ b/omotion/db_key.py
@@ -49,8 +49,30 @@ def require_encryption() -> bool:
     return bool(_require_encryption)
 
 
+def _keyring():
+    """Import ``keyring``, converting a missing dependency into the actionable
+    ``EncryptionUnavailable`` rather than a bare ``ModuleNotFoundError``.
+
+    ``keyring`` and ``sqlcipher3`` ship in the ``[encryption]`` extra, so a build
+    that forgets it fails at the first keystore touch. Mirrors how ``db_open``
+    handles the ``sqlcipher3`` import — the message has to name the fix, because
+    the place this surfaces is a packaged clinical app on a bench.
+    """
+    try:
+        import keyring
+    except ImportError as exc:  # pragma: no cover - exercised via monkeypatch
+        raise EncryptionUnavailable(
+            "the scan-database encryption policy requires the 'keyring' package, "
+            "which is not installed. Install the SDK with its encryption extra: "
+            "pip install 'openmotion-sdk[encryption]' (a packaged app must also "
+            "list keyring and sqlcipher3 among its build requirements, or "
+            "PyInstaller cannot bundle them)."
+        ) from exc
+    return keyring
+
+
 def _assert_backend() -> None:
-    import keyring
+    keyring = _keyring()
 
     kr = keyring.get_keyring()
     # Windows Credential Manager is the supported clinical backend.
@@ -69,7 +91,7 @@ def get_key(*, create: bool = False) -> str:
     missing key raises ``EncryptionKeyMissing`` (used when opening an existing
     encrypted DB). Never logs or echoes the key.
     """
-    import keyring
+    keyring = _keyring()
 
     value = keyring.get_password(_SERVICE, _ENTRY)
     if value is None:
@@ -105,7 +127,7 @@ def export_key(path: str | Path) -> None:
 
 def import_key(path: str | Path) -> None:
     """Load a key exported by ``export_key`` back into the keystore."""
-    import keyring
+    keyring = _keyring()
 
     key = Path(path).read_text(encoding="ascii").strip()
     if len(key) != 64 or any(c not in "0123456789abcdef" for c in key.lower()):

--- a/tests/test_db_key.py
+++ b/tests/test_db_key.py
@@ -204,3 +204,46 @@ def test_export_cli_reports_error_without_a_key(fake_keyring, tmp_path, capsys):
     rc = db_key._main(["export", str(tmp_path / "nope.key")])
     assert rc == 1
     assert "error:" in capsys.readouterr().out
+
+
+# --------------------------------------------------------------------------
+# Missing optional dependency must fail ACTIONABLY, not with ModuleNotFoundError
+# --------------------------------------------------------------------------
+
+@pytest.fixture
+def no_keyring_installed(monkeypatch):
+    """Simulate a build whose requirements forgot the [encryption] extra."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _fake_import(name, *args, **kwargs):
+        if name == "keyring" or name.startswith("keyring."):
+            raise ImportError("No module named 'keyring'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_import)
+
+
+def test_missing_keyring_raises_actionable_error(no_keyring_installed):
+    """Regression: a packaged clinical app built without the encryption extra
+    surfaced a bare ModuleNotFoundError. It must instead name the fix."""
+    with pytest.raises(db_key.EncryptionUnavailable) as exc:
+        db_key.get_key(create=True)
+    msg = str(exc.value)
+    assert "keyring" in msg
+    assert "openmotion-sdk[encryption]" in msg      # tells you how to fix it
+
+
+def test_missing_keyring_blocks_policy_activation(no_keyring_installed):
+    """set_policy(True) must fail loudly at startup rather than letting the app
+    reach a scan and only then discover it cannot reach the keystore."""
+    with pytest.raises(db_key.EncryptionUnavailable):
+        db_key.set_policy(require_encryption=True)
+
+
+def test_missing_keyring_does_not_affect_research_builds(no_keyring_installed):
+    """Encryption deps are optional: with the policy off, nothing touches the
+    keystore, so a research build without them must work normally."""
+    db_key.set_policy(require_encryption=False)
+    assert db_key.require_encryption() is False


### PR DESCRIPTION
## What

A packaged clinical app built without `keyring` installed failed with a bare:

```
ModuleNotFoundError: No module named 'keyring'
```

`db_open` already converts a missing `sqlcipher3` into an `EncryptionUnavailable` that names the fix, but `db_key` imported `keyring` bare at three sites — so the keystore path had no equivalent guard. All three now route through `_keyring()`.

The new message names both halves of the real fix:
- install `openmotion-sdk[encryption]`, **and**
- a packaged app must also list `keyring`/`sqlcipher3` in its own build requirements, because PyInstaller cannot bundle a package that is not installed in the build environment.

That second half is the actual root cause of the field failure; the app-side fix is **OpenwaterHealth/openmotion-bloodflow-app#396**.

Refs #185

## Testing

Three new tests using an import blocker that simulates a build without the extra:
- the actionable message (asserts it names `openmotion-sdk[encryption]`)
- `set_policy(True)` fails at **startup** rather than at scan time
- a **research** build (policy off) still works normally without the extra — the deps stay genuinely optional

Full software suite: **756 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)