### PR TITLE
Calibration outcome enum + pre-write gate so a failed run never overwrites the console

### DIFF
--- a/omotion/CalibrationWorkflow.py
+++ b/omotion/CalibrationWorkflow.py
@@ -23,6 +23,7 @@ import platform
 import socket
 import sys
 import threading
+import time
 import dataclasses
 from dataclasses import dataclass
 from typing import Callable, Optional, TYPE_CHECKING
@@ -165,6 +166,11 @@ class CalibrationResult:
     started_timestamp: str
     outcome: Optional[CalibrationOutcome] = None
     rolled_back: bool = False   # set by Task 3
+    # True when the operator explicitly approved writing a calibration
+    # whose scan-1 means/contrast were below threshold (#199 pre-write
+    # gate). A consented run is never rolled back — the operator already
+    # said this unit is simply dim.
+    consented_below_threshold: bool = False
 
 
 @dataclass
@@ -470,6 +476,30 @@ def evaluate_passed(rows: list[CalibrationResultRow]) -> bool:
     )
 
 
+def evaluate_gate_passed(rows: list[CalibrationResultRow]) -> bool:
+    """Pre-write gate (#199): mean + contrast only.
+
+    Evaluated on the *calibration* scan, before anything is written to the
+    console. Both quantities are calibration-independent — mean is the raw
+    pixel average and contrast is speckle std/mean — so applying the newly
+    computed calibration cannot change them. That is what makes it sound to
+    judge them one scan early: a camera that is too dim here will still be
+    too dim in the validation scan.
+
+    BFI/BVI are deliberately excluded — they *are* the calibrated
+    quantities, so they only become meaningful after the calibration is
+    applied, which is what the validation scan is for. Ambient-dark is
+    excluded too: phase 1's dark frames are captured but the ambient
+    criterion is defined against the validation scan (#122).
+    """
+    if not rows:
+        return False
+    return all(
+        r.mean_test == "PASS" and r.contrast_test == "PASS"
+        for r in rows
+    )
+
+
 _CSV_FIELDS = [
     "camera_index", "side", "cam",
     "mean", "avg_contrast", "bfi", "bvi", "dark",
@@ -642,6 +672,7 @@ def write_result_json(
     mode: str = "calibrate",
     outcome: str = "",
     calibration_rolled_back: bool = False,
+    consented_below_threshold: bool = False,
 ) -> None:
     """Write a self-describing JSON manifest of the calibration run.
 
@@ -673,6 +704,9 @@ def write_result_json(
         "error": error,
         "outcome": outcome,
         "calibration_rolled_back": calibration_rolled_back,
+        # #199 — this calibration was written on the operator's explicit
+        # authority despite below-threshold scan means/contrast.
+        "consented_below_threshold": consented_below_threshold,
         "operator_id": request.operator_id,
         "notes": request.notes,
         "host": _collect_host_info(),
@@ -990,7 +1024,27 @@ class CalibrationWorkflow:
         on_log_fn: Optional[Callable[[str], None]] = None,
         on_progress_fn: Optional[Callable[[str], None]] = None,
         on_complete_fn: Optional[Callable[[CalibrationResult], None]] = None,
+        on_confirm_fn: Optional[
+            Callable[[list["CalibrationResultRow"]], bool]
+        ] = None,
     ) -> bool:
+        """Run the calibration procedure on a worker thread.
+
+        ``on_confirm_fn`` implements the pre-write gate (#199). It is called
+        — on the worker thread — only when the calibration scan's means or
+        contrasts miss their thresholds, with the per-camera rows measured
+        so far, and must return True to authorise writing the console EEPROM
+        anyway or False to abort untouched. **When it is not supplied, a
+        failing gate aborts without writing**, which is the conservative
+        default: the console keeps whatever calibration it already had.
+
+        The handler blocks the worker thread, so it must bound its own wait
+        — the watchdog is paused across the call precisely so operator think
+        time isn't charged against ``max_duration_sec``, which also means it
+        cannot rescue a handler that never returns. Raising is treated as a
+        decline. ``cancel_calibration()`` remains responsive throughout: the
+        stop event is re-checked as soon as the handler returns.
+        """
         with self._lock:
             if self._running:
                 logger.warning("start_calibration refused: already running.")
@@ -1023,6 +1077,8 @@ class CalibrationWorkflow:
             prior_cal: Optional[Calibration] = None
             wrote_calibration = False
             rolled_back = False
+            consented = False
+            t_proc0 = time.monotonic()
 
             logger.info(
                 "Calibration: starting procedure (operator=%s, output_dir=%s, "
@@ -1185,12 +1241,13 @@ class CalibrationWorkflow:
                         skip_frames,
                     )
                 _reset_firmware_trigger("phase 1 (pre-scan)")
-                # _cal_dark_samples deliberately discarded — the ambient
-                # check (#122) gates on validation-scan dark frames so it
-                # measures the same scan as the row-level mean/contrast/
-                # BFI/BVI tests. If we ever want to also gate on the
-                # calibration scan's dark frames, capture this here.
-                cal_left, cal_right, cal_samples, _cal_dark_samples = _run_subscan_capture(
+                # cal_dark_samples feeds the pre-write gate's row build
+                # (#199) so its table can show an ambient column. The
+                # ambient *criterion* still gates on validation-scan darks
+                # (#122) — evaluate_gate_passed ignores dark_test — so the
+                # pass/fail semantics are unchanged; these frames are only
+                # here so the operator sees a complete table.
+                cal_left, cal_right, cal_samples, cal_dark_samples = _run_subscan_capture(
                     self._interface, request,
                     subject_id=f"calib1_{request.operator_id}",
                     duration_sec=request.duration_sec + request.scan_delay_sec,
@@ -1233,6 +1290,100 @@ class CalibrationWorkflow:
                     "Calibration phase 2 done — proposed calibration:\n%s",
                     _format_calibration(cal_obj),
                 )
+
+                # ── Phase 2.5: pre-write gate (#199) ──────────────────────
+                # The console EEPROM is not touched until either the
+                # calibration scan's own mean/contrast clear their bars or
+                # the operator explicitly authorises writing anyway. Before
+                # this gate existed the write happened here unconditionally
+                # and a bad run was undone afterwards, which meant every
+                # failed calibration briefly destroyed the previous one.
+                _emit_progress("gate")
+                logger.info(
+                    "Calibration phase 2.5: pre-write gate on calibration-"
+                    "scan mean/contrast."
+                )
+                gate_rows = _build_result_rows_from_samples(
+                    cal_samples,
+                    dark_samples=cal_dark_samples,
+                    left_camera_mask=request.left_camera_mask,
+                    right_camera_mask=request.right_camera_mask,
+                    thresholds=request.thresholds,
+                    sensor_left=getattr(self._interface, "left", None),
+                    sensor_right=getattr(self._interface, "right", None),
+                )
+                if evaluate_gate_passed(gate_rows):
+                    logger.info(
+                        "Calibration phase 2.5 done: gate PASS — proceeding "
+                        "to write."
+                    )
+                else:
+                    below = ", ".join(
+                        f"{'L' if r.side == 'left' else 'R'}{r.cam_id + 1}"
+                        for r in gate_rows
+                        if r.mean_test == "FAIL" or r.contrast_test == "FAIL"
+                    )
+                    logger.warning(
+                        "Calibration phase 2.5: gate FAIL — below threshold "
+                        "on %s. Console EEPROM not written yet.", below,
+                    )
+                    _emit_log(
+                        "Calibration: scan means/contrast below threshold "
+                        f"({below}) — awaiting confirmation before writing."
+                    )
+                    if on_confirm_fn is None:
+                        error = (
+                            "calibration scan below threshold on "
+                            f"{below}; not written (no confirmation handler)"
+                        )
+                        canceled = True
+                        return
+
+                    # Pause the watchdog: the operator's think time must not
+                    # be charged against max_duration_sec, or a slow answer
+                    # would surface as a bogus timeout.
+                    wd.cancel()
+                    t_wait0 = time.monotonic()
+                    try:
+                        consented = bool(on_confirm_fn(gate_rows))
+                    except Exception as e:
+                        logger.exception(
+                            "Calibration gate: confirmation handler raised; "
+                            "treating as declined."
+                        )
+                        consented = False
+                        error = f"gate confirmation failed: {e}"
+                    wait_s = time.monotonic() - t_wait0
+                    logger.info(
+                        "Calibration phase 2.5: operator %s after %.1fs.",
+                        "APPROVED the write" if consented else "declined",
+                        wait_s,
+                    )
+                    if self._stop_evt.is_set():
+                        canceled = True
+                        if not error:
+                            error = "canceled at pre-write gate"
+                        return
+                    if not consented:
+                        canceled = True
+                        if not error:
+                            error = (
+                                "declined at pre-write gate: calibration "
+                                f"scan below threshold on {below}"
+                            )
+                        return
+                    # Restart the watchdog on the remaining budget, with the
+                    # wait excluded.
+                    remaining = request.max_duration_sec - (
+                        time.monotonic() - t_proc0 - wait_s
+                    )
+                    wd = threading.Timer(max(1.0, remaining), _watchdog)
+                    wd.daemon = True
+                    wd.start()
+                    _emit_log(
+                        "Calibration: proceeding with operator approval "
+                        "despite below-threshold scan."
+                    )
 
                 _emit_progress("write_calibration")
                 _emit_log("Calibration: writing to console…")
@@ -1345,11 +1496,19 @@ class CalibrationWorkflow:
                 if (
                     wrote_calibration and prior_cal is not None
                     and outcome is not CalibrationOutcome.PASSED
+                    and not consented
                 ):
                     # The write in phase 3 predates the validation verdict.
                     # Anything short of PASSED means the new calibration is
                     # unvalidated — put the previous one back (best-effort;
                     # the console may be gone).
+                    #
+                    # Skipped when the operator consented at the pre-write
+                    # gate: they were shown the below-threshold numbers and
+                    # asked for this calibration anyway, so undoing it would
+                    # discard exactly what they approved. Such a run still
+                    # reports FAILED — the verdict is honest, the write is
+                    # simply intentional.
                     try:
                         self._interface.write_calibration(
                             prior_cal.c_min, prior_cal.c_max,
@@ -1400,6 +1559,7 @@ class CalibrationWorkflow:
                         },
                         interface=self._interface,
                         calibration_rolled_back=rolled_back,
+                        consented_below_threshold=consented,
                     )
                     logger.info("Calibration manifest written: %s", json_path)
                 except Exception:
@@ -1423,6 +1583,7 @@ class CalibrationWorkflow:
                     started_timestamp=ts,
                     outcome=outcome,
                     rolled_back=rolled_back,
+                    consented_below_threshold=consented,
                 )
                 with self._lock:
                     self._running = False

--- a/omotion/CalibrationWorkflow.py
+++ b/omotion/CalibrationWorkflow.py
@@ -123,45 +123,6 @@ class CalibrationResultRow:
     hwid: str
 
 
-@dataclass
-class CalibrationResult:
-    ok: bool
-    passed: bool
-    canceled: bool
-    error: str
-    csv_path: str
-    json_path: str
-    calibration: Optional[Calibration]
-    rows: list[CalibrationResultRow]
-    calibration_scan_left_path: str
-    calibration_scan_right_path: str
-    validation_scan_left_path: str
-    validation_scan_right_path: str
-    started_timestamp: str
-
-
-@dataclass
-class TestScanResult:
-    """Outcome of a stand-alone Test scan — phase 1 only, no calibration
-    write, no validation scan. Shape mirrors ``CalibrationResult`` so the
-    bloodflow-app's QML layer can re-use the row formatting code, but the
-    fields are scoped to what a test scan actually produces (no
-    ``calibration`` field — Test scans don't write to console EEPROM, no
-    ``validation_scan_*_path`` — there's no validation scan).
-    """
-    ok: bool
-    passed: bool
-    canceled: bool
-    error: str
-    csv_path: str
-    json_path: str
-    rows: list[CalibrationResultRow]
-    test_scan_left_path: str
-    test_scan_right_path: str
-    started_timestamp: str
-    mode: str = "test"
-
-
 class CalibrationOutcome(str, enum.Enum):
     """Single authoritative terminal state of a calibration / test-scan
     procedure. Replaces consumer-side guessing from the ok/passed/
@@ -185,6 +146,48 @@ def _resolve_outcome(
     if not ok:
         return CalibrationOutcome.ERROR
     return CalibrationOutcome.PASSED if passed else CalibrationOutcome.FAILED
+
+
+@dataclass
+class CalibrationResult:
+    ok: bool
+    passed: bool
+    canceled: bool
+    error: str
+    csv_path: str
+    json_path: str
+    calibration: Optional[Calibration]
+    rows: list[CalibrationResultRow]
+    calibration_scan_left_path: str
+    calibration_scan_right_path: str
+    validation_scan_left_path: str
+    validation_scan_right_path: str
+    started_timestamp: str
+    outcome: CalibrationOutcome = CalibrationOutcome.ERROR
+    rolled_back: bool = False   # set by Task 3
+
+
+@dataclass
+class TestScanResult:
+    """Outcome of a stand-alone Test scan — phase 1 only, no calibration
+    write, no validation scan. Shape mirrors ``CalibrationResult`` so the
+    bloodflow-app's QML layer can re-use the row formatting code, but the
+    fields are scoped to what a test scan actually produces (no
+    ``calibration`` field — Test scans don't write to console EEPROM, no
+    ``validation_scan_*_path`` — there's no validation scan).
+    """
+    ok: bool
+    passed: bool
+    canceled: bool
+    error: str
+    csv_path: str
+    json_path: str
+    rows: list[CalibrationResultRow]
+    test_scan_left_path: str
+    test_scan_right_path: str
+    started_timestamp: str
+    mode: str = "test"
+    outcome: CalibrationOutcome = CalibrationOutcome.ERROR
 
 
 # ---------------------------------------------------------------------------
@@ -637,6 +640,7 @@ def write_result_json(
     scan_paths: dict,
     interface,
     mode: str = "calibrate",
+    outcome: str = "",
 ) -> None:
     """Write a self-describing JSON manifest of the calibration run.
 
@@ -666,6 +670,7 @@ def write_result_json(
         "passed": passed,
         "canceled": canceled,
         "error": error,
+        "outcome": outcome,
         "operator_id": request.operator_id,
         "notes": request.notes,
         "host": _collect_host_info(),
@@ -1012,6 +1017,7 @@ class CalibrationWorkflow:
             passed = False
             error = ""
             canceled = False
+            timed_out = False
 
             logger.info(
                 "Calibration: starting procedure (operator=%s, output_dir=%s, "
@@ -1024,6 +1030,8 @@ class CalibrationWorkflow:
             )
 
             def _watchdog() -> None:
+                nonlocal timed_out
+                timed_out = True
                 self._stop_evt.set()
                 logger.warning(
                     "Calibration watchdog fired after %d sec; aborting.",
@@ -1148,8 +1156,7 @@ class CalibrationWorkflow:
                 flash_ok, flash_err = _flash_sensors()
                 if not flash_ok:
                     error = f"flash phase failed: {flash_err}"
-                    if "canceled" in flash_err:
-                        canceled = True
+                    canceled = self._stop_evt.is_set()   # was: "canceled" in flash_err
                     return
                 logger.info("Calibration phase 0 done: sensors flashed.")
                 if self._stop_evt.is_set():
@@ -1306,13 +1313,27 @@ class CalibrationWorkflow:
                     error = f"{type(e).__name__}: {e}"
             finally:
                 wd.cancel()
-                if self._stop_evt.is_set() and not canceled:
+                # The watchdog is authoritative: if it fired, this run is a
+                # timeout regardless of which phase-boundary check (flash /
+                # scan) already stamped a generic "canceled ..." message —
+                # those messages describe a symptom of the stop_evt the
+                # watchdog itself set, not an independent cancel. Only fall
+                # back to the earlier finally-block guessing (any
+                # unaccounted-for stop_evt is a plain cancel) when the
+                # watchdog did not fire.
+                if timed_out:
+                    canceled = True
+                    error = (
+                        f"calibration exceeded max_duration_sec="
+                        f"{request.max_duration_sec}"
+                    )
+                elif self._stop_evt.is_set() and not canceled:
                     canceled = True
                     if not error:
-                        error = (
-                            f"calibration exceeded max_duration_sec="
-                            f"{request.max_duration_sec}"
-                        )
+                        error = "canceled"
+                outcome = _resolve_outcome(
+                    ok=ok, passed=passed, canceled=canceled, timed_out=timed_out,
+                )
 
                 if cal_obj is not None:
                     logger.info(
@@ -1332,6 +1353,7 @@ class CalibrationWorkflow:
                         passed=passed,
                         canceled=canceled,
                         error=error,
+                        outcome=outcome.value,
                         request=request,
                         rows=rows,
                         calibration=cal_obj,
@@ -1350,8 +1372,8 @@ class CalibrationWorkflow:
 
                 logger.info(
                     "Calibration: procedure complete (ok=%s, passed=%s, "
-                    "canceled=%s, error=%r)",
-                    ok, passed, canceled, error,
+                    "canceled=%s, error=%r, outcome=%s)",
+                    ok, passed, canceled, error, outcome,
                 )
 
                 result = CalibrationResult(
@@ -1363,6 +1385,7 @@ class CalibrationWorkflow:
                     validation_scan_left_path=val_left,
                     validation_scan_right_path=val_right,
                     started_timestamp=ts,
+                    outcome=outcome,
                 )
                 with self._lock:
                     self._running = False
@@ -1423,6 +1446,7 @@ class CalibrationWorkflow:
             passed = False
             error = ""
             canceled = False
+            timed_out = False
 
             logger.info(
                 "Test scan: starting (operator=%s, output_dir=%s, "
@@ -1435,6 +1459,8 @@ class CalibrationWorkflow:
             )
 
             def _watchdog() -> None:
+                nonlocal timed_out
+                timed_out = True
                 self._stop_evt.set()
                 logger.warning(
                     "Test-scan watchdog fired after %d sec; aborting.",
@@ -1521,8 +1547,7 @@ class CalibrationWorkflow:
                 flash_ok, flash_err = _flash_sensors()
                 if not flash_ok:
                     error = f"flash phase failed: {flash_err}"
-                    if "canceled" in flash_err:
-                        canceled = True
+                    canceled = self._stop_evt.is_set()   # was: "canceled" in flash_err
                     return
                 if self._stop_evt.is_set():
                     canceled = True
@@ -1597,13 +1622,23 @@ class CalibrationWorkflow:
                     error = f"{type(e).__name__}: {e}"
             finally:
                 wd.cancel()
-                if self._stop_evt.is_set() and not canceled:
+                # See the calibration worker's identical comment: the
+                # watchdog is authoritative — if it fired, this run is a
+                # timeout regardless of which phase-boundary check already
+                # stamped a generic "canceled ..." message.
+                if timed_out:
+                    canceled = True
+                    error = (
+                        f"test scan exceeded max_duration_sec="
+                        f"{request.max_duration_sec}"
+                    )
+                elif self._stop_evt.is_set() and not canceled:
                     canceled = True
                     if not error:
-                        error = (
-                            f"test scan exceeded max_duration_sec="
-                            f"{request.max_duration_sec}"
-                        )
+                        error = "canceled"
+                outcome = _resolve_outcome(
+                    ok=ok, passed=passed, canceled=canceled, timed_out=timed_out,
+                )
 
                 try:
                     json_path = os.path.join(
@@ -1615,6 +1650,7 @@ class CalibrationWorkflow:
                         passed=passed,
                         canceled=canceled,
                         error=error,
+                        outcome=outcome.value,
                         request=request,
                         rows=rows,
                         calibration=None,
@@ -1632,8 +1668,8 @@ class CalibrationWorkflow:
 
                 logger.info(
                     "Test scan: procedure complete (ok=%s, passed=%s, "
-                    "canceled=%s, error=%r)",
-                    ok, passed, canceled, error,
+                    "canceled=%s, error=%r, outcome=%s)",
+                    ok, passed, canceled, error, outcome,
                 )
 
                 result = TestScanResult(
@@ -1643,6 +1679,7 @@ class CalibrationWorkflow:
                     test_scan_left_path=test_left,
                     test_scan_right_path=test_right,
                     started_timestamp=ts,
+                    outcome=outcome,
                 )
                 with self._lock:
                     self._running = False

--- a/omotion/CalibrationWorkflow.py
+++ b/omotion/CalibrationWorkflow.py
@@ -641,6 +641,7 @@ def write_result_json(
     interface,
     mode: str = "calibrate",
     outcome: str = "",
+    calibration_rolled_back: bool = False,
 ) -> None:
     """Write a self-describing JSON manifest of the calibration run.
 
@@ -671,6 +672,7 @@ def write_result_json(
         "canceled": canceled,
         "error": error,
         "outcome": outcome,
+        "calibration_rolled_back": calibration_rolled_back,
         "operator_id": request.operator_id,
         "notes": request.notes,
         "host": _collect_host_info(),
@@ -1018,6 +1020,9 @@ class CalibrationWorkflow:
             error = ""
             canceled = False
             timed_out = False
+            prior_cal: Optional[Calibration] = None
+            wrote_calibration = False
+            rolled_back = False
 
             logger.info(
                 "Calibration: starting procedure (operator=%s, output_dir=%s, "
@@ -1232,10 +1237,12 @@ class CalibrationWorkflow:
                 _emit_progress("write_calibration")
                 _emit_log("Calibration: writing to console…")
                 logger.info("Calibration phase 3: writing to console EEPROM.")
+                prior_cal = self._interface.get_calibration()
                 cal_obj = self._interface.write_calibration(
                     cal_obj.c_min, cal_obj.c_max,
                     cal_obj.i_min, cal_obj.i_max,
                 )
+                wrote_calibration = True
                 logger.info(
                     "Calibration phase 3 done — calibration written and "
                     "cached (source=%s).", cal_obj.source,
@@ -1335,6 +1342,34 @@ class CalibrationWorkflow:
                     ok=ok, passed=passed, canceled=canceled, timed_out=timed_out,
                 )
 
+                if (
+                    wrote_calibration and prior_cal is not None
+                    and outcome is not CalibrationOutcome.PASSED
+                ):
+                    # The write in phase 3 predates the validation verdict.
+                    # Anything short of PASSED means the new calibration is
+                    # unvalidated — put the previous one back (best-effort;
+                    # the console may be gone).
+                    try:
+                        self._interface.write_calibration(
+                            prior_cal.c_min, prior_cal.c_max,
+                            prior_cal.i_min, prior_cal.i_max,
+                        )
+                        rolled_back = True
+                        _emit_log(
+                            "Calibration: restored previous calibration "
+                            "(run did not pass)."
+                        )
+                        logger.info(
+                            "Calibration: EEPROM rolled back to pre-run values."
+                        )
+                    except Exception as e:
+                        logger.exception("Calibration: EEPROM rollback failed.")
+                        error = (
+                            f"{error}; rollback failed: {e}"
+                            if error else f"rollback failed: {e}"
+                        )
+
                 if cal_obj is not None:
                     logger.info(
                         "Calibration: final calibration on console:\n%s",
@@ -1364,6 +1399,7 @@ class CalibrationWorkflow:
                             "validation_right": val_right,
                         },
                         interface=self._interface,
+                        calibration_rolled_back=rolled_back,
                     )
                     logger.info("Calibration manifest written: %s", json_path)
                 except Exception:
@@ -1386,6 +1422,7 @@ class CalibrationWorkflow:
                     validation_scan_right_path=val_right,
                     started_timestamp=ts,
                     outcome=outcome,
+                    rolled_back=rolled_back,
                 )
                 with self._lock:
                     self._running = False
@@ -1660,6 +1697,7 @@ class CalibrationWorkflow:
                         },
                         interface=self._interface,
                         mode="test",
+                        calibration_rolled_back=False,
                     )
                     logger.info("Test scan manifest written: %s", json_path)
                 except Exception:

--- a/omotion/CalibrationWorkflow.py
+++ b/omotion/CalibrationWorkflow.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import csv
 import datetime
+import enum
 import json
 import logging
 import os
@@ -159,6 +160,31 @@ class TestScanResult:
     test_scan_right_path: str
     started_timestamp: str
     mode: str = "test"
+
+
+class CalibrationOutcome(str, enum.Enum):
+    """Single authoritative terminal state of a calibration / test-scan
+    procedure. Replaces consumer-side guessing from the ok/passed/
+    canceled boolean triple (which allowed 16 combinations, ~5 of them
+    meaningful, and could not distinguish a watchdog timeout from an
+    operator cancel)."""
+    PASSED = "passed"        # ran end-to-end, all cameras met thresholds
+    FAILED = "failed"        # ran end-to-end, >=1 camera missed a threshold
+    CANCELED = "canceled"    # cancel_calibration() stopped it
+    TIMED_OUT = "timed_out"  # max_duration_sec watchdog stopped it
+    ERROR = "error"          # broke before completing (flash, USB, degenerate data, ...)
+
+
+def _resolve_outcome(
+    *, ok: bool, passed: bool, canceled: bool, timed_out: bool,
+) -> CalibrationOutcome:
+    if timed_out:
+        return CalibrationOutcome.TIMED_OUT
+    if canceled:
+        return CalibrationOutcome.CANCELED
+    if not ok:
+        return CalibrationOutcome.ERROR
+    return CalibrationOutcome.PASSED if passed else CalibrationOutcome.FAILED
 
 
 # ---------------------------------------------------------------------------

--- a/omotion/CalibrationWorkflow.py
+++ b/omotion/CalibrationWorkflow.py
@@ -163,7 +163,7 @@ class CalibrationResult:
     validation_scan_left_path: str
     validation_scan_right_path: str
     started_timestamp: str
-    outcome: CalibrationOutcome = CalibrationOutcome.ERROR
+    outcome: Optional[CalibrationOutcome] = None
     rolled_back: bool = False   # set by Task 3
 
 
@@ -187,7 +187,7 @@ class TestScanResult:
     test_scan_right_path: str
     started_timestamp: str
     mode: str = "test"
-    outcome: CalibrationOutcome = CalibrationOutcome.ERROR
+    outcome: Optional[CalibrationOutcome] = None
 
 
 # ---------------------------------------------------------------------------
@@ -1409,7 +1409,7 @@ class CalibrationWorkflow:
                 logger.info(
                     "Calibration: procedure complete (ok=%s, passed=%s, "
                     "canceled=%s, error=%r, outcome=%s)",
-                    ok, passed, canceled, error, outcome,
+                    ok, passed, canceled, error, outcome.value,
                 )
 
                 result = CalibrationResult(
@@ -1707,7 +1707,7 @@ class CalibrationWorkflow:
                 logger.info(
                     "Test scan: procedure complete (ok=%s, passed=%s, "
                     "canceled=%s, error=%r, outcome=%s)",
-                    ok, passed, canceled, error, outcome,
+                    ok, passed, canceled, error, outcome.value,
                 )
 
                 result = TestScanResult(

--- a/omotion/__init__.py
+++ b/omotion/__init__.py
@@ -56,6 +56,7 @@ from . import db_key, db_migrate, db_open, db_schema
 from .SessionPlayback import materialize_corrected_csv
 from .Calibration import Calibration
 from .CalibrationWorkflow import (
+    CalibrationOutcome,
     CalibrationRequest,
     CalibrationResult,
     CalibrationResultRow,
@@ -104,6 +105,7 @@ __all__ = [
     "db_schema",
     "materialize_corrected_csv",
     "Calibration",
+    "CalibrationOutcome",
     "CalibrationRequest",
     "CalibrationResult",
     "CalibrationResultRow",

--- a/tests/test_calibration_outcome.py
+++ b/tests/test_calibration_outcome.py
@@ -32,3 +32,25 @@ def test_outcome_is_str_enum():
 def test_exported_from_package():
     from omotion import CalibrationOutcome as exported
     assert exported is CalibrationOutcome
+
+
+def test_legacy_construction_defaults_outcome_to_none():
+    """A result built without outcome= (pre-outcome caller shape) must
+    surface outcome=None so consumers fall back to the boolean triple —
+    an ERROR default would misreport healthy legacy results as errors."""
+    from omotion.CalibrationWorkflow import CalibrationResult, TestScanResult
+    r = CalibrationResult(
+        ok=True, passed=True, canceled=False, error="",
+        csv_path="", json_path="", calibration=None, rows=[],
+        calibration_scan_left_path="", calibration_scan_right_path="",
+        validation_scan_left_path="", validation_scan_right_path="",
+        started_timestamp="",
+    )
+    t = TestScanResult(
+        ok=True, passed=True, canceled=False, error="",
+        csv_path="", json_path="", rows=[],
+        test_scan_left_path="", test_scan_right_path="",
+        started_timestamp="",
+    )
+    assert r.outcome is None and r.rolled_back is False
+    assert t.outcome is None

--- a/tests/test_calibration_outcome.py
+++ b/tests/test_calibration_outcome.py
@@ -1,0 +1,34 @@
+"""Pure tests for the outcome resolver — no hardware, no threads."""
+import pytest
+
+from omotion.CalibrationWorkflow import CalibrationOutcome, _resolve_outcome
+
+
+@pytest.mark.parametrize(
+    "ok,passed,canceled,timed_out,expected",
+    [
+        (True,  True,  False, False, CalibrationOutcome.PASSED),
+        (True,  False, False, False, CalibrationOutcome.FAILED),
+        (False, False, True,  False, CalibrationOutcome.CANCELED),
+        (False, False, False, False, CalibrationOutcome.ERROR),
+        # Watchdog timeout wins over the canceled flag it sets as a side effect.
+        (False, False, True,  True,  CalibrationOutcome.TIMED_OUT),
+        # Timeout during an error still reports as timeout (the timeout caused it).
+        (False, False, False, True,  CalibrationOutcome.TIMED_OUT),
+    ],
+)
+def test_resolve_outcome(ok, passed, canceled, timed_out, expected):
+    assert _resolve_outcome(
+        ok=ok, passed=passed, canceled=canceled, timed_out=timed_out,
+    ) is expected
+
+
+def test_outcome_is_str_enum():
+    # QML/JSON consumers rely on the string value.
+    assert CalibrationOutcome.TIMED_OUT == "timed_out"
+    assert f"{CalibrationOutcome.PASSED.value}" == "passed"
+
+
+def test_exported_from_package():
+    from omotion import CalibrationOutcome as exported
+    assert exported is CalibrationOutcome

--- a/tests/test_calibration_workflow.py
+++ b/tests/test_calibration_workflow.py
@@ -422,6 +422,105 @@ def test_cancel_outcome_is_canceled_not_timed_out(interface, request_obj):
     assert "max_duration_sec" not in holder["r"].error
 
 
+def test_fail_verdict_rolls_back_eeprom(interface, request_obj, thresholds):
+    """A FAILED calibration must not leave the unvalidated calibration on
+    the console: write_calibration is called a second time with the
+    pre-run values and the result reports rolled_back=True."""
+    from dataclasses import replace
+    from omotion.CalibrationWorkflow import CalibrationThresholds
+    _make_fake_scan_workflow(interface, _LEFT, _RIGHT)
+    prior = interface.get_calibration()
+    # Snapshot before starting — the demo interface's cached calibration
+    # object could in principle be refreshed by a later write, so compare
+    # against copies taken now rather than re-reading `prior` after the
+    # run completes.
+    prior_c_min = prior.c_min.copy()
+    prior_c_max = prior.c_max.copy()
+    strict = CalibrationThresholds(
+        min_mean_per_camera=[1e9] * 8,      # nothing can pass
+        min_contrast_per_camera=[0.0] * 8,
+        min_bfi_per_camera=[-1e9] * 8,
+        min_bvi_per_camera=[-1e9] * 8,
+    )
+    req = replace(request_obj, thresholds=strict)
+    calls = []
+    def _record_write(cmin, cmax, imin, imax):
+        calls.append((cmin, cmax, imin, imax))
+        return Calibration(c_min=cmin, c_max=cmax, i_min=imin, i_max=imax,
+                           source="test")
+    interface.write_calibration = MagicMock(side_effect=_record_write)
+    done = threading.Event(); holder = {}
+    interface.start_calibration(
+        req, on_complete_fn=lambda r: (holder.update(r=r), done.set()))
+    assert done.wait(30)
+    r = holder["r"]
+    assert r.ok and not r.passed
+    assert r.rolled_back is True
+    assert len(calls) == 2                       # new write + restore
+    np.testing.assert_array_equal(calls[1][0], prior_c_min)
+    np.testing.assert_array_equal(calls[1][1], prior_c_max)
+
+
+def test_pass_verdict_does_not_roll_back(interface, request_obj):
+    # happy-path arrangement from test_happy_path_produces_csv_and_passes
+    if not _have_fixtures():
+        pytest.skip("fixture CSVs missing")
+
+    _make_fake_scan_workflow(interface, _LEFT, _RIGHT)
+    interface.write_calibration = MagicMock(
+        return_value=Calibration(
+            c_min=np.zeros((2, 8)), c_max=np.full((2, 8), 0.5),
+            i_min=np.zeros((2, 8)), i_max=np.full((2, 8), 200.0),
+            source="console",
+        )
+    )
+
+    done = threading.Event()
+    holder = {}
+    interface.start_calibration(
+        request_obj,
+        on_complete_fn=lambda r: (holder.update(r=r), done.set()),
+    )
+    assert done.wait(timeout=60.0), "calibration didn't complete"
+    assert holder["r"].rolled_back is False
+    interface.write_calibration.assert_called_once()
+
+
+def test_rollback_failure_is_best_effort(interface, request_obj):
+    """If the restore write itself raises (e.g. console USB died), the
+    result still completes, rolled_back stays False, and the error text
+    carries the rollback failure."""
+    # strict thresholds as above; write_calibration succeeds on call 1,
+    # raises RuntimeError("usb gone") on call 2.
+    from dataclasses import replace
+    from omotion.CalibrationWorkflow import CalibrationThresholds
+    _make_fake_scan_workflow(interface, _LEFT, _RIGHT)
+    strict = CalibrationThresholds(
+        min_mean_per_camera=[1e9] * 8,      # nothing can pass
+        min_contrast_per_camera=[0.0] * 8,
+        min_bfi_per_camera=[-1e9] * 8,
+        min_bvi_per_camera=[-1e9] * 8,
+    )
+    req = replace(request_obj, thresholds=strict)
+
+    calls = []
+    def _write_side_effect(cmin, cmax, imin, imax):
+        calls.append((cmin, cmax, imin, imax))
+        if len(calls) == 1:
+            return Calibration(c_min=cmin, c_max=cmax, i_min=imin, i_max=imax,
+                               source="test")
+        raise RuntimeError("usb gone")
+    interface.write_calibration = MagicMock(side_effect=_write_side_effect)
+
+    done = threading.Event(); holder = {}
+    interface.start_calibration(
+        req, on_complete_fn=lambda r: (holder.update(r=r), done.set()))
+    assert done.wait(30)
+    r = holder["r"]
+    assert r.rolled_back is False
+    assert "rollback failed" in r.error
+
+
 def test_watchdog_timeout_outcome_is_timed_out(interface, request_obj):
     from dataclasses import replace
     from omotion.CalibrationWorkflow import CalibrationOutcome

--- a/tests/test_calibration_workflow.py
+++ b/tests/test_calibration_workflow.py
@@ -423,9 +423,16 @@ def test_cancel_outcome_is_canceled_not_timed_out(interface, request_obj):
 
 
 def test_fail_verdict_rolls_back_eeprom(interface, request_obj, thresholds):
-    """A FAILED calibration must not leave the unvalidated calibration on
-    the console: write_calibration is called a second time with the
-    pre-run values and the result reports rolled_back=True."""
+    """An *unconsented* FAILED calibration must not leave the unvalidated
+    calibration on the console: write_calibration is called a second time
+    with the pre-run values and the result reports rolled_back=True.
+
+    The failure is forced on BFI rather than mean. Mean and contrast are
+    now judged one scan earlier by the pre-write gate (#199), which aborts
+    before writing at all — so there would be nothing to roll back. BFI is
+    a calibrated quantity, knowable only after the validation scan, which
+    is precisely the case the rollback still exists for.
+    """
     from dataclasses import replace
     from omotion.CalibrationWorkflow import CalibrationThresholds
     _make_fake_scan_workflow(interface, _LEFT, _RIGHT)
@@ -437,9 +444,9 @@ def test_fail_verdict_rolls_back_eeprom(interface, request_obj, thresholds):
     prior_c_min = prior.c_min.copy()
     prior_c_max = prior.c_max.copy()
     strict = CalibrationThresholds(
-        min_mean_per_camera=[1e9] * 8,      # nothing can pass
-        min_contrast_per_camera=[0.0] * 8,
-        min_bfi_per_camera=[-1e9] * 8,
+        min_mean_per_camera=[0.0] * 8,      # gate passes …
+        min_contrast_per_camera=[0.0] * 8,  # … so the write happens
+        min_bfi_per_camera=[1e9] * 8,       # then validation fails
         min_bvi_per_camera=[-1e9] * 8,
     )
     req = replace(request_obj, thresholds=strict)
@@ -491,14 +498,16 @@ def test_rollback_failure_is_best_effort(interface, request_obj):
     result still completes, rolled_back stays False, and the error text
     carries the rollback failure."""
     # strict thresholds as above; write_calibration succeeds on call 1,
-    # raises RuntimeError("usb gone") on call 2.
+    # raises RuntimeError("usb gone") on call 2. Failure forced on BFI so
+    # the pre-write gate (#199) lets the run reach the write — see
+    # test_fail_verdict_rolls_back_eeprom.
     from dataclasses import replace
     from omotion.CalibrationWorkflow import CalibrationThresholds
     _make_fake_scan_workflow(interface, _LEFT, _RIGHT)
     strict = CalibrationThresholds(
-        min_mean_per_camera=[1e9] * 8,      # nothing can pass
+        min_mean_per_camera=[0.0] * 8,
         min_contrast_per_camera=[0.0] * 8,
-        min_bfi_per_camera=[-1e9] * 8,
+        min_bfi_per_camera=[1e9] * 8,       # fails only at validation
         min_bvi_per_camera=[-1e9] * 8,
     )
     req = replace(request_obj, thresholds=strict)
@@ -556,3 +565,173 @@ def test_watchdog_timeout_outcome_is_timed_out(interface, request_obj):
     assert done.wait(timeout=15.0)
     assert holder["r"].outcome is CalibrationOutcome.TIMED_OUT
     assert "max_duration_sec" in holder["r"].error
+
+
+# ── Pre-write gate (#199) ─────────────────────────────────────────────────
+#
+# The console EEPROM must not be touched until either the calibration
+# scan's own mean/contrast clear their bars, or the operator explicitly
+# authorises writing anyway. Before the gate existed, every failed
+# calibration briefly destroyed the previous one and then restored it.
+
+
+def _gate_failing_thresholds():
+    """Mean unreachable → the gate fails; everything else permissive so
+    nothing *else* is what stopped the run."""
+    return CalibrationThresholds(
+        min_mean_per_camera=[1e9] * 8,
+        min_contrast_per_camera=[0.0] * 8,
+        min_bfi_per_camera=[-1e9] * 8,
+        min_bvi_per_camera=[-1e9] * 8,
+    )
+
+
+def test_gate_failure_without_handler_never_writes(interface, request_obj):
+    """No confirmation handler is the conservative default: abort, and
+    leave whatever calibration the console already had."""
+    from dataclasses import replace
+    from omotion.CalibrationWorkflow import CalibrationOutcome
+    _make_fake_scan_workflow(interface, _LEFT, _RIGHT)
+    interface.write_calibration = MagicMock()
+
+    req = replace(request_obj, thresholds=_gate_failing_thresholds())
+    done = threading.Event(); holder = {}
+    interface.start_calibration(
+        req, on_complete_fn=lambda r: (holder.update(r=r), done.set()))
+    assert done.wait(30)
+
+    r = holder["r"]
+    interface.write_calibration.assert_not_called()
+    assert r.outcome is CalibrationOutcome.CANCELED
+    assert "below threshold" in r.error
+    assert r.rolled_back is False
+    assert r.consented_below_threshold is False
+
+
+def test_gate_decline_never_writes(interface, request_obj):
+    from dataclasses import replace
+    from omotion.CalibrationWorkflow import CalibrationOutcome
+    _make_fake_scan_workflow(interface, _LEFT, _RIGHT)
+    interface.write_calibration = MagicMock()
+
+    seen = {}
+    def _decline(rows):
+        seen["rows"] = rows
+        return False
+
+    req = replace(request_obj, thresholds=_gate_failing_thresholds())
+    done = threading.Event(); holder = {}
+    interface.start_calibration(
+        req, on_confirm_fn=_decline,
+        on_complete_fn=lambda r: (holder.update(r=r), done.set()))
+    assert done.wait(30)
+
+    interface.write_calibration.assert_not_called()
+    assert holder["r"].outcome is CalibrationOutcome.CANCELED
+    assert "declined" in holder["r"].error
+    # The handler is handed the measured rows so the UI can show the
+    # operator what missed, rather than a bare yes/no prompt.
+    assert seen["rows"], "confirm handler got no rows"
+    assert all(r.mean_test == "FAIL" for r in seen["rows"])
+
+
+def test_gate_consent_proceeds_and_keeps_the_write(interface, request_obj):
+    """Consent means write, run the validation scan, and — crucially —
+    do NOT roll back afterwards, even though the verdict is FAILED. The
+    operator was shown the numbers and asked for this calibration."""
+    from dataclasses import replace
+    _make_fake_scan_workflow(interface, _LEFT, _RIGHT)
+    calls = []
+    def _record_write(cmin, cmax, imin, imax):
+        calls.append((cmin, cmax, imin, imax))
+        return Calibration(c_min=cmin, c_max=cmax, i_min=imin, i_max=imax,
+                           source="test")
+    interface.write_calibration = MagicMock(side_effect=_record_write)
+
+    req = replace(request_obj, thresholds=_gate_failing_thresholds())
+    done = threading.Event(); holder = {}
+    interface.start_calibration(
+        req, on_confirm_fn=lambda rows: True,
+        on_complete_fn=lambda r: (holder.update(r=r), done.set()))
+    assert done.wait(30)
+
+    r = holder["r"]
+    assert r.consented_below_threshold is True
+    assert r.passed is False          # honest verdict — mean still failed
+    assert r.rolled_back is False     # but the write stands
+    assert len(calls) == 1, "consented run must not write twice"
+    # Validation still ran, so the operator gets BFI/BVI numbers too —
+    # r.rows is built from the *validation* samples in phase 5, so its
+    # presence is the proof. (The fake scan workflow doesn't emit scan
+    # CSVs, so the *_scan_*_path fields are empty even on a happy path.)
+    assert r.rows, "no result rows from the validation scan"
+    assert all(row.bfi_test in ("PASS", "FAIL") for row in r.rows)
+
+
+def test_gate_passes_silently_when_scan_is_good(interface, request_obj):
+    """A healthy unit must never see the prompt."""
+    _make_fake_scan_workflow(interface, _LEFT, _RIGHT)
+    interface.write_calibration = MagicMock(
+        return_value=Calibration(
+            c_min=np.zeros((2, 8)), c_max=np.full((2, 8), 0.5),
+            i_min=np.zeros((2, 8)), i_max=np.full((2, 8), 200.0),
+            source="console"))
+    asked = []
+    done = threading.Event(); holder = {}
+    interface.start_calibration(
+        request_obj,
+        on_confirm_fn=lambda rows: asked.append(rows) or True,
+        on_complete_fn=lambda r: (holder.update(r=r), done.set()))
+    assert done.wait(60)
+
+    assert asked == [], "gate prompted on a passing scan"
+    assert holder["r"].consented_below_threshold is False
+
+
+def test_gate_handler_exception_is_treated_as_decline(interface, request_obj):
+    """A broken UI callback must not write the EEPROM by accident."""
+    from dataclasses import replace
+    _make_fake_scan_workflow(interface, _LEFT, _RIGHT)
+    interface.write_calibration = MagicMock()
+
+    def _boom(rows):
+        raise RuntimeError("qml died")
+
+    req = replace(request_obj, thresholds=_gate_failing_thresholds())
+    done = threading.Event(); holder = {}
+    interface.start_calibration(
+        req, on_confirm_fn=_boom,
+        on_complete_fn=lambda r: (holder.update(r=r), done.set()))
+    assert done.wait(30)
+
+    interface.write_calibration.assert_not_called()
+    assert "gate confirmation failed" in holder["r"].error
+
+
+def test_gate_wait_is_not_charged_against_the_watchdog(interface, request_obj):
+    """Operator think time must not surface as a bogus timeout: the
+    watchdog is paused across the prompt."""
+    from dataclasses import replace
+    _make_fake_scan_workflow(interface, _LEFT, _RIGHT)
+    interface.write_calibration = MagicMock(
+        side_effect=lambda cmin, cmax, imin, imax: Calibration(
+            c_min=cmin, c_max=cmax, i_min=imin, i_max=imax, source="test"))
+
+    # Budget deliberately shorter than the operator's deliberation.
+    req = replace(request_obj, thresholds=_gate_failing_thresholds(),
+                  max_duration_sec=3)
+
+    def _slow_yes(rows):
+        time.sleep(4.0)
+        return True
+
+    done = threading.Event(); holder = {}
+    interface.start_calibration(
+        req, on_confirm_fn=_slow_yes,
+        on_complete_fn=lambda r: (holder.update(r=r), done.set()))
+    assert done.wait(60)
+
+    r = holder["r"]
+    assert r.consented_below_threshold is True
+    assert "max_duration_sec" not in r.error
+    interface.write_calibration.assert_called()

--- a/tests/test_calibration_workflow.py
+++ b/tests/test_calibration_workflow.py
@@ -353,3 +353,107 @@ def test_start_test_scan_uses_collector_sink_and_skip_default_storage(
         assert len(collector_sinks) >= 1, (
             f"Expected a _CalibrationCollectorSink in req.sinks; got {req.sinks}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Task 2: outcome wired through both workers (Refs #199)
+# ---------------------------------------------------------------------------
+
+def test_happy_path_outcome_is_passed(interface, request_obj):
+    from omotion.CalibrationWorkflow import CalibrationOutcome
+    _make_fake_scan_workflow(interface, _LEFT, _RIGHT)
+    interface.write_calibration = MagicMock(
+        side_effect=lambda cmin, cmax, imin, imax: Calibration(
+            c_min=cmin, c_max=cmax, i_min=imin, i_max=imax, source="test"))
+    done = threading.Event()
+    holder = {}
+    interface.start_calibration(
+        request_obj, on_complete_fn=lambda r: (holder.update(r=r), done.set()))
+    assert done.wait(30)
+    assert holder["r"].outcome is CalibrationOutcome.PASSED
+
+
+def test_cancel_outcome_is_canceled_not_timed_out(interface, request_obj):
+    """Regression for the old finally-block back-fill that stamped ANY
+    stop_evt as 'exceeded max_duration_sec' when the canceled flag hadn't
+    been picked up by a phase boundary yet."""
+    if not _have_fixtures():
+        pytest.skip("fixture CSVs missing")
+
+    from omotion.CalibrationWorkflow import CalibrationOutcome
+
+    # (mirror the existing test_cancel_during_phase_1 setup, then:)
+    sw = interface.scan_workflow
+    started = threading.Event()
+    cancel_called = threading.Event()
+
+    def _slow_scan(req):
+        sw._running = True
+        sw._last_scan_error = None
+        sw._last_scan_canceled = False
+
+        def _run():
+            started.set()
+            cancel_called.wait(timeout=5.0)
+            sw._last_scan_canceled = True
+            sw._running = False
+
+        threading.Thread(target=_run, daemon=True).start()
+        return True
+
+    sw.start_scan = _slow_scan
+    sw.await_complete = lambda *, timeout_sec=None: (
+        time.sleep(min(0.1, timeout_sec)) if timeout_sec else None
+    )
+    sw.cancel_scan = MagicMock(side_effect=lambda **kw: cancel_called.set())
+    interface.write_calibration = MagicMock()
+
+    # ... start_calibration, cancel mid-phase-1, wait for completion ...
+    done = threading.Event()
+    holder = {}
+    interface.start_calibration(
+        request_obj,
+        on_complete_fn=lambda r: (holder.update(r=r), done.set()),
+    )
+    assert started.wait(timeout=5.0)
+    interface.cancel_calibration()
+    assert done.wait(timeout=15.0)
+    assert holder["r"].outcome is CalibrationOutcome.CANCELED
+    assert "max_duration_sec" not in holder["r"].error
+
+
+def test_watchdog_timeout_outcome_is_timed_out(interface, request_obj):
+    from dataclasses import replace
+    from omotion.CalibrationWorkflow import CalibrationOutcome
+    # A fake scan workflow that never completes, and a 1-second watchdog.
+    req = replace(request_obj, max_duration_sec=1)
+
+    # (fake start_scan sets running=True and never flips it back; cancel_scan
+    #  flips running=False so _run_subscan_capture's poll loop exits)
+    sw = interface.scan_workflow
+
+    def _never_completing_scan(r):
+        sw._running = True
+        sw._last_scan_error = None
+        sw._last_scan_canceled = False
+        return True
+
+    def _fake_cancel_scan(**kw):
+        sw._running = False
+        sw._last_scan_canceled = True
+
+    sw.start_scan = _never_completing_scan
+    sw.cancel_scan = MagicMock(side_effect=_fake_cancel_scan)
+    sw.await_complete = lambda *, timeout_sec=None: (
+        time.sleep(min(0.05, timeout_sec)) if timeout_sec else None
+    )
+    interface.write_calibration = MagicMock()
+
+    # ... start_calibration(req, ...), wait ...
+    done = threading.Event()
+    holder = {}
+    interface.start_calibration(
+        req, on_complete_fn=lambda r: (holder.update(r=r), done.set()))
+    assert done.wait(timeout=15.0)
+    assert holder["r"].outcome is CalibrationOutcome.TIMED_OUT
+    assert "max_duration_sec" in holder["r"].error


### PR DESCRIPTION
Refs #199. App-side companion PR: OpenwaterHealth/openmotion-bloodflow-app#413.

## What

1. **`CalibrationOutcome` enum** (`passed / failed / canceled / timed_out / error`) + pure `_resolve_outcome()` resolver, exported from `omotion`. Both workers stamp an authoritative `outcome` on `CalibrationResult` / `TestScanResult` — consumers no longer guess from the `ok/passed/canceled` boolean triple, which couldn't distinguish a watchdog timeout from an operator cancel at all.
2. **Watchdog `timed_out` flag** — the `max_duration_sec` watchdog is now distinguishable from `cancel_calibration()`. Fixes the latent bug where the `finally` back-fill stamped *any* unconsumed stop-event as `exceeded max_duration_sec`, and conversely where a timeout whose stop-event was consumed at a phase boundary reported a generic "canceled during …".
3. **String-matched cancel detection removed** — `if "canceled" in flash_err` replaced with a direct `stop_evt` check (both workers).
4. **Pre-write gate (new phase 2.5)** — see below. The console is no longer written speculatively.
5. **EEPROM rollback, now keyed on consent** — retained only for failures the operator never authorised.

## The pre-write gate

Phase 3 wrote the computed calibration to console EEPROM *before* the validation scan could judge it, so **every failing run destroyed the previous calibration and then restored it from a copy.** Rollback made that survivable but not correct: the console was still mutated on the way through, and a restore that itself failed (USB drop mid-write) left the unvalidated calibration in place with nothing to put back.

New **phase 2.5** evaluates the calibration scan's own mean and contrast before anything is written:

```
scan 1 → compute → mean/contrast gate
                     ├─ pass → write → scan 2 → verdict     (unchanged)
                     └─ fail → on_confirm_fn
                                ├─ approve → write → scan 2 → verdict
                                └─ decline → abort, EEPROM never touched
```

**Why mean/contrast can be judged a scan early:** both are calibration-independent — mean is the raw pixel average, contrast is speckle std/mean — so applying the newly computed calibration cannot change them. A camera too dim at phase 1 is still too dim at validation. BFI/BVI are deliberately excluded (`evaluate_gate_passed`): they *are* the calibrated quantities and only become meaningful once the calibration is applied, which is exactly what the validation scan is for. Ambient-dark is excluded too — its criterion is defined against validation-scan darks (#122).

`on_confirm_fn` is a new optional `start_calibration` handler, called on the worker thread with the measured rows so a UI can show what missed rather than prompting blind.

- **No handler supplied → abort without writing.** The conservative default: unattended callers (HIL suites, scripts) leave the console alone rather than silently writing a below-threshold calibration.
- A **raising** handler is treated as a decline — a broken UI callback must not write EEPROM by accident.
- The **watchdog is paused across the prompt**, so operator think time isn't charged against `max_duration_sec` (otherwise a slow answer surfaced as a bogus timeout). Because the handler blocks the worker, it owns its own deadline — documented on `start_calibration`.
- `cancel_calibration()` stays responsive: the stop event is re-checked the moment the handler returns.

Consent is recorded as `CalibrationResult.consented_below_threshold` and as a `consented_below_threshold` manifest key.

**Rollback is now consent-keyed** — it fires only when the outcome isn't `PASSED` *and* the operator never consented. In practice that's a BFI/BVI or ambient failure at validation: precisely the cases the gate cannot judge. Undoing a consented write would discard exactly what was approved.

## Backward compat

- `ok/passed/canceled/error` unchanged; new dataclass fields appended with defaults.
- `outcome` defaults to **`None`** (not a member) so legacy constructions fall back cleanly to the boolean triple in consumers — an `ERROR` default misreported healthy legacy results (caught in review; regression-tested).
- `on_confirm_fn` is optional and keyword-only; existing callers are unaffected apart from the gate's conservative no-handler abort.
- `write_result_json`'s new params are defaulted.

## Tests

`tests/test_calibration_outcome.py` (9) + `tests/test_calibration_workflow.py` (+11: outcome happy-path/cancel/timeout, rollback on FAIL / not on PASS / best-effort failure, and 6 gate tests — no-handler, decline, consent-keeps-the-write, silent on a good scan, raising handler, watchdog-not-charged-for-think-time) + `tests/test_calibration_workflow_compute.py`. **783 passed** with hardware markers deselected.

Two pre-existing rollback tests forced failure via `min_mean=1e9`, which the gate now catches first — repointed at BFI so they still exercise the path they were written for.

## Notes for release

Publish to PyPI before tagging a bloodflow-app release. The app consumes `outcome` through a compat shim, so an app built against a pre-outcome SDK degrades gracefully rather than breaking — but note the **gate is not available without this PR**, so such a build keeps the old write-then-validate behavior.

⚠️ **Behavior changes to hand-validate on the bench:**
- A below-threshold calibration scan now stops and asks *before* writing; declining leaves the console untouched.
- A failing run no longer transiently overwrites the previous calibration at all.
- A consented run keeps its write despite a FAILED verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
