### PR TITLE
feat: detect a histogram stream that stops delivering frames

### DIFF
--- a/omotion/MotionComposite.py
+++ b/omotion/MotionComposite.py
@@ -33,12 +33,14 @@ class MotionComposite:
         desc: str = "COMPOSITE",
         async_mode: bool = False,
         on_io_error: Optional[Callable[[Optional[int], str], None]] = None,
+        on_stream_stall: Optional[Callable[[str, float], None]] = None,
     ):
         self.dev = dev
         self.desc = desc
         self.async_mode = async_mode
         self.demo_mode = False
         self.on_io_error = on_io_error
+        self.on_stream_stall = on_stream_stall
 
         self.comm = CommInterface(
             dev, 0, desc=f"{desc}-COMM", async_mode=True
@@ -46,6 +48,13 @@ class MotionComposite:
         self.histo = StreamInterface(dev, 1, desc=f"{desc}-HISTO")
         self.imu = StreamInterface(dev, 2, desc=f"{desc}-IMU")
         self.comm.on_io_error = self._forward_io_error
+        # #192: until now only the command interface had any route to report
+        # a fault, so a histogram stream that went silent mid-scan reached
+        # nobody at all. Only the histo stream is watched — it has a
+        # guaranteed ~40 fps cadence to measure against, whereas the IMU
+        # stream can be legitimately idle and would false-positive.
+        self.histo.on_stream_stall = self._forward_stream_stall
+        self.imu.stall_timeout_sec = 0
 
         self.packet_count = 0
 
@@ -96,3 +105,14 @@ class MotionComposite:
             cb(errno, message)
         except Exception as e:
             logger.warning("on_io_error callback raised: %s", e)
+
+    def _forward_stream_stall(self, stalled_for_sec: float) -> None:
+        """Forward a stalled histogram stream, tagged with this side's desc
+        so the consumer knows which sensor went quiet (#192)."""
+        cb = self.on_stream_stall
+        if cb is None:
+            return
+        try:
+            cb(self.histo.desc, stalled_for_sec)
+        except Exception as e:
+            logger.warning("on_stream_stall callback raised: %s", e)

--- a/omotion/StreamInterface.py
+++ b/omotion/StreamInterface.py
@@ -12,6 +12,13 @@ logger = logging.getLogger(
     f"{_log_root}.StreamInterface" if _log_root else "StreamInterface"
 )
 
+# Seconds of total silence on an armed stream before it is reported as
+# stalled (#192). At the nominal 40 fps this is ~200 missed frames — an
+# order of magnitude above the app's per-camera dropout threshold (2 s,
+# fail-soft) and well inside its whole-scan stall timeout (15 s, #248), so
+# the specific fault is reported before the generic one.
+_DEFAULT_STALL_TIMEOUT_SEC = 5.0
+
 
 def _rle_decompress(data: bytes) -> bytes:
     """Decompress PackBits-style byte-level RLE data."""
@@ -119,6 +126,28 @@ class StreamInterface(USBInterfaceBase):
         self.expected_size = None
         self.isStreaming = False
         self.packets_received: int = 0  # USB transfers queued since last start_streaming
+        # Data-flow watchdog (#192). A silent-but-enumerated IN endpoint
+        # produces read timeouts forever, and the loop below deliberately
+        # keeps waiting on those — so a side that stopped delivering was
+        # indistinguishable from an idle one and a scan could run its full
+        # duration producing nothing. Nominal cadence is ~40 frames/s, so
+        # multi-second silence during an armed stream is not a slow device.
+        # Seconds of silence before reporting; <= 0 disables.
+        #
+        # This layer has no trigger awareness — it measures arrivals, not
+        # intent. That is safe for SDK-driven scans, where start_trigger()
+        # precedes the source iteration that arms streaming
+        # (ScanWorkflow.py:685 vs :765), so frames flow from the first read.
+        # A caller that deliberately holds the trigger off while streaming
+        # stays armed must set this to 0 for that window, or it will get one
+        # spurious report per session.
+        self.stall_timeout_sec: float = _DEFAULT_STALL_TIMEOUT_SEC
+        # Optional callback(stalled_for_sec). Detection only — what to DO
+        # about a dead side (abort the scan, warn, continue) is policy and
+        # lives above this layer.
+        self.on_stream_stall = None
+        self._last_data_mono: float | None = None
+        self._stall_reported = False
 
     def start_streaming(self, queue_obj, expected_size):
         # Recover from a stale thread left over by a previous scan whose
@@ -143,6 +172,10 @@ class StreamInterface(USBInterfaceBase):
         self.data_queue = queue_obj
         self.expected_size = expected_size
         self.packets_received = 0
+        # Fresh stall clock per session, so a stall in scan N cannot fire
+        # immediately at the start of N+1 (#192).
+        self._last_data_mono = time.monotonic()
+        self._stall_reported = False
         self.stop_event.clear()
         self.thread = threading.Thread(target=self._stream_loop, daemon=True)
         self.thread.start()
@@ -376,6 +409,42 @@ class StreamInterface(USBInterfaceBase):
             self.data_queue.put(raw)
         return cmp_count, cmp_errors
 
+    def _check_stream_stall(self):
+        """Report a side that has stopped delivering frames (#192).
+
+        Fires at most once per streaming session. The point is to escalate,
+        not to fill the log at 2 Hz for the rest of a 12-hour scan; the
+        consumer decides what to do and can read ``packets_received`` for
+        the full picture. Never raises — a foreign callback must not be able
+        to kill the stream thread (same discipline as
+        ``CommInterface._notify_io_error``).
+        """
+        timeout_s = self.stall_timeout_sec
+        if not timeout_s or timeout_s <= 0 or self._stall_reported:
+            return
+        last = self._last_data_mono
+        if last is None:
+            return
+        stalled_for = time.monotonic() - last
+        if stalled_for < timeout_s:
+            return
+
+        self._stall_reported = True
+        logger.error(
+            "%s: no data for %.1fs on an armed stream (%d chunk(s) this "
+            "session) — stream stalled",
+            self.desc, stalled_for, self.packets_received,
+        )
+        cb = self.on_stream_stall
+        if cb is None:
+            return
+        try:
+            cb(stalled_for)
+        except Exception as e:  # noqa: BLE001 - foreign callback
+            logger.warning(
+                "%s: on_stream_stall callback raised: %s", self.desc, e
+            )
+
     def _stream_loop(self):
         # Read timeout must exceed the worst-case USB transfer latency for the
         # final frame.  Normal cadence is ~25 ms; the last frame of a scan can
@@ -409,12 +478,18 @@ class StreamInterface(USBInterfaceBase):
             data_queue = self.data_queue
             if expected_size is None or data_queue is None:
                 break
+            self._check_stream_stall()
             try:
                 data = self.dev.read(
                     self.ep_in.bEndpointAddress, expected_size,
                     timeout=_READ_TIMEOUT_MS,
                 )
                 pipe_errors = 0
+                if data:
+                    # The device is alive. Reset the clock on arrival, not on
+                    # a successful put: a full data_queue is a host-side
+                    # parser problem, not a stalled sensor (#192).
+                    self._last_data_mono = time.monotonic()
                 if data and data_queue is self.data_queue:
                     # Use a bounded put so the loop can never block forever
                     # on a stopped/slow parser. With self.stop_event set the

--- a/tests/test_stream_stall.py
+++ b/tests/test_stream_stall.py
@@ -1,0 +1,237 @@
+"""Unit tests for stream data-flow stall detection (#192).
+
+The histogram stream had no failure-reporting path at all — not a threshold
+set too permissively, no wire. ``MotionComposite`` wires ``on_io_error`` for
+the command interface only, and ``StreamInterface``'s read-timeout branch
+reads, verbatim, ``# Otherwise keep waiting — scan is still running.`` with no
+counter and no ceiling. A side that stopped delivering frames mid-scan was
+indistinguishable from an idle one, so a scan could run its full duration
+producing nothing (bloodflow-app#390: an entire sensor side dark for ~21
+minutes while the firmware logged 23,133 "HISTO enqueue fail: queue full").
+
+These pin detection only. Deciding what to *do* about a stalled side (abort
+the scan, warn, keep going) is policy and deliberately lives above this layer
+— the callback is the hook.
+
+No hardware: the device is a MagicMock whose read raises a USB timeout, which
+is exactly what a silent-but-enumerated IN endpoint produces.
+"""
+
+import queue
+import threading
+import time
+from unittest.mock import MagicMock
+
+import pytest
+import usb.core
+
+from omotion.StreamInterface import StreamInterface
+
+pytestmark = pytest.mark.unit
+
+# Comfortably above the loop's own iteration cost, far below test timeouts.
+_STALL_SEC = 0.3
+_SETTLE = 2.0
+
+
+def _silent_device():
+    """A device that stays enumerated but never delivers a frame."""
+    dev = MagicMock(spec=usb.core.Device)
+
+    def _timeout(*_a, **_kw):
+        time.sleep(0.01)  # emulate the read window rather than spinning hot
+        raise usb.core.USBTimeoutError("timed out", -7, 110)
+
+    dev.read.side_effect = _timeout
+    return dev
+
+
+def _make_stream(dev, stall_timeout_sec=_STALL_SEC):
+    si = StreamInterface(dev, interface_index=1, desc="TEST-HISTO")
+    si.ep_in = MagicMock(bEndpointAddress=0x81, wMaxPacketSize=512)
+    si.stall_timeout_sec = stall_timeout_sec
+    return si
+
+
+class _Recorder:
+    """Captures stall callbacks from the stream thread."""
+
+    def __init__(self):
+        self.calls = []
+        self.fired = threading.Event()
+
+    def __call__(self, stalled_for_sec):
+        self.calls.append(stalled_for_sec)
+        self.fired.set()
+
+
+def _run_briefly(si, seconds):
+    si.start_streaming(queue.Queue(maxsize=16), expected_size=4105)
+    try:
+        time.sleep(seconds)
+    finally:
+        si.stop_streaming()
+
+
+def test_silent_endpoint_reports_a_stall():
+    """The regression: a side that stops delivering must be noticed."""
+    si = _make_stream(_silent_device())
+    rec = _Recorder()
+    si.on_stream_stall = rec
+
+    si.start_streaming(queue.Queue(maxsize=16), expected_size=4105)
+    try:
+        assert rec.fired.wait(timeout=_SETTLE), (
+            "a totally silent IN endpoint produced no stall report"
+        )
+    finally:
+        si.stop_streaming()
+
+    assert rec.calls[0] >= _STALL_SEC
+
+
+def test_stall_is_reported_once_per_streaming_session():
+    """One report, not one per read window — the point is to escalate, not
+    to fill the log at 2 Hz for the rest of a 12-hour scan."""
+    si = _make_stream(_silent_device())
+    rec = _Recorder()
+    si.on_stream_stall = rec
+
+    si.start_streaming(queue.Queue(maxsize=16), expected_size=4105)
+    try:
+        assert rec.fired.wait(timeout=_SETTLE)
+        time.sleep(_STALL_SEC * 3)
+    finally:
+        si.stop_streaming()
+
+    assert len(rec.calls) == 1, f"stall reported {len(rec.calls)} times"
+
+
+def test_no_stall_before_the_threshold():
+    si = _make_stream(_silent_device(), stall_timeout_sec=10.0)
+    rec = _Recorder()
+    si.on_stream_stall = rec
+
+    _run_briefly(si, 0.4)
+
+    assert rec.calls == []
+
+
+def test_flowing_data_never_stalls():
+    """Regression fence: a healthy stream must stay silent."""
+    dev = MagicMock(spec=usb.core.Device)
+
+    def _frame(*_a, **_kw):
+        time.sleep(0.01)
+        return bytearray(4105)
+
+    dev.read.side_effect = _frame
+    si = _make_stream(dev)
+    rec = _Recorder()
+    si.on_stream_stall = rec
+
+    _run_briefly(si, _STALL_SEC * 3)
+
+    assert rec.calls == []
+    assert si.packets_received > 0
+
+
+def test_data_resets_the_stall_clock():
+    """Frames arriving just under the threshold must keep it from firing —
+    otherwise a merely slow stream is reported as a dead one."""
+    dev = MagicMock(spec=usb.core.Device)
+    state = {"n": 0}
+
+    def _slow(*_a, **_kw):
+        # One frame every ~0.2 s against a 0.3 s threshold.
+        state["n"] += 1
+        time.sleep(0.2)
+        return bytearray(4105)
+
+    dev.read.side_effect = _slow
+    si = _make_stream(dev)
+    rec = _Recorder()
+    si.on_stream_stall = rec
+
+    _run_briefly(si, 1.2)
+
+    assert rec.calls == [], "a slow-but-alive stream was reported as stalled"
+
+
+def test_zero_timeout_disables_detection():
+    si = _make_stream(_silent_device(), stall_timeout_sec=0)
+    rec = _Recorder()
+    si.on_stream_stall = rec
+
+    _run_briefly(si, _STALL_SEC * 3)
+
+    assert rec.calls == []
+
+
+def test_stall_clock_restarts_with_each_streaming_session():
+    """A stall in scan N must not immediately re-fire at the start of N+1."""
+    si = _make_stream(_silent_device())
+    rec = _Recorder()
+    si.on_stream_stall = rec
+
+    si.start_streaming(queue.Queue(maxsize=16), expected_size=4105)
+    try:
+        assert rec.fired.wait(timeout=_SETTLE)
+    finally:
+        si.stop_streaming()
+
+    rec.fired.clear()
+    si.start_streaming(queue.Queue(maxsize=16), expected_size=4105)
+    try:
+        # Immediately after restart the clock is fresh, so nothing yet.
+        assert not rec.fired.wait(timeout=_STALL_SEC / 3)
+    finally:
+        si.stop_streaming()
+
+
+def test_a_raising_callback_cannot_kill_the_stream_thread():
+    """The callback is foreign code. A scan must not die because a consumer
+    threw — the same discipline CommInterface._notify_io_error already uses."""
+    si = _make_stream(_silent_device())
+    si.on_stream_stall = MagicMock(side_effect=RuntimeError("boom"))
+
+    si.start_streaming(queue.Queue(maxsize=16), expected_size=4105)
+    try:
+        time.sleep(_STALL_SEC * 2)
+        assert si.thread.is_alive(), "stream thread died on a raising callback"
+    finally:
+        si.stop_streaming()
+
+
+# --- the missing wire ----------------------------------------------------
+
+def test_composite_wires_the_histo_stall_callback():
+    """The regression this ticket is named for: MotionComposite wired
+    on_io_error for the command interface and nothing at all for the
+    streams, so a stalled side had no route to any consumer."""
+    from omotion.MotionComposite import MotionComposite
+
+    seen = []
+    mc = MotionComposite(
+        MagicMock(spec=usb.core.Device), desc="LEFT",
+        on_stream_stall=lambda desc, secs: seen.append((desc, secs)),
+    )
+
+    assert mc.histo.on_stream_stall is not None, "histo stream has no error wire"
+
+    mc.histo.on_stream_stall(7.5)
+
+    assert seen == [("LEFT-HISTO", 7.5)], (
+        "a stalled side must identify itself to the consumer"
+    )
+
+
+def test_composite_does_not_arm_the_watchdog_on_the_imu_stream():
+    """The IMU stream can be legitimately idle; only the histogram stream
+    has a guaranteed cadence to measure against."""
+    from omotion.MotionComposite import MotionComposite
+
+    mc = MotionComposite(MagicMock(spec=usb.core.Device), desc="LEFT")
+
+    assert mc.histo.stall_timeout_sec > 0
+    assert mc.imu.stall_timeout_sec == 0


### PR DESCRIPTION
Refs #192

## What was missing

Not a threshold set too permissively — **no wire existed**. `MotionComposite.py:48` wired `on_io_error` for the command interface and nothing at all for the streams, and `StreamInterface`'s read-timeout branch reads, verbatim:

```python
# Otherwise keep waiting — scan is still running.
```

No counter, no ceiling. `_MAX_PIPE_RECOVERIES = 3` looks like a limit but is EPIPE-only and merely `break`s. `packets_received` is the number that would catch this, but it is emitted once at teardown as an INFO line and consulted by nothing.

So a side that stopped delivering frames mid-scan was indistinguishable from an idle one, and a scan could run its full duration producing nothing. That is bloodflow-app#390: an entire sensor side dark for ~21 minutes across three consecutive pre-scan checks, while the firmware logged **23,133** `HISTO enqueue fail: queue full` — its queue backing up precisely because nothing was draining it — and the host had no mechanism to notice.

## What this adds

A data-flow watchdog on `StreamInterface`. While streaming is armed, track last arrival; after `stall_timeout_sec` of total silence, log at ERROR and invoke an optional `on_stream_stall` callback.

- **Fires at most once per streaming session.** The point is to escalate, not to fill the log at 2 Hz for the rest of a 12-hour scan. The consumer can read `packets_received` for the full picture.
- **The clock resets on arrival, not on a successful queue put.** A full `data_queue` is a host-side parser problem, not a stalled sensor.
- **Fresh clock per session**, so a stall in scan N cannot fire immediately at the start of N+1.
- **Never raises.** A foreign callback must not be able to kill the stream thread — same discipline `CommInterface._notify_io_error` already uses.

`MotionComposite` grows the matching `on_stream_stall` parameter and wires it to the histo stream, tagging the report with the side's `desc` so the consumer knows which sensor went quiet. **The IMU stream is explicitly disarmed** (`stall_timeout_sec = 0`) — it can be legitimately idle, whereas the histogram stream has a guaranteed cadence to measure against.

## Detection only — deliberately

Nothing auto-aborts. What to *do* about a stalled side — abort the scan, warn, keep going — is policy with patient-facing consequences, and it belongs above this layer. The callback is the hook. This is the same split as #390 / #406: land the mechanism, decide the policy separately.

That also sidesteps the design question raised on the issue. Routing a stalled stream into `IoError` would declare the whole sensor **disconnected**, which is arguably wrong — the command channel may be perfectly healthy, and a sensor that answers commands is not "disconnected" in the sense the state machine means. It would also land in the reconnect flap described on #191. A consumer that wants that behaviour can still choose it.

## Why 5 s

~200 missed frames at the nominal 40 fps. An order of magnitude above the app's per-camera dropout threshold (2 s, fail-soft) and well inside its whole-scan stall timeout (15 s, bloodflow-app#248), so the specific fault is reported before the generic one.

Worth being explicit that the app-side watchdog **cannot** be stretched to cover this. `motion_connector.py:378` is `newest = max(last_seen.values(), ...)` and its docstring says it fires only when *every* camera has gone silent. A healthy LEFT keeps that value fresh, so a fully dark RIGHT never trips it for the entire scan. Correct for what #248 set out to do; structurally unable to do this.

## Ordering — checked, not assumed

Safe for SDK-driven scans: `start_trigger()` at `ScanWorkflow.py:685` precedes the source iteration that arms streaming at `:765`, so frames flow from the first read and there is no startup gap that could false-positive.

**Known limitation, documented in-source:** this layer measures arrivals, not intent — it has no trigger awareness. A caller that deliberately holds the trigger off *while streaming stays armed* will get one spurious report per session unless it sets `stall_timeout_sec = 0` for that window. Relevant to the app, which tracks `_trigger_state` and gates its own watchdog on it; worth confirming during app integration.

## Verification

`tests/test_stream_stall.py` — 10 tests, `@pytest.mark.unit`, no hardware. **3 fail against `next`** (nothing reports a stall); the rest are fences that pass vacuously today and would catch a future false-positive. All 10 pass here. Full unit suite: **41 passed**. `flake8` on every added line: clean (the pre-existing hits in `StreamInterface.py` are untouched).

Covered: a silent endpoint reports; reports exactly once; nothing before the threshold; a flowing stream never reports; a *slow but alive* stream never reports (frames at 0.2 s against a 0.3 s threshold); `0` disables; the clock restarts per session; a raising callback cannot kill the stream thread; `MotionComposite` wires histo and disarms IMU.

The device mock is `MagicMock(spec=usb.core.Device)` whose read raises `USBTimeoutError` — exactly what a silent-but-enumerated IN endpoint produces.

**Not verified on hardware.** Worth a bench pass: start a scan, decouple one side's fiber, confirm the report arrives within the threshold and names the correct side while the other side keeps streaming — and confirm a normal scan start/stop produces no report.

## Follow-ups, not in this PR

- Consuming the callback (abort / surface to the operator) — needs the policy decision above.
- Per-camera granularity. This is per-side total loss; one camera of eight going quiet is a cadence problem, and the app's `cameraDropoutThresholdSec` is the existing partial-loss signal.
- The root cause of the blackouts themselves. This is detection, not repair — see the camera-dropout family (bloodflow-app#172, #183, #246, sensor-fw#68).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
