### PR TITLE
feat: EV-sign WinUSB driver MSI + catalogs via eSigner CKA; retire self-signed Root install

### DIFF
--- a/.github/workflows/driver-msi.yml
+++ b/.github/workflows/driver-msi.yml
@@ -22,13 +22,58 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Verify signing secrets are present
+      # Preferred: SSL.com EV cert via eSigner CKA (sdk#216). The private key
+      # stays in SSL.com's cloud HSM; CKA registers a CNG provider and loads
+      # the cert into Cert:\CurrentUser\My so signtool signs by thumbprint
+      # (exported as CODESIGN_THUMBPRINT, which flips build_driver_msi.ps1
+      # into EV mode). Falls back to the legacy self-signed PFX with a loud
+      # warning while the ES_* secrets don't exist, so PR CI stays green.
+      - name: Set up signing (eSigner CKA, legacy PFX fallback)
+        shell: pwsh
+        working-directory: ${{ github.workspace }}
         env:
+          ES_USERNAME: ${{ secrets.ES_USERNAME }}
+          ES_PASSWORD: ${{ secrets.ES_PASSWORD }}
+          ES_TOTP_SECRET: ${{ secrets.ES_TOTP_SECRET }}
+          # repo variable ES_MODE=sandbox targets SSL.com's sandbox
+          # environment for pipeline testing (needs sandbox credentials)
+          ES_MODE: ${{ vars.ES_MODE || 'product' }}
           PFX_B64: ${{ secrets.OW_DRIVER_PFX_BASE64 }}
-          PFX_PW: ${{ secrets.OW_DRIVER_PFX_PASSWORD }}
         run: |
