### PR TITLE
fix: refuse the scan-db keystore on macOS, and pin the backend by module

### DIFF
--- a/omotion/db_key.py
+++ b/omotion/db_key.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import logging
 import secrets
+import sys
 from pathlib import Path
 
 logger = logging.getLogger("omotion.db_key")
@@ -57,7 +58,12 @@ def _keyring():
     that forgets it fails at the first keystore touch. Mirrors how ``db_open``
     handles the ``sqlcipher3`` import — the message has to name the fix, because
     the place this surfaces is a packaged clinical app on a bench.
+
+    Also the single chokepoint where macOS is refused: every keystore touch in
+    this module (``_assert_backend``, ``get_key``, ``import_key``, and
+    ``export_key`` via ``get_key``) routes through here.
     """
+    _assert_keystore_platform()
     try:
         import keyring
     except ImportError as exc:  # pragma: no cover - exercised via monkeypatch
@@ -71,15 +77,57 @@ def _keyring():
     return keyring
 
 
+def _assert_keystore_platform() -> None:
+    """Refuse every keystore access on macOS.
+
+    macOS is a research-only platform for this product — it is never shipped in
+    clinical mode, so the encrypted scan DB (and therefore the keystore) has no
+    role there. The macOS Keychain would be a technically adequate backend, but
+    accepting it would mean the encryption path silently exists on a platform
+    that is not validated for clinical use. Reaching the keystore on darwin is
+    therefore a build/configuration error, and a loud one is better than a
+    working-but-unvalidated encryption path.
+
+    A macOS *research* build never gets here: ``require_encryption()`` is False,
+    so ``db_open`` takes the plaintext branch without asking for a key.
+    """
+    if sys.platform == "darwin":
+        raise EncryptionUnavailable(
+            "the scan-database keystore is not available on macOS. macOS builds "
+            "are research-only and are never validated for clinical mode, so the "
+            "encryption policy must stay off (require_encryption=False) there. "
+            "Reaching the keystore on macOS means something enabled the clinical "
+            "encryption path on an unsupported platform — fix the build config "
+            "rather than the keystore."
+        )
+
+
+# The OS-owned keystores approved to hold the scan-db key, by backend module.
+# Windows Credential Manager is the only one: it is hardware/OS-protected and
+# per-user, and Windows is the only platform shipped in clinical mode. The
+# macOS Keychain is deliberately absent — see _assert_keystore_platform, which
+# refuses darwin outright and fires before this check is ever reached.
+#
+# Everything else is rejected — most importantly ``keyrings.alt`` (plaintext or
+# obfuscated files), ``keyring.backends.fail`` (no keystore at all) and
+# ``keyring.backends.chainer`` (defers to whatever it discovered, so it cannot
+# be verified up front). Matching on the module rather than the class name
+# matters: a plaintext backend is free to call its class ``WinVaultKeyring``,
+# and a name-only check would wave it through.
+_SUPPORTED_BACKENDS = {
+    "keyring.backends.Windows": "Windows Credential Manager",
+}
+
+
 def _assert_backend() -> None:
     keyring = _keyring()
 
     kr = keyring.get_keyring()
-    # Windows Credential Manager is the supported clinical backend.
-    if "WinVault" not in type(kr).__name__ and "Windows" not in type(kr).__module__:
+    if type(kr).__module__ not in _SUPPORTED_BACKENDS:
+        supported = ", ".join(sorted(_SUPPORTED_BACKENDS.values()))
         raise EncryptionUnavailable(
-            "encryption policy requires the Windows Credential Manager keyring, "
-            f"got {type(kr).__module__}.{type(kr).__name__}"
+            f"encryption policy requires an OS keystore ({supported}), got "
+            f"{type(kr).__module__}.{type(kr).__name__}"
         )
 
 

--- a/tests/test_db_key.py
+++ b/tests/test_db_key.py
@@ -4,6 +4,7 @@ None of these touch the real OS keyring: policy tests are pure, and key
 get/create/export tests monkeypatch keyring.get_password/set_password.
 """
 import importlib
+import sys
 
 import pytest
 
@@ -16,6 +17,18 @@ def _reset_policy():
     importlib.reload(db_key)
     yield
     importlib.reload(db_key)
+
+
+@pytest.fixture(autouse=True)
+def _non_darwin_platform(monkeypatch):
+    """Pin sys.platform away from darwin for the whole module.
+
+    db_key now refuses every keystore access on macOS, so without this the
+    keystore tests below would all fail when the suite is run on a Mac — the
+    result would depend on the developer's laptop, not on the code. The
+    macOS-refusal tests set it back to "darwin" themselves.
+    """
+    monkeypatch.setattr(sys, "platform", "win32")
 
 
 # --------------------------------------------------------------------------
