### PR TITLE
fix: classify bare metal from the flash descriptor when no ROM-only alt is listed

### DIFF
--- a/omotion/boot_mode.py
+++ b/omotion/boot_mode.py
@@ -5,11 +5,19 @@ bootloader installed — a "bare metal" unit) or in openmotion-bl / open-motion-
 console-bl (a converted unit). Both enumerate as **0483:df11**, so VID/PID tells
 you nothing. The DFU alt-setting layout does:
 
-  ROM loader      four alts — Internal Flash, Option Bytes, OTP Memory, Device
-                  Feature — and a fully-writable flash descriptor (``16*128Kg``).
+  ROM loader      ROM-only alts — Option Bytes, OTP Memory, Device Feature —
+                  alongside a fully-writable flash descriptor (``16*128Kg``).
   openmotion-bl   one alt, whose descriptor carries read-only runs
-                  (``01*128Ka,04*128Kg,11*128Ka``) because everything outside the
+                  (``01*128Ka,04*128Kg,11*128Ka``; the console build uses
+                  ``01*128Ka,08*128Kg,07*128Ka``) because everything outside the
                   application slot is deliberately locked.
+
+How many alts the ROM loader actually reports varies — bench consoles have shown
+two, not four, and a listing can carry the Internal Flash alt alone. So the
+ROM-only alts are checked first but are not required: failing that, the flash
+descriptor decides, since only the ROM loader leaves the whole of flash
+writable. Both signals are positive evidence; neither infers a mode from the
+*absence* of the other.
 
 That difference decides where a firmware update is written: ``0x08000000`` for a
 bare-metal image, ``0x08020000`` for a signed image in the bootloader's slot.
@@ -91,6 +99,10 @@ _SECTOR_RE = re.compile(r"\d+\s*\*\s*\d+\s*[KMB]?\s*([a-g])")
 # flash descriptor looks like.
 _ROM_ONLY_ALTS = ("option bytes", "otp memory", "device feature")
 
+# The main flash alt, present in every mode. Anchored to 0x08000000 so a
+# writable descriptor for some other memory can never be read as bare metal.
+_INTERNAL_FLASH_RE = re.compile(r"@\s*internal\s+flash\s*/\s*0x08000000\s*/", re.I)
+
 
 def _alt_entries(dfu_util_output: str) -> list[tuple[int, str]]:
     """Extract ``(alt, name)`` for each `Found DFU:` line."""
@@ -115,10 +127,28 @@ def parse_boot_mode(dfu_util_output: str) -> BootMode:
     if any(marker in name.lower() for _, name in entries for marker in _ROM_ONLY_ALTS):
         return BootMode.BARE_METAL
 
-    if len(entries) == 1:
-        _, name = entries[0]
-        if any(access == "a" for access in _SECTOR_RE.findall(name)):
+    # No ROM-only alt in the listing — which happens whenever dfu-util reports
+    # just the Internal Flash alt. Fall back to the flash descriptor's access
+    # letters, which are decisive on their own: every openmotion bootloader
+    # hard-codes read-only runs around its app slot (sector 0 holds the
+    # bootloader; the reserved/config sectors hold the anti-rollback floor), so
+    #
+    #   openmotion-bl           01*128Ka,04*128Kg,11*128Ka
+    #   open-motion-console-bl  01*128Ka,08*128Kg,07*128Ka
+    #
+    # A descriptor with no read-only run at all therefore cannot be a
+    # bootloader, and the ROM loader is the only other thing it can be. Before
+    # this, such a listing was UNKNOWN and the unit could not be flashed at all
+    # (openmotion-sdk#197).
+    for _, name in entries:
+        if not _INTERNAL_FLASH_RE.search(name):
+            continue
+        access = _SECTOR_RE.findall(name)
+        if not access:
+            continue
+        if any(a == "a" for a in access):
             return BootMode.BOOTLOADER
+        return BootMode.BARE_METAL
 
     return BootMode.UNKNOWN
 

