### PR TITLE
fix: call clear_halt on the Device, not the non-existent usb.util helper

### DIFF
--- a/omotion/CommInterface.py
+++ b/omotion/CommInterface.py
@@ -229,17 +229,43 @@ class CommInterface(USBInterfaceBase):
                             continue
                         logger.error("%s: write timed out after %d attempts", self.desc, 1 + _retries)
                         raise
-                    # A stalled endpoint (EPIPE / broken-pipe) can be recovered by
-                    # issuing a CLEAR_HALT control transfer.  Try once; if it works
-                    # re-send the original data.  Any other USB error is re-raised
-                    # so callers and _read_loop disconnect logic see it normally.
-                    if e.errno in (32, -9):  # EPIPE on Linux; LIBUSB_ERROR_PIPE cross-platform
+                    # A stalled OUT endpoint (EPIPE) leaves the host-side pipe
+                    # unusable until a CLEAR_HALT control transfer resets it.
+                    # Clear it so a *later* write on a still-present device has a
+                    # working pipe, then always re-raise: this write failed either
+                    # way, and _read_loop has usually already latched
+                    # _transport_down_evt by the time we get here.
+                    #
+                    # We deliberately do NOT re-send.  The stall can arrive after
+                    # the device already accepted and executed the transfer, and
+                    # the sensor firmware has no id dedup — it runs
+                    # process_if_command() on every frame that passes framing +
+                    # CRC (sensor-fw Core/Src/uart_comms.c:331).  A duplicate
+                    # inverts OW_CMD_TOGGLE_LED (if_commands.c:139) and
+                    # double-appends an OW_FPGA_BITSTREAM chunk
+                    # (if_commands.c:527-529), walking the write pointer past the
+                    # buffer.  Retry with duplicate suppression belongs one layer
+                    # up, in send_packet.  See #189.
+                    #
+                    # pyusb puts the libusb code in .backend_error_code and the
+                    # POSIX errno in .errno, and _libusb_errno[-9] is 32 on every
+                    # platform, so LIBUSB_ERROR_PIPE always arrives as errno 32.
+                    if e.errno in (32, -9):  # EPIPE (32); -9 never reaches .errno
                         logger.warning("%s: OUT endpoint stalled, attempting clear_halt", self.desc)
                         try:
-                            usb.util.clear_halt(self.dev, self.ep_out)
-                            return self.dev.write(self.ep_out.bEndpointAddress, data, timeout=timeout)
-                        except Exception as recovery_err:
-                            logger.error("%s: clear_halt recovery failed: %s", self.desc, recovery_err)
+                            # clear_halt is a usb.core.Device method; usb.util has
+                            # no such attribute — that was the #189 defect.
+                            self.dev.clear_halt(self.ep_out.bEndpointAddress)
+                            logger.info("%s: OUT endpoint halt cleared", self.desc)
+                        except (usb.core.USBError, NotImplementedError) as recovery_err:
+                            # Common after teardown: dispose_resources() has
+                            # already released the interface, so libusb returns
+                            # NOT_FOUND.  The errno tells that apart from a live
+                            # device refusing the request.
+                            logger.warning(
+                                "%s: clear_halt failed (errno=%s): %s",
+                                self.desc, getattr(recovery_err, "errno", None), recovery_err,
+                            )
                     raise
 
     def receive(self, length=512, timeout=100):

