### PR TITLE
fix: scope sibling asset selection to the downloaded release

### DIFF
--- a/omotion/firmware_update.py
+++ b/omotion/firmware_update.py
@@ -294,8 +294,10 @@ class FirmwareUpdateError(RuntimeError):
 
 # Downloaded-file provenance, so update() can find a sibling asset for whatever
 # boot mode the device turns out to be in. In-process only: callers download and
-# flash within one session, and a stale entry is harmless because the sibling
-# lookup is a directory listing, not a cache.
+# flash within one session. Also the authority on which files count as siblings
+# — the download directory may be shared across releases, so a directory
+# listing could offer a leftover from a different version. A stale entry whose
+# file is gone is skipped at lookup time.
 _DOWNLOADS: dict[str, tuple[FirmwareKind, str]] = {}
 
 
@@ -416,8 +418,17 @@ class FirmwareUpdater:
 
         provenance = _provenance(bin_path)
         if provenance is not None:
-            kind, _tag = provenance
-            siblings = [p.name for p in bin_path.parent.iterdir() if p.is_file()]
+            kind, tag = provenance
+            # Only files downloaded from the same release may stand in for
+            # bin_path. The directory itself is no authority: callers reuse one
+            # downloads/ folder across releases, and a listing would let a
+            # higher-preference leftover from a different version win (#218).
+            parent = bin_path.parent.resolve()
+            siblings = [
+                Path(p).name
+                for p, prov in _DOWNLOADS.items()
+                if prov == (kind, tag) and Path(p).parent == parent and Path(p).is_file()
+            ]
             # Raises UnsupportedReleaseError if this release has nothing for
             # the mode — e.g. a bootloader unit pointed at a legacy release.
             return bin_path.parent / resolve_asset(kind, mode, siblings)