@@ -104,26 +117,132 @@ def test_get_key_create_true_is_idempotent(fake_keyring):
 # Backend pinning — the real _assert_backend (not stubbed)
 # --------------------------------------------------------------------------
 
-def test_set_policy_true_rejects_non_windows_backend(monkeypatch):
+def _fake_backend(monkeypatch, module: str, name: str):
+    """Install a stand-in keyring backend reporting the given module + class name.
+
+    The real backends can't be instantiated off-platform, and the identity
+    _assert_backend pins on is exactly (module, class name) — so faking those
+    two attributes is the whole contract under test.
+    """
     import keyring
 
-    class _PlaintextKeyring:  # name lacks 'WinVault'; module lacks 'Windows'
-        pass
+    kr = type(name, (), {})()
+    type(kr).__module__ = module
+    monkeypatch.setattr(keyring, "get_keyring", lambda: kr)
+    return kr
 
-    monkeypatch.setattr(keyring, "get_keyring", lambda: _PlaintextKeyring())
+
+def test_set_policy_true_accepts_winvault_backend(monkeypatch):
+    _fake_backend(monkeypatch, "keyring.backends.Windows", "WinVaultKeyring")
+    db_key.set_policy(require_encryption=True)  # must not raise
+    assert db_key.require_encryption() is True
+
+
+def test_set_policy_true_rejects_macos_keychain_backend(monkeypatch):
+    """Even the real macOS Keychain is refused: macOS is research-only, so the
+    encryption path must not quietly work on an unvalidated platform."""
+    monkeypatch.setattr(sys, "platform", "darwin")
+    _fake_backend(monkeypatch, "keyring.backends.macOS", "Keyring")
     with pytest.raises(db_key.EncryptionUnavailable):
         db_key.set_policy(require_encryption=True)
 
 
-def test_set_policy_true_accepts_winvault_backend(monkeypatch):
-    import keyring
+def test_set_policy_true_rejects_unknown_backend(monkeypatch):
+    _fake_backend(monkeypatch, "keyrings.alt.file", "PlaintextKeyring")
+    with pytest.raises(db_key.EncryptionUnavailable):
+        db_key.set_policy(require_encryption=True)
 
-    class WinVaultKeyring:  # name contains 'WinVault'
-        pass
 
-    monkeypatch.setattr(keyring, "get_keyring", lambda: WinVaultKeyring())
-    db_key.set_policy(require_encryption=True)  # must not raise
-    assert db_key.require_encryption() is True
+def test_set_policy_true_rejects_plaintext_backend_impersonating_winvault(monkeypatch):
+    """A class *named* like the Windows backend but living in keyrings.alt must
+    still be rejected — keyrings.alt stores secrets in plaintext, so accepting
+    it would silently void the at-rest guarantee the policy exists to enforce."""
+    _fake_backend(monkeypatch, "keyrings.alt.file", "WinVaultKeyring")
+    with pytest.raises(db_key.EncryptionUnavailable):
+        db_key.set_policy(require_encryption=True)
+
+
+def test_set_policy_true_rejects_fail_backend(monkeypatch):
+    # keyring's fail backend = "no usable keystore on this machine"
+    _fake_backend(monkeypatch, "keyring.backends.fail", "Keyring")
+    with pytest.raises(db_key.EncryptionUnavailable):
+        db_key.set_policy(require_encryption=True)
+
+
+def test_set_policy_true_rejects_chainer_backend(monkeypatch):
+    """The chainer delegates to whatever it found, so it can't be verified up
+    front — the point of asserting at startup is to know, not to hope."""
+    _fake_backend(monkeypatch, "keyring.backends.chainer", "ChainerBackend")
+    with pytest.raises(db_key.EncryptionUnavailable):
+        db_key.set_policy(require_encryption=True)
+
+
+def test_backend_rejection_names_the_offending_backend(monkeypatch):
+    # the message is read off a bench console; it has to say what was found
+    _fake_backend(monkeypatch, "keyrings.alt.file", "PlaintextKeyring")
+    with pytest.raises(db_key.EncryptionUnavailable) as exc:
+        db_key.set_policy(require_encryption=True)
+    assert "keyrings.alt.file.PlaintextKeyring" in str(exc.value)
+
+
+# --------------------------------------------------------------------------
+# macOS is refused outright — research-only platform, never clinical
+# --------------------------------------------------------------------------
+
+@pytest.fixture
+def _darwin(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "darwin")
+
+
+def test_get_key_is_refused_on_macos(_darwin, fake_keyring):
+    # fake_keyring proves the refusal is the platform, not a missing backend
+    with pytest.raises(db_key.EncryptionUnavailable):
+        db_key.get_key(create=True)
+
+
+def test_get_key_without_create_is_refused_on_macos(_darwin, fake_keyring):
+    # must be EncryptionUnavailable (wrong platform), NOT EncryptionKeyMissing
+    # (right platform, absent key) — the two point at different fixes
+    with pytest.raises(db_key.EncryptionUnavailable):
+        db_key.get_key(create=False)
+
+
+def test_import_key_is_refused_on_macos(_darwin, fake_keyring):
+    # the path deliberately does not exist: the platform refusal must land
+    # before any file is read, so the escrow CLI can't half-run on macOS
+    with pytest.raises(db_key.EncryptionUnavailable):
+        db_key.import_key("no_such_key_file.txt")
+
+
+def test_export_key_is_refused_on_macos(_darwin, fake_keyring):
+    # likewise nothing may be written to the target path
+    with pytest.raises(db_key.EncryptionUnavailable):
+        db_key.export_key("no_such_dir/out.txt")
+
+
+def test_macos_provisions_nothing_before_refusing(_darwin, fake_keyring):
+    """The refusal must land before any keystore write — a half-provisioned key
+    on an unsupported platform is worse than a clean failure."""
+    with pytest.raises(db_key.EncryptionUnavailable):
+        db_key.get_key(create=True)
+    assert fake_keyring._store == {}
+
+
+def test_macos_refusal_names_the_platform_and_the_fix(_darwin, fake_keyring):
+    # read off a bench console: it has to say macOS, and what to change
+    with pytest.raises(db_key.EncryptionUnavailable) as exc:
+        db_key.get_key(create=True)
+    message = str(exc.value)
+    assert "macOS" in message
+    assert "require_encryption=False" in message
+
+
+def test_macos_research_build_still_boots(_darwin):
+    """The whole point of the refusal: policy-off on macOS must stay silent.
+    A research build is the only supported macOS configuration, so it cannot be
+    collateral damage of refusing the clinical path."""
+    db_key.set_policy(require_encryption=False)  # must not raise
+    assert db_key.require_encryption() is False
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Refs #209