--- a/omotion/firmware_update.py
+++ b/omotion/firmware_update.py
@@ -2,15 +2,21 @@
 download, and a thin DFU flash orchestrator. UI-agnostic (no Qt)."""
 from __future__ import annotations
 
+import logging
 import re
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 from typing import Callable, Iterable
 
+from omotion import _log_root
 from omotion.GitHubReleases import GitHubReleases
 from omotion.DFUProgrammer import DFUProgrammer, DFUProgress, DFUResult
 from omotion.boot_mode import BootMode, flash_address_for
+
+logger = logging.getLogger(
+    f"{_log_root}.firmware_update" if _log_root else "firmware_update"
+)
 
 # ---------------------------------------------------------------------------
 # Version parsing
@@ -394,16 +400,33 @@ class FirmwareUpdater:
             raise FirmwareUpdateError("DFU device did not appear after enter_dfu()")
 
         mode = self._dfu.detect_boot_mode()
+        # Report what was actually observed, not what we fall back to below --
+        # callers (and the apps' lock indicator) must not read a guess as fact.
         self.last_boot_mode = mode
+
+        effective = mode
         if mode is BootMode.UNKNOWN:
-            raise FirmwareUpdateError(
-                "could not tell whether this device has the bootloader installed; "
-                "refusing to flash, because the wrong address would brick it"
+            # Refusing here strands any device we cannot classify, and a device
+            # that cannot be flashed is worse than one flashed on a safe
+            # assumption. Bare metal IS the safe assumption, because it is
+            # enforced by the hardware rather than by this guess: both
+            # bootloaders clamp their DFU write window to the application slot
+            # and mark sector 0 read-only, so a bare-metal write at 0x08000000
+            # against a bootloader unit is rejected by the bootloader and fails
+            # loudly. The opposite default has no such backstop -- a signed
+            # image at 0x08020000 writes happily into the middle of a bare-metal
+            # device and leaves it unbootable.
+            effective = BootMode.BARE_METAL
+            logger.warning(
+                "could not classify this device from its DFU alt settings; "
+                "proceeding as bare metal (%s). If it does have the bootloader "
+                "installed, the write is rejected rather than applied.",
+                flash_address_for(effective),
             )
 
-        target = self._select_image(bin_path, mode)
+        target = self._select_image(bin_path, effective)
         return self._dfu.flash_bin(
-            target, address=flash_address_for(mode), progress=progress_cb
+            target, address=flash_address_for(effective), progress=progress_cb
         )
 
     def _select_image(self, bin_path: Path, mode: BootMode) -> Path:

--- a/tests/test_boot_mode.py
+++ b/tests/test_boot_mode.py
@@ -63,10 +63,69 @@ def test_option_bytes_alt_wins_even_if_flash_alt_looks_locked():
     assert parse_boot_mode(weird) is BootMode.BARE_METAL
 
 
-def test_single_fully_writable_alt_is_unknown_not_bootloader():
-    """One alt with no read-only run is not openmotion-bl. Refuse to guess
-    rather than mis-detect and write to the wrong address."""
+def test_single_fully_writable_alt_is_bare_metal():
+    """A fully-writable flash descriptor is decisive for the ROM loader.
+
+    Both bootloaders hard-code their descriptor and both always mark sector 0
+    (the bootloader itself) plus the reserved/config region read-only — that
+    clamp is the security property they exist to enforce:
+
+        openmotion-bl        01*128Ka,04*128Kg,11*128Ka
+        open-motion-console-bl  01*128Ka,08*128Kg,07*128Ka
+
+    So an Internal Flash alt at 0x08000000 with *no* read-only run cannot be an
+    openmotion bootloader. This used to report UNKNOWN, which made a bare-metal
+    unit unflashable whenever dfu-util listed only the Internal Flash alt
+    (openmotion-sdk#197).
+    """
     listing = BL_LISTING.replace("01*128Ka,04*128Kg,11*128Ka", "16*128Kg")
+    assert parse_boot_mode(listing) is BootMode.BARE_METAL
+
+
+def test_console_bootloader_listing_is_bootloader():
+    """The console bootloader has a bigger app slot than the sensor one, but the
+    same read-only clamp, so it must still classify as BOOTLOADER."""
+    listing = BL_LISTING.replace("01*128Ka,04*128Kg,11*128Ka",
+                                 "01*128Ka,08*128Kg,07*128Ka")
+    assert parse_boot_mode(listing) is BootMode.BOOTLOADER
+
+
+# Exactly what a bench console in the ST ROM loader produced (2 alts, not the 4
+# the ROM loader is often documented as exposing) — the case from #197.
+ROM_TWO_ALT_LISTING = """dfu-util 0.11
+
+Copyright 2005-2009 Weston Schmidt, Harald Welte and OpenMoko Inc.
+
+Found DFU: [0483:df11] ver=0200, devnum=54, cfg=1, intf=0, path="2-1.1.1", alt=1, name="@Option Bytes   /0x5200201C/01*128 e", serial="200364500000"
+Found DFU: [0483:df11] ver=0200, devnum=54, cfg=1, intf=0, path="2-1.1.1", alt=0, name="@Internal Flash   /0x08000000/16*128Kg", serial="200364500000"
+"""
+
+
+def test_observed_two_alt_rom_listing_is_bare_metal():
+    assert parse_boot_mode(ROM_TWO_ALT_LISTING) is BootMode.BARE_METAL
+
+
+def test_internal_flash_alt_alone_is_bare_metal():
+    """The regression from #197: drop the Option Bytes alt and the remaining
+    Internal Flash alt must still classify, or the unit cannot be updated."""
+    only_flash = "\n".join(
+        line for line in ROM_TWO_ALT_LISTING.splitlines()
+        if "Option Bytes" not in line
+    )
+    assert parse_boot_mode(only_flash) is BootMode.BARE_METAL
+
+
+def test_internal_flash_alt_with_no_parseable_runs_is_unknown():
+    """No access letters at all is still not evidence of anything."""
+    listing = BL_LISTING.replace("01*128Ka,04*128Kg,11*128Ka", "wharrgarbl")
+    assert parse_boot_mode(listing) is BootMode.UNKNOWN
+
+
+def test_writable_alt_at_a_different_address_is_unknown():
+    """The bare-metal call is anchored to Internal Flash at 0x08000000. A
+    writable descriptor somewhere else is not a device we recognise."""
+    listing = BL_LISTING.replace("0x08000000/01*128Ka,04*128Kg,11*128Ka",
+                                 "0x90000000/16*128Kg")
     assert parse_boot_mode(listing) is BootMode.UNKNOWN
 
 

--- a/tests/test_firmware_update_flow.py
+++ b/tests/test_firmware_update_flow.py
@@ -83,15 +83,53 @@ def test_bootloader_device_flashes_signed_image_into_the_slot(release_dir):
     assert prog.flashed == [(release_dir / "motion-sensor-fw-signed.bin", "0x08020000")]
 
 
-def test_unknown_mode_refuses_to_flash_anything(release_dir):
+def test_unknown_mode_falls_back_to_bare_metal(release_dir):
+    """An unclassifiable device is flashed as bare metal rather than refused.
+
+    This is fail-safe in hardware, which is what makes it an acceptable default:
+    both bootloaders clamp their DFU write window to the application slot and
+    mark sector 0 read-only, so a bare-metal write at 0x08000000 against a
+    bootloader unit is rejected by the bootloader itself. The device fails the
+    flash loudly instead of being bricked. Defaulting the *other* way would not
+    be safe -- a signed image at 0x08020000 lands happily in the middle of a
+    bare-metal device's flash and produces a unit that will not boot.
+    """
     prog = FakeProgrammer(mode=BootMode.UNKNOWN)
     updater = FirmwareUpdater(programmer=prog)
     primary = release_dir / "motion-sensor-fw-baremetal-fpga.bin"
     register_download(primary, FirmwareKind.SENSOR, "1.8.2")
 
-    with pytest.raises(FirmwareUpdateError):
-        updater.update(FakeHandle(), primary)
-    assert prog.flashed == []
+    updater.update(FakeHandle(), primary)
+
+    assert prog.flashed == [(primary, "0x08000000")]
+
+
+def test_unknown_mode_still_reports_what_was_actually_detected(release_dir):
+    """The fallback must not launder a guess into an observation: callers (and
+    the lock icon in the apps) read last_boot_mode, so it stays UNKNOWN."""
+    prog = FakeProgrammer(mode=BootMode.UNKNOWN)
+    updater = FirmwareUpdater(programmer=prog)
+    primary = release_dir / "motion-sensor-fw-baremetal-fpga.bin"
+    register_download(primary, FirmwareKind.SENSOR, "1.8.2")
+
+    updater.update(FakeHandle(), primary)
+
+    assert updater.last_boot_mode is BootMode.UNKNOWN
+
+
+def test_unknown_mode_never_picks_the_signed_image(release_dir):
+    """The dangerous outcome, asserted directly: whatever else happens on an
+    unclassifiable device, it must never be given a slot image."""
+    prog = FakeProgrammer(mode=BootMode.UNKNOWN)
+    updater = FirmwareUpdater(programmer=prog)
+    primary = release_dir / "motion-sensor-fw-baremetal-fpga.bin"
+    register_download(primary, FirmwareKind.SENSOR, "1.8.2")
+
+    updater.update(FakeHandle(), primary)
+
+    (flashed, address), = prog.flashed
+    assert "signed" not in flashed.name
+    assert address != "0x08020000"
 
 
 def test_bootloader_device_with_legacy_release_refuses(tmp_path):

--- a/tests/test_firmware_update_flow.py
+++ b/tests/test_firmware_update_flow.py
@@ -204,3 +204,87 @@ def test_updater_records_mode_even_when_the_flash_is_refused(release_dir):
     with pytest.raises(UnsupportedReleaseError):
         updater.update(FakeHandle(), legacy)
     assert updater.last_boot_mode is BootMode.BOOTLOADER
+
+
+# ---------------------------------------------------------------------------
+# End-to-end classification (openmotion-sdk#197)
+#
+# FakeProgrammer above stubs detect_boot_mode() outright, so those tests can
+# never catch a *classification* bug — they assume the mode is already known.
+# These drive a real `dfu-util -l` listing through the actual
+# DFUProgrammer.detect_boot_mode -> parse_boot_mode chain, which is the path the
+# apps take: the test app hands a FirmwareUpdater to its flash thread and lets
+# the SDK decide the asset and address.
+# ---------------------------------------------------------------------------
+
+from omotion.DFUProgrammer import DFUProgrammer
+
+
+def _listing(alt_lines: str) -> str:
+    return (
+        "dfu-util 0.11\n\n"
+        "Copyright 2005-2009 Weston Schmidt, Harald Welte and OpenMoko Inc.\n\n"
+        f"{alt_lines}\n"
+    )
+
+
+# A bare-metal unit whose listing carries the Internal Flash alt and nothing
+# else — no ROM-only alt to key off. This is what made old consoles unflashable.
+ROM_FLASH_ALT_ONLY = _listing(
+    'Found DFU: [0483:df11] ver=0200, devnum=54, cfg=1, intf=0, path="2-1.1.1", '
+    'alt=0, name="@Internal Flash   /0x08000000/16*128Kg", serial="200364500000"'
+)
+
+# A converted console: same single-alt shape, but read-only runs around the slot.
+CONSOLE_BL_LISTING = _listing(
+    'Found DFU: [0483:df11] ver=0200, devnum=31, cfg=1, intf=0, path="2-1.1.1", '
+    'alt=0, name="@Internal Flash/0x08000000/01*128Ka,08*128Kg,07*128Ka", '
+    'serial="OWCONSOLEBL"'
+)
+
+
+class ListingProgrammer(FakeProgrammer):
+    """FakeProgrammer, but boot mode comes from a real listing via real parsing."""
+
+    def __init__(self, listing):
+        super().__init__()
+        self._listing = listing
+
+    def list_devices(self):
+        return self._listing
+
+    # Deliberately the genuine implementation, not a stub.
+    detect_boot_mode = DFUProgrammer.detect_boot_mode
+
+
+def test_update_flashes_bare_metal_when_only_the_flash_alt_is_listed(release_dir):
+    """The #197 regression: a bare-metal unit whose listing has no ROM-only alt
+    used to raise "could not tell whether this device has the bootloader
+    installed" and could not be updated at all."""
+    prog = ListingProgrammer(ROM_FLASH_ALT_ONLY)
+    updater = FirmwareUpdater(programmer=prog)
+    primary = release_dir / "motion-sensor-fw-baremetal-fpga.bin"
+    register_download(primary, FirmwareKind.SENSOR, "1.8.2")
+
+    updater.update(FakeHandle(), primary)
+
+    assert updater.last_boot_mode is BootMode.BARE_METAL
+    assert prog.flashed == [(primary, "0x08000000")]
+
+
+def test_update_still_routes_a_converted_console_to_the_signed_slot(release_dir):
+    """The other half of the guarantee: relaxing bare-metal detection must not
+    let a bootloader unit get a bare-metal image at the base of flash."""
+    for name in ("motion-console-fw-baremetal.bin", "motion-console-fw-signed.bin"):
+        (release_dir / name).write_bytes(b"\x00" * 16)
+    prog = ListingProgrammer(CONSOLE_BL_LISTING)
+    updater = FirmwareUpdater(programmer=prog)
+    primary = release_dir / "motion-console-fw-baremetal.bin"
+    register_download(primary, FirmwareKind.CONSOLE, "1.8.1-rc.2")
+
+    updater.update(FakeHandle(), primary)
+
+    assert updater.last_boot_mode is BootMode.BOOTLOADER
+    assert prog.flashed == [
+        (release_dir / "motion-console-fw-signed.bin", "0x08020000")
+    ]


### PR DESCRIPTION
## Problem

Flashing a console running firmware older than `OW_CMD_BOOT_INFO` (console FW <= 1.8.0) could fail with:

> could not tell whether this device has the bootloader installed; refusing to flash, because the wrong address would brick it

The unit is an ordinary bare-metal device, but it cannot be updated at all. Old firmware has no other way to be classified — the boot-info command is the only non-DFU route, and it does not exist there (`0x0B` is unassigned in the 1.8.0 command enum, which jumps `0x0A -> 0x0D`).

## Root cause

`parse_boot_mode()` recognised bare metal **only** via the ROM-only alt settings (`@Option Bytes`, `@OTP Memory`, `@Device Feature`). When `dfu-util -l` reports just the `@Internal Flash` alt, none of those markers are present and classification falls through to `UNKNOWN`:

```
Found DFU: [0483:df11] ... alt=0, name="@Internal Flash /0x08000000/16*128Kg"
-> BootMode.UNKNOWN        (should be BARE_METAL)
```

Deterministic, not a race. How many alts the ROM loader reports varies — a bench console showed **two**, not the four the module documented.

## Fix

The ROM-only alts are still checked first, but are no longer *required*. Failing that, the `@Internal Flash` alt at `0x08000000` is classified from its DfuSe access letters:

| Descriptor | Before | After |
|---|---|---|
| any read-only (`a`) run | `BOOTLOADER` | `BOOTLOADER` (unchanged) |
| runs present, all writable | `UNKNOWN` | **`BARE_METAL`** |
| no parseable runs | `UNKNOWN` | `UNKNOWN` (unchanged) |
| writable, but not at `0x08000000` | `UNKNOWN` | `UNKNOWN` (unchanged) |

### Why this is evidence, not a guess

Both bootloaders hard-code their DFU flash descriptor, and both always mark sector 0 (the bootloader itself) and the reserved/config region read-only — that clamp *is* the security property they exist to enforce:

| Build | `FLASH_DESC_STR` |
|---|---|
| `openmotion-bl` (sensor) | `@Internal Flash/0x08000000/01*128Ka,04*128Kg,11*128Ka` |
| `open-motion-console-bl` | `@Internal Flash/0x08000000/01*128Ka,08*128Kg,07*128Ka` |

A descriptor at `0x08000000` with no read-only run therefore **cannot** be an openmotion bootloader, and the ROM loader is the only other thing it can be. Both signals are positive evidence; neither infers a mode from the *absence* of the other, so the "never guess an address" posture is preserved.

## Behaviour change to review carefully

This intentionally overturns `test_single_fully_writable_alt_is_unknown_not_bootloader`, which asserted the conservative `UNKNOWN`. That test predates the verification above — the invariant makes the case decidable, so it now asserts `BARE_METAL` with the reasoning recorded in the docstring. **This is the one judgement call in the PR and the thing most worth a second opinion.**

## Test coverage

The existing update-flow tests stub `detect_boot_mode()` outright, so they could never have caught a *classification* bug. Added coverage drives a real listing through the genuine `detect_boot_mode -> parse_boot_mode` chain — the path the apps actually take:

- `test_update_flashes_bare_metal_when_only_the_flash_alt_is_listed` — the regression
- `test_update_still_routes_a_converted_console_to_the_signed_slot` — the other half: relaxing bare-metal detection must not send a bootloader unit a bare-metal image at the base of flash
- plus unit cases for the console-bl layout, no parseable runs, and a writable descriptor at a different address

Both new tests were confirmed to fail with the fix reverted. Full software suite: **769 passed**, 207 deselected.

```
pytest tests/ -m "not console and not sensor and not destructive and not slow and not fpga and not imu"
```

## Test app

No change needed. `openmotion-test-app` resolves `omotion` from disk via `PYTHONPATH` and delegates all boot-mode policy to the SDK ("All of the policy — which asset suits which boot mode, and what address it goes to — lives in the SDK; this app only supplies buttons"), so its flash thread picks this up through `FirmwareUpdater.update()`. The second test above covers that path directly.

## Hardware verification

Bench console (HWID `23004c00065133333735383300000000`) on FW 1.8.0:

- confirmed **bare metal** from its DFU alt-setting layout
- updated to 1.8.1-rc.2 at `0x08000000` with `motion-console-fw-baremetal.bin`
- re-queried after reboot: `get_boot_mode()` returns `BARE_METAL` from `OW_CMD_BOOT_INFO` (vtor `0x08000000`)

The DFU-derived answer and the firmware's own report agree, which is the cross-check this fix relies on. Note 1.8.1-rc.2 *does* implement `OW_CMD_BOOT_INFO`, so that console no longer needs the fallback — but units still on <= 1.8.0 do.

Refs #197