--- a/tests/test_firmware_update_flow.py
+++ b/tests/test_firmware_update_flow.py
@@ -72,11 +72,14 @@ def test_bare_metal_device_flashes_baremetal_image_at_flash_base(release_dir):
 
 def test_bootloader_device_flashes_signed_image_into_the_slot(release_dir):
     """Same starting path as the bare-metal case — the detected mode, not the
-    caller, decides which sibling is used."""
+    caller, decides which sibling is used. Both files are registered, as
+    download_firmware() registers every asset it fetches; only registered
+    same-release files are sibling candidates."""
     prog = FakeProgrammer(mode=BootMode.BOOTLOADER)
     updater = FirmwareUpdater(programmer=prog)
     primary = release_dir / "motion-sensor-fw-baremetal-fpga.bin"
     register_download(primary, FirmwareKind.SENSOR, "1.8.2")
+    register_download(release_dir / "motion-sensor-fw-signed.bin", FirmwareKind.SENSOR, "1.8.2")
 
     updater.update(FakeHandle(), primary)
 
@@ -109,6 +112,54 @@ def test_bootloader_device_with_legacy_release_refuses(tmp_path):
 def test_legacy_release_still_flashes_on_a_bare_metal_device(tmp_path):
     legacy = tmp_path / "motion-sensor-fw.bin"
     legacy.write_bytes(b"\x00" * 16)
+    register_download(legacy, FirmwareKind.SENSOR, "1.8.1")
+    prog = FakeProgrammer(mode=BootMode.BARE_METAL)
+
+    FirmwareUpdater(programmer=prog).update(FakeHandle(), legacy)
+
+    assert prog.flashed == [(legacy, "0x08000000")]
+
+
+def test_stale_higher_preference_file_from_another_release_is_not_selected(tmp_path):
+    """Regression for #218: the downloads dir is shared across releases, so a
+    leftover registered for a newer release must not shadow the release the
+    caller actually chose."""
+    legacy = tmp_path / "motion-sensor-fw.bin"
+    legacy.write_bytes(b"\x00" * 16)
+    stale = tmp_path / "motion-sensor-fw-baremetal-fpga.bin"
+    stale.write_bytes(b"\x01" * 16)
+    register_download(legacy, FirmwareKind.SENSOR, "1.8.1")
+    register_download(stale, FirmwareKind.SENSOR, "1.10.0")
+    prog = FakeProgrammer(mode=BootMode.BARE_METAL)
+
+    FirmwareUpdater(programmer=prog).update(FakeHandle(), legacy)
+
+    assert prog.flashed == [(legacy, "0x08000000")]
+
+
+def test_stale_signed_image_does_not_bypass_the_legacy_release_refusal(tmp_path):
+    """A bootloader unit on a pre-bootloader release must refuse — not flash a
+    signed image left over from some other release (#218)."""
+    legacy = tmp_path / "motion-sensor-fw.bin"
+    legacy.write_bytes(b"\x00" * 16)
+    stale = tmp_path / "motion-sensor-fw-signed.bin"
+    stale.write_bytes(b"\x01" * 16)
+    register_download(legacy, FirmwareKind.SENSOR, "1.8.1")
+    register_download(stale, FirmwareKind.SENSOR, "1.10.0")
+    prog = FakeProgrammer(mode=BootMode.BOOTLOADER)
+
+    with pytest.raises(UnsupportedReleaseError):
+        FirmwareUpdater(programmer=prog).update(FakeHandle(), legacy)
+    assert prog.flashed == []
+
+
+def test_unregistered_files_in_the_directory_are_not_candidates(tmp_path):
+    """A file from a previous session (no provenance in this process) is
+    invisible to sibling selection even when its name would win on preference
+    (#218)."""
+    legacy = tmp_path / "motion-sensor-fw.bin"
+    legacy.write_bytes(b"\x00" * 16)
+    (tmp_path / "motion-sensor-fw-baremetal-fpga.bin").write_bytes(b"\x01" * 16)
     register_download(legacy, FirmwareKind.SENSOR, "1.8.1")
     prog = FakeProgrammer(mode=BootMode.BARE_METAL)
 
@@ -186,6 +237,7 @@ def test_updater_records_the_mode_it_detected(release_dir):
     updater = FirmwareUpdater(programmer=prog)
     primary = release_dir / "motion-sensor-fw-baremetal-fpga.bin"
     register_download(primary, FirmwareKind.SENSOR, "1.8.2")
+    register_download(release_dir / "motion-sensor-fw-signed.bin", FirmwareKind.SENSOR, "1.8.2")
 
     assert updater.last_boot_mode is None
     updater.update(FakeHandle(), primary)
@@ -193,11 +245,12 @@ def test_updater_records_the_mode_it_detected(release_dir):
 
 
 def test_updater_records_mode_even_when_the_flash_is_refused(release_dir):
-    """A refusal is still information about the device — don't discard it."""
+    """A refusal is still information about the device — don't discard it.
+
+    The new-style files from the fixture stay on disk, unregistered: they must
+    not shadow the legacy release's refusal (#218)."""
     legacy = release_dir / "motion-sensor-fw.bin"
     legacy.write_bytes(b"\x00" * 16)
-    for stale in ("motion-sensor-fw-baremetal-fpga.bin", "motion-sensor-fw-signed.bin"):
-        (release_dir / stale).unlink()
     register_download(legacy, FirmwareKind.SENSOR, "1.8.1")
     updater = FirmwareUpdater(programmer=FakeProgrammer(mode=BootMode.BOOTLOADER))
 


### PR DESCRIPTION
Refs #218

## Problem

`FirmwareUpdater._select_image` discovered the boot-mode-appropriate image by listing **every file** in the download directory. The test-app reuses one persistent `downloads/` folder across releases, so a higher-preference leftover from a previously downloaded release could win the preference match and get flashed silently in place of the release the operator selected:

- Bare-metal sensor, operator selects 1.8.1 (legacy era, only `motion-sensor-fw.bin`): a stale `motion-sensor-fw-baremetal-fpga.bin` from a newer release gets flashed instead, and the app reports the 1.8.1 update as successful.
- Bootloader-mode sensor pointed at a pre-bootloader release: a stale `motion-sensor-fw-signed.bin` from another release gets flashed instead of raising `UnsupportedReleaseError`.

Found while investigating a refused 1.8.1 sensor rollback (the refusal itself was the intended bootloader guard; this bug is what would have happened next on a bare-metal unit with a populated downloads folder).

## Fix

Sibling candidates now come from the `_DOWNLOADS` provenance registry instead of the directory listing, restricted to entries with the same `(kind, tag)` in the same directory that still exist on disk. `download_firmware()` (and the test-app's download thread) already register every asset they fetch, so the real flow is unchanged — unregistered files simply stop being candidates.

## Tests

- Three new regression tests: stale higher-preference file registered for another release is not selected; stale signed image does not bypass the legacy-release refusal; unregistered directory contents are never candidates.
- Two existing tests updated to register the signed sibling explicitly (matching what `download_firmware()` actually does); the manual stale-file `unlink()` workaround in `test_updater_records_mode_even_when_the_flash_is_refused` is now unnecessary and removed.
- `pytest tests/test_firmware_update_flow.py tests/test_firmware_update.py tests/test_firmware_asset_resolution.py tests/test_boot_mode.py tests/test_bootloader_install.py` — 104 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)