### PR TITLE
fix: select histogram bins by column name

### DIFF
--- a/data-processing/plot_all_spectrogram.py
+++ b/data-processing/plot_all_spectrogram.py
@@ -4,6 +4,7 @@ import numpy as np
 
 CSV_FILE = "histogram.csv"
 NUM_BINS = 1024
+BIN_COLS = [str(i) for i in range(NUM_BINS)]
 GRID_ROWS = 4
 GRID_COLS = 2
 
@@ -22,7 +23,7 @@ def plot_histogram_spectrograms(df):
         cam_df = df[df['cam_id'] == cam_id].sort_values("frame_id")
 
         # Extract just the bin data into a 2D array: rows = frames, cols = bins
-        histo_matrix = cam_df.iloc[:, 2:2+NUM_BINS].to_numpy()
+        histo_matrix = cam_df[BIN_COLS].to_numpy()
 
         # Plot as spectrogram-like image
         im = ax.imshow(

--- a/data-processing/plot_histo_average.py
+++ b/data-processing/plot_histo_average.py
@@ -5,6 +5,7 @@ import numpy as np
 CSV_FILE      = "histogram.csv"
 CAMERA_ID     = 0
 NUM_BINS      = 1024
+BIN_COLS = [str(i) for i in range(NUM_BINS)]
 FRAME_ID_MAX  = 256            # frame_id wraps 255 → 0
 
 
@@ -33,7 +34,7 @@ def plot_weighted_average(csv_path, cam_id):
                    .sort_values("logical_frame_index")
 
     # ---- Extract histogram bins ----
-    histo_matrix = cam_df.iloc[:, 2: 2 + NUM_BINS].to_numpy()
+    histo_matrix = cam_df[BIN_COLS].to_numpy()
     histo_matrix[:, -1] = 0                       # zero-out bin 1023
 
     frame_ids = cam_df['logical_frame_index'].to_numpy()

--- a/data-processing/plot_single_spectrogram.py
+++ b/data-processing/plot_single_spectrogram.py
@@ -3,6 +3,7 @@ import matplotlib.pyplot as plt
 
 CSV_FILE = "histogram.csv"
 NUM_BINS = 1024
+BIN_COLS = [str(i) for i in range(NUM_BINS)]
 CAMERA_ID = 0
 FRAME_ID_MAX = 256  # Since frame_id wraps around at 255 -> 0
 
@@ -40,7 +41,7 @@ def plot_camera_histograms(csv_path):
     cam_df = cam_df.sort_values(by="logical_frame_index")
 
     # Extract only the histogram bins (columns 2 to 2+1024)
-    histo_matrix = cam_df.iloc[:, 2:2 + NUM_BINS].to_numpy()
+    histo_matrix = cam_df[BIN_COLS].to_numpy()
     histo_matrix[:, -1] = 0  # Optional: zero out last bin for visualization
 
     # Plot spectrogram


### PR DESCRIPTION

## Summary

- update `plot_histo_average.py` to select histogram bins by column name
- update `plot_all_spectrogram.py` to select histogram bins by column name
- update `plot_single_spectrogram.py` to select histogram bins by column name

## Root cause

The scripts selected histogram bins using positional slices such as `iloc[:, 2:2+1024]`.

Current raw CSV files include additional metadata columns such as `timestamp_s` and `type`, so positional selection can include non-numeric columns and cause object-dtype errors.

## Fix

The scripts now construct the expected histogram column names and select them explicitly:

```python
BIN_COLS = [str(i) for i in range(NUM_BINS)]
histo_matrix = cam_df[BIN_COLS].to_numpy()
````

This follows the fix pattern used for #136.

Fixes #137
EOF

````

Then run the `gh pr create` command above.

Here’s the PR text separately for reference:

:::writing{variant="document" id="41827"}
## Summary

- update `plot_histo_average.py` to select histogram bins by column name
- update `plot_all_spectrogram.py` to select histogram bins by column name
- update `plot_single_spectrogram.py` to select histogram bins by column name

## Root cause

The scripts selected histogram bins using positional slices such as `iloc[:, 2:2+1024]`.

Current raw CSV files include additional metadata columns such as `timestamp_s` and `type`, so positional selection can include non-numeric columns and cause object-dtype errors.

## Fix

The scripts now construct the expected histogram column names and select them explicitly:

```python
BIN_COLS = [str(i) for i in range(NUM_BINS)]
histo_matrix = cam_df[BIN_COLS].to_numpy()
````

This follows the fix pattern used for #136.

Fixes #137