> **Direction changed after review.** The first revision of this branch *accepted* the macOS Keychain as a clinical backend. Per Ethan: macOS will never be shipped in clinical mode, so the keystore should be refused there outright rather than made to work. Rewritten accordingly.

## What

Two changes to `omotion/db_key.py`:

**1. Refuse macOS outright.** `_assert_keystore_platform()` raises `EncryptionUnavailable` on darwin, called from `_keyring()` — the single chokepoint every keystore touch routes through (`_assert_backend`, `get_key`, `import_key`, and `export_key` via `get_key`).

**2. Pin the backend by module, not class name.** The old check was `"WinVault" not in type(kr).__name__ and "Windows" not in type(kr).__module__`. A plaintext backend defeats that by naming its class `WinVaultKeyring` — and `keyrings.alt` stores secrets in plaintext, so it would silently void the at-rest guarantee the policy exists to enforce. Now matched against an explicit module allowlist (Windows Credential Manager only), which also rejects `keyring.backends.fail` (no keystore) and `keyring.backends.chainer` (defers to whatever it discovered, so it can't be verified up front).

## Why refuse rather than support

The Keychain is a technically adequate backend — OS-owned, per-user, same threat model as Credential Manager. But accepting it means the clinical encryption path silently works on a platform that isn't validated for clinical use. A loud failure is the better outcome: reaching the keystore on macOS means something enabled the clinical path on an unsupported platform, and the fix belongs in the build config.

The refusal deliberately lands **before** any keystore write or file read, so nothing can be half-provisioned on an unsupported platform (covered by `test_macos_provisions_nothing_before_refusing`).

## macOS research builds are unaffected

`require_encryption()` is False, so `db_open` takes the plaintext branch and never asks for a key — `_keyring()` is unreachable. Pinned by `test_macos_research_build_still_boots`.

## Testing

`tests/test_db_key.py` — 33 passed. With `test_db_open.py` + `test_db_migrate.py` — 54 passed.

An autouse fixture pins `sys.platform` away from darwin for the module, so the keystore tests don't start failing when the suite is run on a Mac; the macOS tests set it back themselves.

## ⚠️ Blocks on an app-side change

The bloodflow app's macOS DMG currently bundles `config/app_config.json` with `clinicalMode: true` (`build_macos.sh` bundles `config/` wholesale and never flips the variant, unlike `scripts/build_common.ps1` on Windows). That drives `require_encrypted_db=True` → `set_policy(True)` → the keystore.

That build **already fails at startup on `next` today** for the same reason (the old check rejects `keyring.backends.macOS` too); this PR only makes the error message say why. The macOS build needs to be forced to research mode — tracked separately in the app repo.