-          if (-not $env:PFX_B64) { throw "Secret OW_DRIVER_PFX_BASE64 is not set" }
-          if (-not $env:PFX_PW)  { throw "Secret OW_DRIVER_PFX_PASSWORD is not set" }
+          if ($env:ES_USERNAME -and $env:ES_PASSWORD -and $env:ES_TOTP_SECRET) {
+            $work = Join-Path $env:RUNNER_TEMP "esigner-cka"
+            New-Item -ItemType Directory -Force $work | Out-Null
+            Set-Location $work
+            Invoke-WebRequest -OutFile eSigner_CKA_Setup.zip "https://github.com/SSLcom/eSignerCKA/releases/download/v1.0.8/SSL.COM-eSigner-CKA_1.0.8.zip"
+            Expand-Archive -Force eSigner_CKA_Setup.zip
+            Move-Item -Destination "eSigner_CKA_Installer.exe" -Path "eSigner_CKA_Setup\*.exe"
+            $dir = Join-Path $env:USERPROFILE "eSignerCKA"
+            New-Item -ItemType Directory -Force $dir | Out-Null
+            Start-Process ".\eSigner_CKA_Installer.exe" -ArgumentList "/CURRENTUSER /VERYSILENT /SUPPRESSMSGBOXES /DIR=`"$dir`"" -Wait
+            # Post-install helpers from SSL.com's reference workflow; guarded
+            # because not every CKA build ships them (VC++ redists are already
+            # on the hosted runners).
+            foreach ($aux in @("$work\setup\vc_redist.x86.exe", "$work\setup\vc_redist.x64.exe")) {
+              if (Test-Path $aux) { Start-Process $aux -ArgumentList "/install /q" -Wait }
+            }
+            foreach ($aux in @("$dir\RegisterKSP.exe", "$dir\eSignerCSP.Config.exe")) {
+              if (Test-Path $aux) { & $aux | Out-Null }
+            }
+            & "$dir\eSignerCKATool.exe" config -mode $env:ES_MODE -user $env:ES_USERNAME -pass $env:ES_PASSWORD -totp $env:ES_TOTP_SECRET -key "$dir\master.key" -r
+            & "$dir\eSignerCKATool.exe" unload
+            & "$dir\eSignerCKATool.exe" load
+            $cert = Get-ChildItem Cert:\CurrentUser\My -CodeSigningCert | Select-Object -First 1
+            if (-not $cert) { throw "eSigner CKA loaded no code-signing certificate" }
+            Write-Host "EV signing as: $($cert.Subject)  [$($cert.Thumbprint)]"
+            "CODESIGN_THUMBPRINT=$($cert.Thumbprint)" >> $env:GITHUB_ENV
+          }
+          elseif ($env:PFX_B64) {
+            Write-Host "::warning::eSigner secrets not set — signing with the LEGACY self-signed PFX; do not ship this artifact"
+            [IO.File]::WriteAllBytes("$env:GITHUB_WORKSPACE\winusb-driver\OpenMotion_signing_cert.pfx", [Convert]::FromBase64String($env:PFX_B64))
+          }
+          else {
+            throw "no signing credentials: set ES_USERNAME/ES_PASSWORD/ES_TOTP_SECRET (eSigner) or OW_DRIVER_PFX_BASE64/OW_DRIVER_PFX_PASSWORD (legacy)"
+          }
 
       - name: Install WiX 5.0.2
         run: |
@@ -40,14 +85,9 @@ jobs:
       - name: Show WiX version
         run: wix --version
 
-      - name: Decode signing PFX from secret
-        env:
-          PFX_B64: ${{ secrets.OW_DRIVER_PFX_BASE64 }}
-        run: |
-          [IO.File]::WriteAllBytes("$PWD\OpenMotion_signing_cert.pfx", [Convert]::FromBase64String($env:PFX_B64))
-
       - name: Build and sign driver MSI
         env:
+          # legacy-fallback path only; ignored in EV mode
           OW_DRIVER_PFX_PASSWORD: ${{ secrets.OW_DRIVER_PFX_PASSWORD }}
         run: .\build_driver_msi.ps1 -AppResourcesZip ""
 

--- a/winusb-driver/Product.wxs
+++ b/winusb-driver/Product.wxs
@@ -1,10 +1,23 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Built two ways by build_driver_msi.ps1 (sdk#216):
+
+     EV mode (wix build -d EvSigned=1 — CI, the shipping variant): the cats
+     and MSI are signed by the SSL.com EV cert, whose chain is publicly
+     trusted, so the MSI installs the cert into TrustedPublisher ONLY (for
+     prompt-free pnputil driver staging) and additionally retires the old
+     self-signed "CN=Openwater WinUSB" cert from machines that trusted it.
+
+     Legacy mode (no define — local-dev fallback): self-signed cert, so the
+     MSI must install it into Root AND TrustedPublisher for the driver
+     packages to stage at all. Never ship this variant. -->
+
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs"
      xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util">
 
   <Package Name="OpenMotion WinUSB Driver"
            Manufacturer="Openwater"
-           Version="1.1.0"
+           Version="1.2.0"
            UpgradeCode="{F6F5B7B5-98B8-4E6D-9E68-4C7A8A0A1234}"
            Language="1033"
            Scope="perMachine"
@@ -66,7 +79,12 @@
       <ComponentRef Id="cmpCat3"/>
     </Feature>
 
-    <!-- QuietExec custom actions (WiX v4) -->
+    <!-- QuietExec custom actions (WiX v4).
+
+         TrustedPublisher is needed in BOTH modes: it is what lets pnputil
+         stage the driver packages without a publisher-confirmation prompt
+         (which, under msiexec's non-interactive custom action, would fail
+         the install rather than prompt). -->
     <SetProperty Id="InstallCertTrustedPublisher"
                  Value="&quot;[System32Folder]certutil.exe&quot; -f -addstore &quot;TrustedPublisher&quot; &quot;[#filCert]&quot;"
                  Before="InstallCertTrustedPublisher" Sequence="execute"/>
@@ -74,19 +92,22 @@
                   BinaryRef="Wix4UtilCA_$(sys.BUILDARCHSHORT)" DllEntry="WixQuietExec"
                   Execute="deferred" Impersonate="no" Return="check"/>
 
+<?ifndef EvSigned ?>
+    <!-- Legacy only: a self-signed cert has no trusted chain, so it must
+         also be planted in Root for the catalog signatures to validate. -->
     <SetProperty Id="InstallCertRoot"
                  Value="&quot;[System32Folder]certutil.exe&quot; -f -addstore &quot;Root&quot; &quot;[#filCert]&quot;"
                  Before="InstallCertRoot" Sequence="execute"/>
     <CustomAction Id="InstallCertRoot"
                   BinaryRef="Wix4UtilCA_$(sys.BUILDARCHSHORT)" DllEntry="WixQuietExec"
                   Execute="deferred" Impersonate="no" Return="check"/>
+<?endif?>
 
-    <!-- Remove the retired/compromised old signing cert. The old self-signed
-         private key was exposed in public git history, so the cert it signs is
-         treated as burned. Keyed by THUMBPRINT (not subject) so only the old
-         cert is removed; the new cert shares the same subject and is kept.
-         Best-effort: Return="ignore" so a clean machine that never had the old
-         cert still installs cleanly. -->
+    <!-- Remove the retired/compromised old signing cert. That self-signed
+         private key was exposed in public git history, so the cert it signs
+         is treated as burned. Keyed by THUMBPRINT (not subject) so only that
+         cert is removed. Best-effort: Return="ignore" so a clean machine
+         that never had the old cert still installs cleanly. -->
     <SetProperty Id="RemoveOldCertTrustedPublisher"
                  Value="&quot;[System32Folder]certutil.exe&quot; -delstore &quot;TrustedPublisher&quot; D3A6A27AA018DF07164D551D9B83AE6F27D1D453"
                  Before="RemoveOldCertTrustedPublisher" Sequence="execute"/>
@@ -100,6 +121,25 @@
     <CustomAction Id="RemoveOldCertRoot"
                   BinaryRef="Wix4UtilCA_$(sys.BUILDARCHSHORT)" DllEntry="WixQuietExec"
                   Execute="deferred" Impersonate="no" Return="ignore"/>
+
+<?ifdef EvSigned ?>
+    <!-- EV only: also retire the second-generation self-signed cert (the
+         2026 20-yr "CN=Openwater WinUSB" replacement) that earlier MSIs
+         planted in Root/TrustedPublisher — the EV chain replaces it. -->
+    <SetProperty Id="RemoveSelfSignedTrustedPublisher"
+                 Value="&quot;[System32Folder]certutil.exe&quot; -delstore &quot;TrustedPublisher&quot; 6E8D9AACC5FE08163E3E4B98A9956CE9F1B353F0"
+                 Before="RemoveSelfSignedTrustedPublisher" Sequence="execute"/>
+    <CustomAction Id="RemoveSelfSignedTrustedPublisher"
+                  BinaryRef="Wix4UtilCA_$(sys.BUILDARCHSHORT)" DllEntry="WixQuietExec"
+                  Execute="deferred" Impersonate="no" Return="ignore"/>
+
+    <SetProperty Id="RemoveSelfSignedRoot"
+                 Value="&quot;[System32Folder]certutil.exe&quot; -delstore &quot;Root&quot; 6E8D9AACC5FE08163E3E4B98A9956CE9F1B353F0"
+                 Before="RemoveSelfSignedRoot" Sequence="execute"/>
+    <CustomAction Id="RemoveSelfSignedRoot"
+                  BinaryRef="Wix4UtilCA_$(sys.BUILDARCHSHORT)" DllEntry="WixQuietExec"
+                  Execute="deferred" Impersonate="no" Return="ignore"/>
+<?endif?>
 
     <SetProperty Id="AddDriverIf0"
                  Value="&quot;[System32Folder]pnputil.exe&quot; /add-driver &quot;[#filInf0]&quot; /install"
@@ -129,16 +169,30 @@
                   BinaryRef="Wix4UtilCA_$(sys.BUILDARCHSHORT)" DllEntry="WixQuietExec"
                   Execute="deferred" Impersonate="no" Return="check"/>
 
+<?ifdef EvSigned ?>
     <InstallExecuteSequence>
-      <Custom Action="InstallCertTrustedPublisher" After="InstallFiles" Condition="NOT Installed OR REINSTALL"/>
-      <Custom Action="InstallCertRoot"             After="InstallCertTrustedPublisher" Condition="NOT Installed OR REINSTALL"/>
-      <Custom Action="RemoveOldCertTrustedPublisher" After="InstallCertRoot" Condition="NOT Installed OR REINSTALL"/>
-      <Custom Action="RemoveOldCertRoot"           After="RemoveOldCertTrustedPublisher" Condition="NOT Installed OR REINSTALL"/>
-      <Custom Action="AddDriverIf0"                After="RemoveOldCertRoot" Condition="NOT Installed OR REINSTALL"/>
-      <Custom Action="AddDriverIf1"                After="AddDriverIf0" Condition="NOT Installed OR REINSTALL"/>
-      <Custom Action="AddDriverIf2"                After="AddDriverIf1" Condition="NOT Installed OR REINSTALL"/>
-      <Custom Action="AddDriverIf3" After="AddDriverIf2" Condition="NOT Installed OR REINSTALL"/>
+      <Custom Action="InstallCertTrustedPublisher"      After="InstallFiles" Condition="NOT Installed OR REINSTALL"/>
+      <Custom Action="RemoveOldCertTrustedPublisher"    After="InstallCertTrustedPublisher" Condition="NOT Installed OR REINSTALL"/>
+      <Custom Action="RemoveOldCertRoot"                After="RemoveOldCertTrustedPublisher" Condition="NOT Installed OR REINSTALL"/>
+      <Custom Action="RemoveSelfSignedTrustedPublisher" After="RemoveOldCertRoot" Condition="NOT Installed OR REINSTALL"/>
+      <Custom Action="RemoveSelfSignedRoot"             After="RemoveSelfSignedTrustedPublisher" Condition="NOT Installed OR REINSTALL"/>
+      <Custom Action="AddDriverIf0"                     After="RemoveSelfSignedRoot" Condition="NOT Installed OR REINSTALL"/>
+      <Custom Action="AddDriverIf1"                     After="AddDriverIf0" Condition="NOT Installed OR REINSTALL"/>
+      <Custom Action="AddDriverIf2"                     After="AddDriverIf1" Condition="NOT Installed OR REINSTALL"/>
+      <Custom Action="AddDriverIf3"                     After="AddDriverIf2" Condition="NOT Installed OR REINSTALL"/>
     </InstallExecuteSequence>
+<?else?>
+    <InstallExecuteSequence>
+      <Custom Action="InstallCertTrustedPublisher"   After="InstallFiles" Condition="NOT Installed OR REINSTALL"/>
+      <Custom Action="InstallCertRoot"               After="InstallCertTrustedPublisher" Condition="NOT Installed OR REINSTALL"/>
+      <Custom Action="RemoveOldCertTrustedPublisher" After="InstallCertRoot" Condition="NOT Installed OR REINSTALL"/>
+      <Custom Action="RemoveOldCertRoot"             After="RemoveOldCertTrustedPublisher" Condition="NOT Installed OR REINSTALL"/>
+      <Custom Action="AddDriverIf0"                  After="RemoveOldCertRoot" Condition="NOT Installed OR REINSTALL"/>
+      <Custom Action="AddDriverIf1"                  After="AddDriverIf0" Condition="NOT Installed OR REINSTALL"/>
+      <Custom Action="AddDriverIf2"                  After="AddDriverIf1" Condition="NOT Installed OR REINSTALL"/>
+      <Custom Action="AddDriverIf3"                  After="AddDriverIf2" Condition="NOT Installed OR REINSTALL"/>
+    </InstallExecuteSequence>
+<?endif?>
 
   </Package>
 </Wix>

--- a/winusb-driver/README.md
+++ b/winusb-driver/README.md
@@ -12,29 +12,45 @@ in-box Windows VCP driver, so it needs no INF here.
 
 ## Rebuild
 
+Two signing modes (sdk#216) — the script picks EV automatically when a
+thumbprint is provided:
+
+**EV (CI, the shipping variant):** `CODESIGN_THUMBPRINT` (or `-Thumbprint`)
+selects a code-signing cert already in `Cert:\CurrentUser\My` — in CI that is
+the SSL.com EV cert loaded by eSigner CKA (key held in SSL.com's cloud HSM).
+Catalogs **and the MSI** are signtool-signed; the MSI is built with
+`-d EvSigned=1` so it installs the cert into **TrustedPublisher only** (the EV
+chain is publicly trusted — no Root install) and also removes the retired
+self-signed `CN=Openwater WinUSB` cert from user machines.
+
+**Legacy self-signed (local-dev fallback — never ship):**
+
 ```powershell
 $env:OW_DRIVER_PFX_PASSWORD = "<pfx password>"
 # first time / replacing the old cert: add -Fresh to mint a new signing cert
 .\build_driver_msi.ps1 -Fresh -AppResourcesZip <path to bloodflow-app resources\OpenMotionDriver-x64.zip>
 ```
 
-The script mints `OpenMotion_signing_cert.pfx` when no PFX is present
-(self-signed, 20-yr). Use `-Fresh` to mint a **replacement** (deletes any
-existing key first). It then derives the public `.cer` from the key and
-(re)signs any catalog not already signed by that key (so a steady-state build
-signs nothing; a key rotation re-signs all four). It then runs `wix build`,
-zips, and copies the zip into the bloodflow-app `resources/`. The MSI installs
-the public cert into TrustedPublisher + Root, removes the old retired cert
-(`certutil -delstore`, by thumbprint), then `pnputil /add-driver /install`s each
-INF. (`driver_install.cmd` performs the certutil + pnputil steps for a manual,
-no-MSI install.)
+Mints `OpenMotion_signing_cert.pfx` when no PFX is present (self-signed,
+20-yr; `-Fresh` deletes any existing key first) and signs with in-box
+`Set-AuthenticodeSignature` (no WDK). This variant's MSI installs the cert
+into TrustedPublisher **+ Root**, since nothing else trusts a self-signed
+chain.
 
-Catalog signing uses in-box `Set-AuthenticodeSignature` (no WDK). The catalog
-*content* is NOT generated here — the `.cat` files are libwdi/Zadig output,
-committed as content (see below); the build only re-signs them with the current
-key. **Do not** generate driver catalogs with `New-FileCatalog` — it produces
-file-integrity catalogs, not driver catalogs, and `pnputil` rejects them
-("hash for the file is not present in the specified catalog file").
+Both modes: the public `.cer` is derived from the active signing identity,
+only catalogs not already signed by that identity are (re)signed (so a
+steady-state build signs nothing; an identity change re-signs all four),
+then `wix build`, zip, and optional copy into bloodflow-app `resources/`.
+The MSI removes the old leaked cert (`certutil -delstore`, by thumbprint)
+and `pnputil /add-driver /install`s each INF. (`driver_install.cmd` performs
+the certutil + pnputil steps for a manual, no-MSI install.)
+
+The catalog *content* is NOT generated here — the `.cat` files are
+libwdi/Zadig output, committed as content (see below); the build only
+re-signs them. **Do not** generate driver catalogs with `New-FileCatalog` —
+it produces file-integrity catalogs, not driver catalogs, and `pnputil`
+rejects them ("hash for the file is not present in the specified catalog
+file").
 
 ## Source vs. build outputs
 
@@ -47,10 +63,14 @@ key and the derived/built outputs are never committed:
   The build re-signs the catalogs only when the signing key changes; to add or
   change a device, regenerate its INF + `.cat` with libwdi/Zadig and commit them.
 - **Not committed (gitignored), produced at build time:** `OpenMotion_signing_cert.pfx`
-  (the private key — CI injects it from the `OW_DRIVER_PFX_BASE64` secret),
-  `OpenMotion_signing_cert.cer` (derived from the key), `OpenMotionDriver-x64.msi`,
-  `cab1.cab`, and `OpenMotionDriver-x64.zip`.
+  (the legacy private key), `OpenMotion_signing_cert.cer` (derived from the
+  active signing identity), `OpenMotionDriver-x64.msi`, `cab1.cab`, and
+  `OpenMotionDriver-x64.zip`.
 
-The PFX password is read from `$env:OW_DRIVER_PFX_PASSWORD` (or prompted) and is
-never written to the repo or logs. CI (`.github/workflows/driver-msi.yml`)
-decodes the PFX secret, runs this script, and uploads the zip as an artifact.
+The legacy PFX password is read from `$env:OW_DRIVER_PFX_PASSWORD` (or
+prompted) and is never written to the repo or logs. CI
+(`.github/workflows/driver-msi.yml`) prefers EV: it sets up eSigner CKA from
+the `ES_USERNAME`/`ES_PASSWORD`/`ES_TOTP_SECRET` secrets and exports
+`CODESIGN_THUMBPRINT`; when those secrets are absent it falls back to
+decoding the legacy `OW_DRIVER_PFX_BASE64` secret with a warning. It then
+runs this script and uploads the zip as an artifact.

--- a/winusb-driver/build_driver_msi.ps1
+++ b/winusb-driver/build_driver_msi.ps1
@@ -1,24 +1,45 @@
 # build_driver_msi.ps1 - regenerate OpenMotionDriver-x64.{msi,zip}.
 #
+# Two signing modes (sdk#216):
+#
+#   EV (CI, the shipping path): -Thumbprint (or $env:CODESIGN_THUMBPRINT)
+#   selects a code-signing cert already in Cert:\CurrentUser\My — in CI that
+#   is the SSL.com EV cert loaded by eSigner CKA (the private key stays in
+#   SSL.com's cloud HSM; CKA exposes it through Windows CNG so signtool
+#   works). Catalogs AND the MSI are signtool-signed and RFC3161-timestamped;
+#   the shipped .cer is derived from the store cert; the MSI is built with
+#   -d EvSigned=1 so it installs the cert into TrustedPublisher only (the EV
+#   chain is publicly trusted — no Root install) and retires the old
+#   self-signed cert from user machines.
+#
+#   Legacy self-signed (local-dev fallback): mints/loads the
+#   "CN=Openwater WinUSB" PFX and signs with it; the MSI certutil-installs
+#   that cert into Root + TrustedPublisher. Kept only so a dev box without
+#   eSigner credentials can produce an installable MSI for bench testing —
+#   never ship this variant.
+#
 # Steps:
-#   1. Mint a fresh self-signed "CN=Openwater WinUSB" code-signing cert if the
-#      PFX is absent (20-yr validity; the old cert expires 2026-08-11).
-#   2. Load the signing key from the PFX and derive the public .cer from it (so
-#      the shipped cert always matches the key). We do NOT trust the cert on the
-#      build machine -- signing needs only the key; trust is the MSI's job.
+#   1. Resolve the signing identity (store cert in EV mode; PFX in legacy
+#      mode, minted fresh if absent — 20-yr validity).
+#   2. Derive the public .cer from the signing identity (so the shipped cert
+#      always matches the key). We do NOT trust the cert on the build
+#      machine -- signing needs only the key; trust is the MSI's job.
 #   3. (re)sign any catalog not already signed by the current key -- all
-#      timestamped. The .cer/.msi/.cab/.zip are build outputs (gitignored); the
-#      .cat files and INFs are committed, libwdi/Zadig-generated content. The key
-#      is the single source of truth for what ships.
+#      timestamped. The .cer/.msi/.cab/.zip are build outputs (gitignored);
+#      the .cat files and INFs are committed, libwdi/Zadig-generated content.
+#      The key is the single source of truth for what ships.
 #   4. wix build the MSI (Util ext supplies the QuietExec custom actions).
+#      EV mode also signs the MSI itself.
 #   5. Zip the MSI + external cab.
 #   6. Refresh the bloodflow-app vendored zip.
 #
-# The PFX password is read from $env:OW_DRIVER_PFX_PASSWORD (or prompted) and is
-# never written to the repo or logs.
+# The legacy PFX password is read from $env:OW_DRIVER_PFX_PASSWORD (or
+# prompted) and is never written to the repo or logs.
 param(
     [string]$AppResourcesZip = "C:\Users\ethan\Projects\openmotion-bloodflow-app\resources\OpenMotionDriver-x64.zip",
-    [string]$TimeStampServer = "http://timestamp.digicert.com",
+    [string]$TimeStampServer = "http://timestamp.digicert.com",  # legacy Set-AuthenticodeSignature timestamp
+    [string]$Rfc3161Server   = "http://ts.ssl.com",              # EV signtool /tr timestamp
+    [string]$Thumbprint      = $env:CODESIGN_THUMBPRINT,
     [switch]$Fresh
 )
 $ErrorActionPreference = "Stop"
@@ -26,48 +47,80 @@ Set-Location (Split-Path -Parent $MyInvocation.MyCommand.Definition)
 
 $pfx = "OpenMotion_signing_cert.pfx"
 $cer = "OpenMotion_signing_cert.cer"
+$evMode = [bool]$Thumbprint
 
-# -- 0. -Fresh: drop any existing cert so a brand-new one is minted below --
-if ($Fresh) {
-    Remove-Item $pfx,$cer -ErrorAction SilentlyContinue
-    Write-Host "Fresh mode: removed any existing signing cert." -ForegroundColor Cyan
+if ($evMode) {
+    # -- EV: the cert must already be in the user store (eSigner CKA in CI) --
+    $signCert = Get-Item "Cert:\CurrentUser\My\$Thumbprint" -ErrorAction SilentlyContinue
+    if (-not $signCert) {
+        throw "no certificate with thumbprint $Thumbprint in Cert:\CurrentUser\My (is eSigner CKA loaded?)"
+    }
+    Write-Host "EV mode: signing as $($signCert.Subject) [$Thumbprint]" -ForegroundColor Cyan
+
+    # signtool: PATH first, else the newest Windows Kits copy
+    $signtool = (Get-Command signtool.exe -ErrorAction SilentlyContinue).Source
+    if (-not $signtool) {
+        $signtool = Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\bin\10.0.*\x64\signtool.exe" -ErrorAction SilentlyContinue |
+            Sort-Object { [version]$_.Directory.Parent.Name } -Descending |
+            Select-Object -First 1 -ExpandProperty FullName
+    }
+    if (-not $signtool) { throw "signtool.exe not found (PATH or Windows Kits)" }
+
+    function Invoke-SignTool([string]$File) {
+        # cloud signing and timestamp servers can both flake; retry before failing
+        for ($i = 1; $i -le 3; $i++) {
+            & $signtool sign /sha1 $Thumbprint /fd SHA256 /tr $Rfc3161Server /td SHA256 $File
+            if ($LASTEXITCODE -eq 0) { return }
+            if ($i -eq 3) { throw "signtool failed for $File after 3 attempts" }
+            Write-Host "signtool exit $LASTEXITCODE -- retrying ($i/3)" -ForegroundColor Yellow
+            Start-Sleep -Seconds 10
+        }
+    }
+} else {
+    # -- legacy self-signed fallback --
+    # 0. -Fresh: drop any existing cert so a brand-new one is minted below
+    if ($Fresh) {
+        Remove-Item $pfx,$cer -ErrorAction SilentlyContinue
+        Write-Host "Fresh mode: removed any existing signing cert." -ForegroundColor Cyan
+    }
+
+    # password
+    $pw = $env:OW_DRIVER_PFX_PASSWORD
+    if (-not $pw) {
+        $sec = Read-Host "PFX password" -AsSecureString
+        $bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($sec)
+        try   { $pw = [Runtime.InteropServices.Marshal]::PtrToStringAuto($bstr) }
+        finally { [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr) }
+    }
+
+    # 1. mint cert if absent
+    if (-not (Test-Path $pfx)) {
+        Write-Host "Minting fresh Openwater WinUSB signing cert (20 yr)..." -ForegroundColor Cyan
+        $cert = New-SelfSignedCertificate -Type CodeSigningCert -Subject "CN=Openwater WinUSB" `
+            -CertStoreLocation Cert:\CurrentUser\My -KeyExportPolicy Exportable `
+            -KeyUsage DigitalSignature -KeyAlgorithm RSA -KeyLength 2048 `
+            -NotAfter (Get-Date).AddYears(20) `
+            -TextExtension @("2.5.29.37={text}1.3.6.1.5.5.7.3.3")
+        $sp = ConvertTo-SecureString $pw -AsPlainText -Force
+        Export-PfxCertificate -Cert $cert -FilePath $pfx -Password $sp | Out-Null
+        Remove-Item ("Cert:\CurrentUser\My\" + $cert.Thumbprint) -Force
+        Write-Host "  wrote $pfx" -ForegroundColor Green
+    }
+
+    # 2. load signing cert (with private key)
+    try {
+        $signCert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2(
+            (Resolve-Path $pfx).Path, $pw,
+            [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::Exportable)
+    } catch {
+        throw "Could not open $pfx with the supplied password. To mint a NEW signing cert, " +
+              "re-run with -Fresh (deletes $pfx/$cer) and provide a new password."
+    }
 }
 
-# -- password --
-$pw = $env:OW_DRIVER_PFX_PASSWORD
-if (-not $pw) {
-    $sec = Read-Host "PFX password" -AsSecureString
-    $bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($sec)
-    try   { $pw = [Runtime.InteropServices.Marshal]::PtrToStringAuto($bstr) }
-    finally { [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr) }
-}
-
-# -- 1. mint cert if absent --
-if (-not (Test-Path $pfx)) {
-    Write-Host "Minting fresh Openwater WinUSB signing cert (20 yr)..." -ForegroundColor Cyan
-    $cert = New-SelfSignedCertificate -Type CodeSigningCert -Subject "CN=Openwater WinUSB" `
-        -CertStoreLocation Cert:\CurrentUser\My -KeyExportPolicy Exportable `
-        -KeyUsage DigitalSignature -KeyAlgorithm RSA -KeyLength 2048 `
-        -NotAfter (Get-Date).AddYears(20) `
-        -TextExtension @("2.5.29.37={text}1.3.6.1.5.5.7.3.3")
-    $sp = ConvertTo-SecureString $pw -AsPlainText -Force
-    Export-PfxCertificate -Cert $cert -FilePath $pfx -Password $sp | Out-Null
-    Remove-Item ("Cert:\CurrentUser\My\" + $cert.Thumbprint) -Force
-    Write-Host "  wrote $pfx" -ForegroundColor Green
-}
-
-# -- 2. load signing cert (with private key) + trust it on this machine --
-try {
-    $signCert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2(
-        (Resolve-Path $pfx).Path, $pw,
-        [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::Exportable)
-} catch {
-    throw "Could not open $pfx with the supplied password. To mint a NEW signing cert, " +
-          "re-run with -Fresh (deletes $pfx/$cer) and provide a new password."
-}
-# Always (re)derive the public .cer from the signing key, so the cert that ships
-# can never disagree with the key that signs the catalogs. The .cer is a build
-# output (gitignored), not committed source.
+# Always (re)derive the public .cer from the signing identity, so the cert
+# that ships can never disagree with the key that signs the catalogs. The
+# .cer is a build output (gitignored), not committed source.
 Export-Certificate -Cert $signCert -FilePath $cer | Out-Null
 # NOTE: we deliberately do NOT import the cert into this machine's trust stores.
 # The build only needs the private key to SIGN; trust is the end user's MSI's job
@@ -78,10 +131,11 @@ Export-Certificate -Cert $signCert -FilePath $cer | Out-Null
 # All four catalogs are committed, libwdi/Zadig-generated content -- the proven
 # way driver catalogs are made for this project. (New-FileCatalog does NOT make
 # valid driver catalogs: pnputil rejects them with "hash ... not present in the
-# catalog".) The build only re-signs a catalog when the key changes; regenerating
-# one (after an INF change) is a manual libwdi/Zadig step. Matching is by signer
-# THUMBPRINT (not chain-validation Status), since the build box doesn't trust the
-# cert -- so a steady-state build (key unchanged) signs nothing.
+# catalog".) Regenerating a catalog (after an INF change) is a manual
+# libwdi/Zadig step. Matching is by signer THUMBPRINT (not chain-validation
+# Status), since the build box doesn't trust the cert. The committed cats carry
+# the legacy self-signed signature, so an EV build re-signs all four; a
+# steady-state legacy build signs nothing.
 $cats = @(
     "DFU_in_FS_Mode.cat",
     "comms_histo_imu(hs)_(interface_0).cat",
@@ -94,8 +148,13 @@ foreach ($c in $cats) {
         Write-Host "  $c already signed by current key, skipping" -ForegroundColor DarkGray
         continue
     }
-    $r = Set-AuthenticodeSignature -FilePath $c -Certificate $signCert `
-            -HashAlgorithm SHA256 -TimeStampServer $TimeStampServer
+    if ($evMode) {
+        Invoke-SignTool $c
+        $r = Get-AuthenticodeSignature $c
+    } else {
+        $r = Set-AuthenticodeSignature -FilePath $c -Certificate $signCert `
+                -HashAlgorithm SHA256 -TimeStampServer $TimeStampServer
+    }
     if (-not $r.SignerCertificate -or $r.SignerCertificate.Thumbprint -ne $signCert.Thumbprint) {
         throw "signing $c failed: $($r.Status) - $($r.StatusMessage)"
     }
@@ -111,9 +170,15 @@ if (-not ((wix extension list -g) -match 'WixToolset\.Util\.wixext')) {
 }
 $msi = "OpenMotionDriver-x64.msi"
 Remove-Item $msi,"cab1.cab" -ErrorAction SilentlyContinue
-wix build Product.wxs -arch x64 -ext WixToolset.Util.wixext -o $msi
+$wixDefines = @()
+if ($evMode) { $wixDefines = @("-d", "EvSigned=1") }
+wix build Product.wxs -arch x64 -ext WixToolset.Util.wixext @wixDefines -o $msi
 if ($LASTEXITCODE -ne 0) { throw "wix build failed" }
 if (-not (Test-Path $msi) -or (Get-Item $msi).Length -lt 100KB) { throw "MSI build looks empty/invalid" }
+
+# EV mode also signs the MSI itself (pointless in legacy mode -- nothing
+# trusts the self-signed cert until the MSI itself installs it).
+if ($evMode) { Invoke-SignTool $msi }
 
 # -- 5. zip MSI + external cab --
 $zip = "OpenMotionDriver-x64.zip"


### PR DESCRIPTION
Refs #216 — companion to OpenwaterHealth/openmotion-bloodflow-app#443.

## What

- **`driver-msi.yml`**: signing setup step now prefers **eSigner CKA** (SSL.com EV cert; key never leaves their cloud HSM) from `ES_USERNAME` / `ES_PASSWORD` / `ES_TOTP_SECRET`, exporting `CODESIGN_THUMBPRINT`. Falls back to the legacy `OW_DRIVER_PFX_*` path with a `::warning::` while those secrets don't exist — so this PR's own CI run stays green and switches to EV automatically once the secrets are added.
- **`build_driver_msi.ps1`**: new EV mode (auto-selected when `CODESIGN_THUMBPRINT`/`-Thumbprint` is set) — signtool-signs the 4 catalogs **and the MSI itself**, RFC3161-timestamped via ts.ssl.com, derives the shipped `.cer` from the store cert, builds with `-d EvSigned=1`. Legacy self-signed path preserved verbatim for local bench builds.
- **`Product.wxs`**: `EvSigned` preprocessor split. EV MSIs install the cert into **TrustedPublisher only** (prompt-free pnputil staging; no more private root cert on user machines) and delstore the retired self-signed `CN=Openwater WinUSB` cert `6E8D9AAC…` in addition to the leaked `D3A6A27A…`. Version 1.1.0 → 1.2.0 so installed machines major-upgrade.

## Verification

- `wix build` of both variants passes locally (WiX 5.0.2); byte-level check confirms the EV MSI contains `RemoveSelfSignedRoot` and no `InstallCertRoot`, and the legacy MSI the reverse.
- `build_driver_msi.ps1` parses clean under Windows PowerShell 5.1.
- This PR's CI run exercises the legacy fallback end-to-end (secrets for EV don't exist yet).

## Follow-ups (tracked in #216)

- After the first EV-signed dispatch build: vendor the artifact zip into bloodflow-app `resources/OpenMotionDriver-x64.zip`.
- Optional later: Microsoft Partner Center attestation signing for fully prompt-free installs (EV cert is the prerequisite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)