--- a/tests/test_comm_clear_halt.py
+++ b/tests/test_comm_clear_halt.py
@@ -1,0 +1,121 @@
+"""Unit tests for CommInterface OUT-endpoint stall recovery (#189).
+
+The EPIPE branch in ``CommInterface.write`` called ``usb.util.clear_halt``,
+which does not exist in pyusb — ``clear_halt`` is a method on
+``usb.core.Device``. Every stall therefore raised ``AttributeError``, which
+the surrounding broad ``except Exception`` caught and relabelled
+"clear_halt recovery failed", so the recovery has never run since SDK 1.5.0.
+
+Only ``test_stall_clears_halt_with_endpoint_address`` and
+``test_non_usberror_from_clear_halt_is_not_swallowed`` fail against pre-fix
+code. ``test_stall_does_not_resend_the_packet`` is a forward regression
+fence: it passes today because the AttributeError aborts before the re-send
+at the old line 240 could run.
+
+The device mock is ``spec=usb.core.Device`` on purpose. A bare MagicMock
+accepts any invented method name, so a test written against one would have
+passed just as green against the very defect these tests exist to catch.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+import usb.core
+
+from omotion.CommInterface import CommInterface
+
+pytestmark = pytest.mark.unit
+
+_EP_OUT_ADDR = 0x01
+
+
+def _make_comm(write_side_effect) -> CommInterface:
+    """Build a CommInterface over a fake device, bypassing claim()."""
+    dev = MagicMock(spec=usb.core.Device)  # spec: a phantom name cannot pass
+    dev.write.side_effect = write_side_effect
+    ci = CommInterface(dev, interface_index=0, desc="TEST", async_mode=False)
+    ci.ep_out = MagicMock(bEndpointAddress=_EP_OUT_ADDR)
+    ci.ep_in = MagicMock(bEndpointAddress=0x81, wMaxPacketSize=64)
+    return ci
+
+
+def _epipe() -> usb.core.USBError:
+    """A stalled OUT endpoint as pyusb reports it.
+
+    pyusb's USBError(strerror, backend_error_code, errno) puts the libusb
+    code in ``backend_error_code`` and the POSIX errno in ``errno``, and
+    ``libusb1._libusb_errno[-9]`` is 32 on every platform — so
+    LIBUSB_ERROR_PIPE always arrives as errno 32.
+    """
+    return usb.core.USBError("pipe error", -9, 32)
+
+
+def test_stall_clears_halt_with_endpoint_address():
+    """The regression: the recovery must actually reach the device."""
+    ci = _make_comm(_epipe())
+
+    with pytest.raises(usb.core.USBError):
+        ci.write(b"\xaa\x00")
+
+    ci.dev.clear_halt.assert_called_once_with(_EP_OUT_ADDR)
+
+
+def test_stall_does_not_resend_the_packet():
+    """At-most-once delivery: no duplicate command reaches the firmware.
+
+    Forward regression fence — passes pre-fix too (see module docstring).
+    """
+    ci = _make_comm(_epipe())
+
+    with pytest.raises(usb.core.USBError):
+        ci.write(b"\xaa\x00")
+
+    assert ci.dev.write.call_count == 1, (
+        "stalled packet was re-sent — the sensor firmware has no id dedup "
+        "(uart_comms.c:331), so a duplicate double-executes the command"
+    )
+
+
+def test_clear_halt_failure_does_not_mask_the_original_epipe():
+    """A device that refuses CLEAR_HALT must not swallow the original error.
+
+    Common after teardown: dispose_resources() has already released the
+    interface, so libusb returns NOT_FOUND.
+    """
+    ci = _make_comm(_epipe())
+    ci.dev.clear_halt.side_effect = usb.core.USBError("entity not found", -5, 2)
+
+    with pytest.raises(usb.core.USBError) as excinfo:
+        ci.write(b"\xaa\x00")
+
+    assert excinfo.value.errno == 32, "the original EPIPE must be the one raised"
+
+
+def test_non_usberror_from_clear_halt_is_not_swallowed():
+    """Guards the narrowed except: a coding defect in the recovery path
+    (the exact shape of #189) must surface, not read as a device fault."""
+    ci = _make_comm(_epipe())
+    ci.dev.clear_halt.side_effect = AttributeError("boom")
+
+    with pytest.raises(AttributeError):
+        ci.write(b"\xaa\x00")
+
+
+def test_enodev_is_not_treated_as_a_stall():
+    """errno 19 (No such device) must not enter the clear_halt branch."""
+    ci = _make_comm(usb.core.USBError("No such device", -4, 19))
+
+    with pytest.raises(usb.core.USBError):
+        ci.write(b"\xaa\x00")
+
+    ci.dev.clear_halt.assert_not_called()
+
+
+def test_timeout_path_still_retries_and_is_unaffected():
+    """Regression fence: the EPIPE change must not disturb the pre-existing
+    write-timeout back-off loop."""
+    ci = _make_comm([usb.core.USBTimeoutError("timeout", -7, 110), 2])
+
+    assert ci.write(b"\xaa\x00", _retries=1) == 2
+    assert ci.dev.write.call_count == 2
+    ci.dev.clear_halt.assert_not_called()


### PR DESCRIPTION
Refs #189 (reported as bloodflow-app#391)

## What was broken

`CommInterface.write()` recovered a stalled OUT endpoint with `usb.util.clear_halt(...)`. That attribute does not exist in pyusb — `clear_halt` is a method on `usb.core.Device`. Every stall raised `AttributeError`, the surrounding `except Exception` caught it and relabelled it "clear_halt recovery failed", and the recovery has never run in any build since 1.5.0.

Verified against installed pyusb 1.3.1:

```
hasattr(usb.util, 'clear_halt')        -> False
hasattr(usb.core.Device, 'clear_halt') -> True
```

`StreamInterface.py:258` / `:459` already use the correct idiom on the IN pipe (landed by `59987df`, 2026-07-20). The OUT/command path was simply never revisited.

## What this changes

1. `self.dev.clear_halt(self.ep_out.bEndpointAddress)`.
2. Narrows `except Exception` to `(usb.core.USBError, NotImplementedError)`, and logs at WARNING with the errno instead of ERROR.
3. **Drops the re-send** — see below.

## Why the re-send is gone, not fixed

Line 240 (`return self.dev.write(...)` after the clear) has never executed in a shipped build. Restoring it would introduce brand-new at-least-once delivery into a protocol with no idempotency token, as a side effect of a bugfix. It is not safe:

- **No dedup in the firmware.** `grep -c "last_id\|dedup\|seen_id"` over sensor-fw `Core/Src/uart_comms.c` and `Core/Src/if_commands.c` returns `0` and `0`. Once framing + CRC pass, `uart_comms.c:331` runs `process_if_command(cmd)` unconditionally. Partial frames are rejected (`:238`), so the hazard is not partial+repeat — it is **accepted-then-halted → double execution**.
- **Two concrete non-idempotent victims.** `if_commands.c:139` is `HAL_GPIO_TogglePin(...)`. Worse, `if_commands.c:527-529`:
  ```c
  memcpy(ptrBitstream, cmd.data, cmd.data_len);
  ptrBitstream += cmd.data_len;
  bitstream_len += cmd.data_len;
  ```
  A duplicate advances **both** the write pointer and the length, corrupting the CRC computed over `bitstream_len` at `:531` and walking past the buffer. FPGA programming is the longest, highest-throughput, most stall-prone path *and* the only one with append semantics.
- **In all three real field events the read loop latched transport-down first** (e.g. `RIGHT-COMM: USB read error (errno=32); exiting read loop` → `state CONNECTED -> DISCONNECTING`). A re-send would push a duplicate into a handle the state machine has already abandoned.

Packet-level retry belongs one layer up, in `send_packet` — which already declares an unread `max_retries=0` at `CommInterface.py:130`. Noting that as the natural home; not proposing it here.

## Calibrate expectations before rc validation

This is a **latent-correctness and log-honesty** defect, not a live recovery failure. Please do not validate it as "recovers stalled sensor comms":

- The branch is EPIPE-only. Write timeouts (errno 110/10060/60) are caught earlier by `is_usb_timeout`, so this is unrelated to bloodflow-app#392's timeout storms.
- It has fired 3 times in 27 days of campaign logs, and **all three were followed shortly by `[Errno 19] No such device`** — not one was followed by successful operation. Expected value against the observed failure mode is near zero.
- `Device.clear_halt` calls `managed_open()` but not `managed_claim_interface`, and `MotionComposite.close()` runs `dispose_resources` first, so a post-teardown call returns NOT_FOUND. The new `errno=%s` is what lets you tell that apart next time.
- It was never silent. `clear_halt recovery failed: module 'usb.util' has no attribute 'clear_halt'` was printed in plain English every time. It was logged; it was not read.
- **It is unfalsifiable on the bench** — a still-present device cannot be made to STALL its comm OUT endpoint on demand. What would resolve it is the new errno log line plus one future occurrence.

## Tests

New `tests/test_comm_clear_halt.py`, 6 tests, `@pytest.mark.unit` (no hardware). Against `next`: **2 failed, 4 passed**. With this commit: **6 passed**. Full unit suite: 31 passed. `tests/test_comm_transport_down.py` still green.

The device mock is `MagicMock(spec=usb.core.Device)` deliberately — a bare `MagicMock` invents any attribute you name, so a test written against one would have passed just as green against the very defect these tests exist to catch. Worth adopting as house style.

The two that discriminate are `test_stall_clears_halt_with_endpoint_address` and `test_non_usberror_from_clear_halt_is_not_swallowed`. `test_stall_does_not_resend_the_packet` is a forward regression fence — it passes pre-fix too, because the `AttributeError` aborts before the re-send could run.

## Release path

`CommInterface` is instantiated only at `MotionComposite.py:43`, so this is **sensor-only**; console commands go over `MotionUart` (pyserial) and are untouched.

Production and `rc` bloodflow-app builds `pip install --upgrade openmotion-sdk` from PyPI. **This must be tagged and manually published (`gh workflow run publish-pypi.yml -f tag=X.Y.Z`) before any bloodflow `1.5.0-rc.N` is cut**, or that build silently pulls the still-broken 1.9.0. `dev` tags and `next`-branch builds install from git and pick it up on merge.

## Conflict note

Draft PR #97 carries `write()` through verbatim and reproduces the buggy call (its only edit inside `write()` is a comment reword). Conflict on rebase is certain but trivial — resolution is "take this side". Commented there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)