### PR TITLE
fix: tec_good is the TEC_TRIP result, not TMPGD — add tec_known so a failed read isn't a trip

### DIFF
--- a/docs/ConsoleTelemetry.md
+++ b/docs/ConsoleTelemetry.md
@@ -54,7 +54,15 @@ Raw ADC voltages returned by `MotionConsole.tec_status()` → `(vout, temp_set, 
 | `tec_set_raw` | `float` (V) | IN2P / TEMPSET | Setpoint bridge voltage; converted to target temperature (°C) in the app |
 | `tec_curr_raw` | `float` (V) | V_itec | TEC current monitor voltage; converted to amps via `(v − 0.5·VREF) / (25·R_s)` |
 | `tec_volt_raw` | `float` (V) | V_vtec | TEC voltage monitor; converted via `(v − 0.5·VREF) × 4` |
-| `tec_good` | `bool` | TMPGD pin | `True` when `\|OUT1 − IN2P\| < 100 mV` (temperature settled to setpoint) |
+| `tec_good` | `bool` | `TecStats.tec_status` | **TEC over-temp trip result**, *not* a TMPGD "settled to setpoint" pin. `False` = tripped. Only meaningful when `tec_known` is `True` |
+| `tec_known` | `bool` | derived | `False` until `_read_tec` completes one successful read. Gate on this before treating `tec_good == False` as a trip |
+
+`tec_good` comes from console FW `tec_trip_evaluate()` (`Core/Src/uart_comms.c`), the only writer of `TecStats.tec_status`. It clears the bit when the TEC sense voltage crosses `TEC_TRIP_VALUE`, calls `Trigger_Safety_Disconnect()`, pushes a `TEC trip point reached` system-error message, and re-arms only after 200 consecutive clean polls. So `tec_good == False` is a **laser safety shutdown**, not a "still warming up" indication.
+
+Two caveats for consumers:
+
+- **Gate on `tec_known`.** `tec_good` defaults to `False`, which is indistinguishable from "tripped", and `_read_tec` assigns it only on a successful read — so a failed poll would otherwise report a trip that never happened. Same trap `safety_known` fixes for the EE/OPT interlock ([bloodflow-app#107](https://github.com/OpenwaterHealth/openmotion-bloodflow-app/issues/107)); see [#206](https://github.com/OpenwaterHealth/openmotion-sdk/issues/206).
+- **A steady `True` is not proof the trip is armed.** The trip is disarmed when `TEC_TRIP_VALUE == 0.0` (console FW never applied its settings), and firmware then reports `tec_status = true` unconditionally.
 
 ### PDU monitor
 
@@ -76,6 +84,8 @@ Polled from two I2C channels on mux 1, device `0x41`, register `0x24`.
 | `safety_se` | `int` (raw byte) | ch 6 | SE interlock raw register byte |
 | `safety_so` | `int` (raw byte) | ch 7 | SO interlock raw register byte |
 | `safety_ok` | `bool` | derived | `True` when `(safety_se & 0x0F) == 0` and `(safety_so & 0x0F) == 0` — both low nibbles clear means the interlock is not tripped |
+| `safety_known` | `bool` | derived | `False` until the interlock chip has actually answered. Distinguishes "no data, defaulted to OK" from "chip responded, faults absent" |
+| `safety_faults` | `List[str]` | derived | Decoded fault labels (peak-current / pulse / rate) across both channels, de-duplicated; empty when clear. Only meaningful when `safety_known` is `True` |
 
 ### Read health
 

--- a/omotion/ConsoleTelemetry.py
+++ b/omotion/ConsoleTelemetry.py
@@ -81,7 +81,27 @@ class ConsoleTelemetry:
     tec_set_raw: float = 0.0        # IN2P / setpoint voltage (→ target temp)
     tec_curr_raw: float = 0.0       # V_itec (→ TEC current)
     tec_volt_raw: float = 0.0       # V_vtec (→ TEC voltage)
-    tec_good: bool = False          # TMPGD pin (abs(OUT1-IN2P) < 100 mV)
+    # TecStats.tec_status from console FW — the TEC over-temp TRIP result, NOT
+    # the TMPGD comparator pin this comment used to claim. tec_trip_evaluate()
+    # (console-fw Core/Src/uart_comms.c) is the only writer of that field: it
+    # clears the bit when the TEC sense voltage crosses TEC_TRIP_VALUE, calls
+    # Trigger_Safety_Disconnect(), and re-arms only after 200 consecutive clean
+    # polls. So False means the console has tripped and shut the laser down —
+    # a safety event, not "temperature has not settled to setpoint yet".
+    # Only meaningful when tec_known is True. Caveat: the trip is disarmed when
+    # TEC_TRIP_VALUE == 0.0 (settings never applied), and firmware then always
+    # reports True — a steady True is not proof the trip is armed. See #206.
+    # The default stays False (unlike safety_ok, which defaults True): an
+    # ungated legacy consumer then errs toward "laser is down" on a failed
+    # poll rather than toward "keep firing".
+    tec_good: bool = False
+    # tec_known is False until _read_tec has completed one successful read on
+    # this poll. tec_good defaults are indistinguishable from "tripped", so
+    # consumers treating tec_good as a safety condition MUST gate on this
+    # rather than reporting a laser shutdown that was never measured. Same
+    # reasoning as safety_known below (bloodflow-app#107); see also
+    # OpenwaterHealth/openmotion-test-app#89.
+    tec_known: bool = False
 
     # --- PDU monitor (16 raw counts + 16 calibrated volts) ---
     pdu_raws: List[int] = field(default_factory=list)
@@ -373,6 +393,10 @@ class ConsoleTelemetryPoller:
         snap.tec_curr_raw = float(tec_curr)
         snap.tec_volt_raw = float(tec_volt)
         snap.tec_good = bool(tec_good)
+        # Only now is tec_good a measurement rather than the dataclass default.
+        # tec_status() raises on any failure, so an unset tec_known means the
+        # console never answered — see the field comment on ConsoleTelemetry.
+        snap.tec_known = True
 
     def _read_pdu(self, snap: ConsoleTelemetry) -> None:
         pdu = self._console.read_pdu_mon()

--- a/omotion/MotionConsole.py
+++ b/omotion/MotionConsole.py
@@ -110,6 +110,9 @@ class TelemetrySample:
     t2: float
     t3: float
     tec_adc: tuple[int, int, int, int]
+    # TecStats.tec_status — the TEC over-temp trip result (False = tripped,
+    # laser shut down by firmware), not a TMPGD settled-to-setpoint pin.
+    # See tec_status() below and issue #206.
     tec_good: bool
 
     def __str__(self):
@@ -1909,6 +1912,20 @@ class MotionConsole(SignalWrapper):
     def tec_status(self) -> Tuple[str, str, str, str, bool]:
         """
         Get TEC status: (voltage, Temperature Setpoint, TEC Current, TEC Voltage, TEC Good)
+
+        ``tec_good`` is ``TecStats.tec_status`` from console FW — the TEC
+        over-temp **trip** result, not a TMPGD "temperature settled" pin.
+        ``tec_trip_evaluate()`` (console-fw ``Core/Src/uart_comms.c``) is its
+        only writer: it clears the bit when the TEC sense voltage crosses
+        ``TEC_TRIP_VALUE``, opens the safety disconnect, and re-arms only after
+        200 consecutive clean polls. ``False`` therefore means the console has
+        tripped and shut the laser down. Note the trip is disarmed when
+        ``TEC_TRIP_VALUE == 0.0``, and firmware then always reports ``True``.
+
+        This method raises rather than returning a sentinel on failure, so a
+        caller can never mistake a failed read for a trip; pollers that cache
+        the value should track "was it ever read" separately (see
+        ``ConsoleTelemetry.tec_known``). See issue #206.
 
         Returns:
             tuple: (volt, temp_set, tec_curr, tec_volt, tec_good)

--- a/tests/test_console_telemetry_unit.py
+++ b/tests/test_console_telemetry_unit.py
@@ -1,4 +1,5 @@
 import logging
+from types import SimpleNamespace
 
 from omotion.ConsoleTelemetry import ConsoleTelemetry, ConsoleTelemetryPoller
 
@@ -70,6 +71,79 @@ def test_read_safety_unknown_leaves_faults_empty():
     poller._read_safety(snap)
     assert snap.safety_known is False
     assert snap.safety_faults == []
+
+
+class _FakeConsoleForTec:
+    """Console stub whose tec_status() either answers or raises."""
+
+    def __init__(self, result=None, exc: Exception | None = None) -> None:
+        self._result = result
+        self._exc = exc
+        self.calls = 0
+
+    def is_connected(self):
+        return True
+
+    def tec_status(self):
+        self.calls += 1
+        if self._exc is not None:
+            raise self._exc
+        return self._result
+
+    def read_pdu_mon(self):
+        return SimpleNamespace(raws=[], volts=[])
+
+    def read_i2c_packet(self, mux_index, channel, device_addr, reg_addr, read_len):
+        return b"\x00" * read_len, read_len
+
+    def get_lsync_pulsecount(self):
+        return 0
+
+
+def test_tec_known_defaults_false_on_fresh_snapshot():
+    # tec_good defaults False, which is indistinguishable from "tripped" --
+    # tec_known is what tells a consumer the value was never measured (#206).
+    snap = ConsoleTelemetry()
+    assert snap.tec_known is False
+    assert snap.tec_good is False
+
+
+def test_read_tec_sets_known_on_successful_read():
+    console = _FakeConsoleForTec(result=("1.0", "0.5", "0.5", "25.0", True))
+    poller = ConsoleTelemetryPoller(console)
+    snap = ConsoleTelemetry()
+
+    poller._read_tec(snap)
+
+    assert snap.tec_known is True
+    assert snap.tec_good is True
+    assert snap.tec_v_raw == 1.0
+    assert snap.tec_set_raw == 0.5
+
+
+def test_read_tec_reports_trip_as_known_false_good():
+    # A real trip: firmware answered and cleared the bit.
+    console = _FakeConsoleForTec(result=("1.0", "0.5", "0.5", "25.0", False))
+    poller = ConsoleTelemetryPoller(console)
+    snap = ConsoleTelemetry()
+
+    poller._read_tec(snap)
+
+    assert snap.tec_known is True
+    assert snap.tec_good is False
+
+
+def test_failed_tec_read_leaves_known_false():
+    # tec_status() raises -> _read_all catches, read_ok goes False, and the
+    # snapshot must NOT look like a trip the console never reported.
+    console = _FakeConsoleForTec(exc=RuntimeError("UART timeout"))
+    poller = ConsoleTelemetryPoller(console)
+
+    snap = poller._read_all()
+
+    assert snap.read_ok is False
+    assert "UART timeout" in (snap.error or "")
+    assert snap.tec_known is False
 
 
 from omotion.ConsoleTelemetry import PdcSample, PDC_MA_PER_LSB


### PR DESCRIPTION
Refs #206

## What

Two related defects on `ConsoleTelemetry.tec_good`.

**1. The comment described the wrong hardware.**

```python
tec_good: bool = False          # TMPGD pin (abs(OUT1-IN2P) < 100 mV)
```

`tec_trip_evaluate()` (console-fw `Core/Src/uart_comms.c:307`) is the **only** writer of `TecStats.tec_status` — it clears the bit when the TEC sense voltage crosses `TEC_TRIP_VALUE`, calls `Trigger_Safety_Disconnect()`, pushes a `TEC trip point reached` system-error message, and re-arms only after 200 consecutive clean polls. (`uart_comms.c:440` just copies `sample.tec_status` into `last_tec_stats`.) So `tec_good == False` is a **laser safety shutdown**, not "temperature has not settled to setpoint yet". Corrected on the dataclass field, on `MotionConsole.tec_status()`'s docstring, on `TelemetrySample.tec_good`, and in `docs/ConsoleTelemetry.md`.

Same stale comment was fixed on the app side in openmotion-test-app#89 / openmotion-test-app#90.

**2. A failed read was indistinguishable from a trip.**

`tec_good` defaults to `False` and `_read_tec` assigns it only on success — so when `tec_status()` throws, `_read_all` returns a snapshot reporting a shutdown that never happened. Added `tec_known: bool = False`, set `True` in `_read_tec` after a successful read, with the field comment telling consumers to gate on it. Exactly the trap `safety_known` fixes for the EE/OPT interlock (bloodflow-app#107).

## Decisions worth a second pair of eyes

- **`tec_good` keeps its `False` default** rather than flipping to `True` to match `safety_ok`. A consumer that hasn't been updated to gate on `tec_known` then errs toward "laser is down" on a failed poll instead of toward "keep firing". Stated in the field comment so the asymmetry with `safety_ok` doesn't read as an oversight.
- **The telemetry CSV schema is unchanged.** `tec_known` is not added to `_TELEMETRY_HEADERS` in `ScanWorkflow.py` — `safety_known` isn't there either, and adding a column would break `scripts/plot_telemetry.py` and existing parsers for no current consumer. Easy to add later if a log-analysis need appears.
- Also filled in the two missing `safety_known` / `safety_faults` rows in the docs field table while correcting the neighboring TEC table.

## Test

- 4 new unit tests in `tests/test_console_telemetry_unit.py` mirroring the existing `safety_known` coverage: default snapshot, successful read, real trip (`known=True, good=False`), and a throwing `tec_status()` (`read_ok=False`, `tec_known` stays `False`).
- `pytest tests/test_console_telemetry_unit.py` → 13 passed.
- `pytest tests/ -m "not console and not sensor and not destructive"` → **766 passed, 29 skipped**. (Run with `--ignore=tests/test_console_pacing.py`, an untracked local file on this bench that references a `MotionConsole._parse_version_tuple` method not present on `next` — pre-existing, unrelated to this change.)

No hardware needed to verify; purely additive to the snapshot dataclass, so existing readers of `tec_good` are unaffected.

## Downstream

openmotion-test-app can drop its local `_tec_trip_known` flag in `motion_connector.py` and read `snap.tec_known` once this ships. bloodflow-app is protected if it ever consumes `tec_good` as a safety condition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
