### PR TITLE
Fix/issue 178 console flakiness

### DIFF
--- a/docs/TestPlan.md
+++ b/docs/TestPlan.md
@@ -125,7 +125,7 @@ Calls `tec_status()`. Asserts the returned tuple is `(float, float, float, float
 Calls `tec_adc(ch)` for channels 0, 1, 2, 3. Asserts each returns a float in [0.0, 3.3].
 
 **`test_tec_voltage_read`**
-Calls `tec_voltage()` (no argument). Asserts the returned float is in [0.0, 3.3].
+Calls `tec_voltage()` (no argument). Asserts the returned TEC DAC setpoint is a float in the public API range [-5.0, 5.0] V. This is intentionally different from the 0-3.3 V ADC bounds used by `tec_adc()` and `tec_status()`.
 
 **`test_tec_voltage_set`**
 Sets a known voltage with `tec_voltage(1.5)`. Reads back with `tec_voltage()`. Asserts the read-back value is within ±0.05 V of the set point.

--- a/omotion/CalibrationWorkflow.py
+++ b/omotion/CalibrationWorkflow.py
@@ -23,6 +23,7 @@ import platform
 import socket
 import sys
 import threading
+import time
 import dataclasses
 from dataclasses import dataclass
 from typing import Callable, Optional, TYPE_CHECKING
@@ -165,6 +166,11 @@ class CalibrationResult:
     started_timestamp: str
     outcome: Optional[CalibrationOutcome] = None
     rolled_back: bool = False   # set by Task 3
+    # True when the operator explicitly approved writing a calibration
+    # whose scan-1 means/contrast were below threshold (#199 pre-write
+    # gate). A consented run is never rolled back — the operator already
+    # said this unit is simply dim.
+    consented_below_threshold: bool = False
 
 
 @dataclass
@@ -470,6 +476,30 @@ def evaluate_passed(rows: list[CalibrationResultRow]) -> bool:
     )
 
 
+def evaluate_gate_passed(rows: list[CalibrationResultRow]) -> bool:
+    """Pre-write gate (#199): mean + contrast only.
+
+    Evaluated on the *calibration* scan, before anything is written to the
+    console. Both quantities are calibration-independent — mean is the raw
+    pixel average and contrast is speckle std/mean — so applying the newly
+    computed calibration cannot change them. That is what makes it sound to
+    judge them one scan early: a camera that is too dim here will still be
+    too dim in the validation scan.
+
+    BFI/BVI are deliberately excluded — they *are* the calibrated
+    quantities, so they only become meaningful after the calibration is
+    applied, which is what the validation scan is for. Ambient-dark is
+    excluded too: phase 1's dark frames are captured but the ambient
+    criterion is defined against the validation scan (#122).
+    """
+    if not rows:
+        return False
+    return all(
+        r.mean_test == "PASS" and r.contrast_test == "PASS"
+        for r in rows
+    )
+
+
 _CSV_FIELDS = [
     "camera_index", "side", "cam",
     "mean", "avg_contrast", "bfi", "bvi", "dark",
@@ -642,6 +672,7 @@ def write_result_json(
     mode: str = "calibrate",
     outcome: str = "",
     calibration_rolled_back: bool = False,
+    consented_below_threshold: bool = False,
 ) -> None:
     """Write a self-describing JSON manifest of the calibration run.
 
@@ -673,6 +704,9 @@ def write_result_json(
         "error": error,
         "outcome": outcome,
         "calibration_rolled_back": calibration_rolled_back,
+        # #199 — this calibration was written on the operator's explicit
+        # authority despite below-threshold scan means/contrast.
+        "consented_below_threshold": consented_below_threshold,
         "operator_id": request.operator_id,
         "notes": request.notes,
         "host": _collect_host_info(),
@@ -990,7 +1024,27 @@ class CalibrationWorkflow:
         on_log_fn: Optional[Callable[[str], None]] = None,
         on_progress_fn: Optional[Callable[[str], None]] = None,
         on_complete_fn: Optional[Callable[[CalibrationResult], None]] = None,
+        on_confirm_fn: Optional[
+            Callable[[list["CalibrationResultRow"]], bool]
+        ] = None,
     ) -> bool:
+        """Run the calibration procedure on a worker thread.
+
+        ``on_confirm_fn`` implements the pre-write gate (#199). It is called
+        — on the worker thread — only when the calibration scan's means or
+        contrasts miss their thresholds, with the per-camera rows measured
+        so far, and must return True to authorise writing the console EEPROM
+        anyway or False to abort untouched. **When it is not supplied, a
+        failing gate aborts without writing**, which is the conservative
+        default: the console keeps whatever calibration it already had.
+
+        The handler blocks the worker thread, so it must bound its own wait
+        — the watchdog is paused across the call precisely so operator think
+        time isn't charged against ``max_duration_sec``, which also means it
+        cannot rescue a handler that never returns. Raising is treated as a
+        decline. ``cancel_calibration()`` remains responsive throughout: the
+        stop event is re-checked as soon as the handler returns.
+        """
         with self._lock:
             if self._running:
                 logger.warning("start_calibration refused: already running.")
@@ -1023,6 +1077,8 @@ class CalibrationWorkflow:
             prior_cal: Optional[Calibration] = None
             wrote_calibration = False
             rolled_back = False
+            consented = False
+            t_proc0 = time.monotonic()
 
             logger.info(
                 "Calibration: starting procedure (operator=%s, output_dir=%s, "
@@ -1185,12 +1241,13 @@ class CalibrationWorkflow:
                         skip_frames,
                     )
                 _reset_firmware_trigger("phase 1 (pre-scan)")
-                # _cal_dark_samples deliberately discarded — the ambient
-                # check (#122) gates on validation-scan dark frames so it
-                # measures the same scan as the row-level mean/contrast/
-                # BFI/BVI tests. If we ever want to also gate on the
-                # calibration scan's dark frames, capture this here.
-                cal_left, cal_right, cal_samples, _cal_dark_samples = _run_subscan_capture(
+                # cal_dark_samples feeds the pre-write gate's row build
+                # (#199) so its table can show an ambient column. The
+                # ambient *criterion* still gates on validation-scan darks
+                # (#122) — evaluate_gate_passed ignores dark_test — so the
+                # pass/fail semantics are unchanged; these frames are only
+                # here so the operator sees a complete table.
+                cal_left, cal_right, cal_samples, cal_dark_samples = _run_subscan_capture(
                     self._interface, request,
                     subject_id=f"calib1_{request.operator_id}",
                     duration_sec=request.duration_sec + request.scan_delay_sec,
@@ -1233,6 +1290,100 @@ class CalibrationWorkflow:
                     "Calibration phase 2 done — proposed calibration:\n%s",
                     _format_calibration(cal_obj),
                 )
+
+                # ── Phase 2.5: pre-write gate (#199) ──────────────────────
+                # The console EEPROM is not touched until either the
+                # calibration scan's own mean/contrast clear their bars or
+                # the operator explicitly authorises writing anyway. Before
+                # this gate existed the write happened here unconditionally
+                # and a bad run was undone afterwards, which meant every
+                # failed calibration briefly destroyed the previous one.
+                _emit_progress("gate")
+                logger.info(
+                    "Calibration phase 2.5: pre-write gate on calibration-"
+                    "scan mean/contrast."
+                )
+                gate_rows = _build_result_rows_from_samples(
+                    cal_samples,
+                    dark_samples=cal_dark_samples,
+                    left_camera_mask=request.left_camera_mask,
+                    right_camera_mask=request.right_camera_mask,
+                    thresholds=request.thresholds,
+                    sensor_left=getattr(self._interface, "left", None),
+                    sensor_right=getattr(self._interface, "right", None),
+                )
+                if evaluate_gate_passed(gate_rows):
+                    logger.info(
+                        "Calibration phase 2.5 done: gate PASS — proceeding "
+                        "to write."
+                    )
+                else:
+                    below = ", ".join(
+                        f"{'L' if r.side == 'left' else 'R'}{r.cam_id + 1}"
+                        for r in gate_rows
+                        if r.mean_test == "FAIL" or r.contrast_test == "FAIL"
+                    )
+                    logger.warning(
+                        "Calibration phase 2.5: gate FAIL — below threshold "
+                        "on %s. Console EEPROM not written yet.", below,
+                    )
+                    _emit_log(
+                        "Calibration: scan means/contrast below threshold "
+                        f"({below}) — awaiting confirmation before writing."
+                    )
+                    if on_confirm_fn is None:
+                        error = (
+                            "calibration scan below threshold on "
+                            f"{below}; not written (no confirmation handler)"
+                        )
+                        canceled = True
+                        return
+
+                    # Pause the watchdog: the operator's think time must not
+                    # be charged against max_duration_sec, or a slow answer
+                    # would surface as a bogus timeout.
+                    wd.cancel()
+                    t_wait0 = time.monotonic()
+                    try:
+                        consented = bool(on_confirm_fn(gate_rows))
+                    except Exception as e:
+                        logger.exception(
+                            "Calibration gate: confirmation handler raised; "
+                            "treating as declined."
+                        )
+                        consented = False
+                        error = f"gate confirmation failed: {e}"
+                    wait_s = time.monotonic() - t_wait0
+                    logger.info(
+                        "Calibration phase 2.5: operator %s after %.1fs.",
+                        "APPROVED the write" if consented else "declined",
+                        wait_s,
+                    )
+                    if self._stop_evt.is_set():
+                        canceled = True
+                        if not error:
+                            error = "canceled at pre-write gate"
+                        return
+                    if not consented:
+                        canceled = True
+                        if not error:
+                            error = (
+                                "declined at pre-write gate: calibration "
+                                f"scan below threshold on {below}"
+                            )
+                        return
+                    # Restart the watchdog on the remaining budget, with the
+                    # wait excluded.
+                    remaining = request.max_duration_sec - (
+                        time.monotonic() - t_proc0 - wait_s
+                    )
+                    wd = threading.Timer(max(1.0, remaining), _watchdog)
+                    wd.daemon = True
+                    wd.start()
+                    _emit_log(
+                        "Calibration: proceeding with operator approval "
+                        "despite below-threshold scan."
+                    )
 
                 _emit_progress("write_calibration")
                 _emit_log("Calibration: writing to console…")
@@ -1345,11 +1496,19 @@ class CalibrationWorkflow:
                 if (
                     wrote_calibration and prior_cal is not None
                     and outcome is not CalibrationOutcome.PASSED
+                    and not consented
                 ):
                     # The write in phase 3 predates the validation verdict.
                     # Anything short of PASSED means the new calibration is
                     # unvalidated — put the previous one back (best-effort;
                     # the console may be gone).
+                    #
+                    # Skipped when the operator consented at the pre-write
+                    # gate: they were shown the below-threshold numbers and
+                    # asked for this calibration anyway, so undoing it would
+                    # discard exactly what they approved. Such a run still
+                    # reports FAILED — the verdict is honest, the write is
+                    # simply intentional.
                     try:
                         self._interface.write_calibration(
                             prior_cal.c_min, prior_cal.c_max,
@@ -1400,6 +1559,7 @@ class CalibrationWorkflow:
                         },
                         interface=self._interface,
                         calibration_rolled_back=rolled_back,
+                        consented_below_threshold=consented,
                     )
                     logger.info("Calibration manifest written: %s", json_path)
                 except Exception:
@@ -1423,6 +1583,7 @@ class CalibrationWorkflow:
                     started_timestamp=ts,
                     outcome=outcome,
                     rolled_back=rolled_back,
+                    consented_below_threshold=consented,
                 )
                 with self._lock:
                     self._running = False

--- a/omotion/CalibrationWorkflow.py
+++ b/omotion/CalibrationWorkflow.py
@@ -123,45 +123,6 @@ class CalibrationResultRow:
     hwid: str
 
 
-@dataclass
-class CalibrationResult:
-    ok: bool
-    passed: bool
-    canceled: bool
-    error: str
-    csv_path: str
-    json_path: str
-    calibration: Optional[Calibration]
-    rows: list[CalibrationResultRow]
-    calibration_scan_left_path: str
-    calibration_scan_right_path: str
-    validation_scan_left_path: str
-    validation_scan_right_path: str
-    started_timestamp: str
-
-
-@dataclass
-class TestScanResult:
-    """Outcome of a stand-alone Test scan — phase 1 only, no calibration
-    write, no validation scan. Shape mirrors ``CalibrationResult`` so the
-    bloodflow-app's QML layer can re-use the row formatting code, but the
-    fields are scoped to what a test scan actually produces (no
-    ``calibration`` field — Test scans don't write to console EEPROM, no
-    ``validation_scan_*_path`` — there's no validation scan).
-    """
-    ok: bool
-    passed: bool
-    canceled: bool
-    error: str
-    csv_path: str
-    json_path: str
-    rows: list[CalibrationResultRow]
-    test_scan_left_path: str
-    test_scan_right_path: str
-    started_timestamp: str
-    mode: str = "test"
-
-
 class CalibrationOutcome(str, enum.Enum):
     """Single authoritative terminal state of a calibration / test-scan
     procedure. Replaces consumer-side guessing from the ok/passed/
@@ -185,6 +146,48 @@ def _resolve_outcome(
     if not ok:
         return CalibrationOutcome.ERROR
     return CalibrationOutcome.PASSED if passed else CalibrationOutcome.FAILED
+
+
+@dataclass
+class CalibrationResult:
+    ok: bool
+    passed: bool
+    canceled: bool
+    error: str
+    csv_path: str
+    json_path: str
+    calibration: Optional[Calibration]
+    rows: list[CalibrationResultRow]
+    calibration_scan_left_path: str
+    calibration_scan_right_path: str
+    validation_scan_left_path: str
+    validation_scan_right_path: str
+    started_timestamp: str
+    outcome: CalibrationOutcome = CalibrationOutcome.ERROR
+    rolled_back: bool = False   # set by Task 3
+
+
+@dataclass
+class TestScanResult:
+    """Outcome of a stand-alone Test scan — phase 1 only, no calibration
+    write, no validation scan. Shape mirrors ``CalibrationResult`` so the
+    bloodflow-app's QML layer can re-use the row formatting code, but the
+    fields are scoped to what a test scan actually produces (no
+    ``calibration`` field — Test scans don't write to console EEPROM, no
+    ``validation_scan_*_path`` — there's no validation scan).
+    """
+    ok: bool
+    passed: bool
+    canceled: bool
+    error: str
+    csv_path: str
+    json_path: str
+    rows: list[CalibrationResultRow]
+    test_scan_left_path: str
+    test_scan_right_path: str
+    started_timestamp: str
+    mode: str = "test"
+    outcome: CalibrationOutcome = CalibrationOutcome.ERROR
 
 
 # ---------------------------------------------------------------------------
@@ -637,6 +640,7 @@ def write_result_json(
     scan_paths: dict,
     interface,
     mode: str = "calibrate",
+    outcome: str = "",
 ) -> None:
     """Write a self-describing JSON manifest of the calibration run.
 
@@ -666,6 +670,7 @@ def write_result_json(
         "passed": passed,
         "canceled": canceled,
         "error": error,
+        "outcome": outcome,
         "operator_id": request.operator_id,
         "notes": request.notes,
         "host": _collect_host_info(),
@@ -1012,6 +1017,7 @@ class CalibrationWorkflow:
             passed = False
             error = ""
             canceled = False
+            timed_out = False
 
             logger.info(
                 "Calibration: starting procedure (operator=%s, output_dir=%s, "
@@ -1024,6 +1030,8 @@ class CalibrationWorkflow:
             )
 
             def _watchdog() -> None:
+                nonlocal timed_out
+                timed_out = True
                 self._stop_evt.set()
                 logger.warning(
                     "Calibration watchdog fired after %d sec; aborting.",
@@ -1148,8 +1156,7 @@ class CalibrationWorkflow:
                 flash_ok, flash_err = _flash_sensors()
                 if not flash_ok:
                     error = f"flash phase failed: {flash_err}"
-                    if "canceled" in flash_err:
-                        canceled = True
+                    canceled = self._stop_evt.is_set()   # was: "canceled" in flash_err
                     return
                 logger.info("Calibration phase 0 done: sensors flashed.")
                 if self._stop_evt.is_set():
@@ -1306,13 +1313,27 @@ class CalibrationWorkflow:
                     error = f"{type(e).__name__}: {e}"
             finally:
                 wd.cancel()
-                if self._stop_evt.is_set() and not canceled:
+                # The watchdog is authoritative: if it fired, this run is a
+                # timeout regardless of which phase-boundary check (flash /
+                # scan) already stamped a generic "canceled ..." message —
+                # those messages describe a symptom of the stop_evt the
+                # watchdog itself set, not an independent cancel. Only fall
+                # back to the earlier finally-block guessing (any
+                # unaccounted-for stop_evt is a plain cancel) when the
+                # watchdog did not fire.
+                if timed_out:
+                    canceled = True
+                    error = (
+                        f"calibration exceeded max_duration_sec="
+                        f"{request.max_duration_sec}"
+                    )
+                elif self._stop_evt.is_set() and not canceled:
                     canceled = True
                     if not error:
-                        error = (
-                            f"calibration exceeded max_duration_sec="
-                            f"{request.max_duration_sec}"
-                        )
+                        error = "canceled"
+                outcome = _resolve_outcome(
+                    ok=ok, passed=passed, canceled=canceled, timed_out=timed_out,
+                )
 
                 if cal_obj is not None:
                     logger.info(
@@ -1332,6 +1353,7 @@ class CalibrationWorkflow:
                         passed=passed,
                         canceled=canceled,
                         error=error,
+                        outcome=outcome.value,
                         request=request,
                         rows=rows,
                         calibration=cal_obj,
@@ -1350,8 +1372,8 @@ class CalibrationWorkflow:
 
                 logger.info(
                     "Calibration: procedure complete (ok=%s, passed=%s, "
-                    "canceled=%s, error=%r)",
-                    ok, passed, canceled, error,
+                    "canceled=%s, error=%r, outcome=%s)",
+                    ok, passed, canceled, error, outcome,
                 )
 
                 result = CalibrationResult(
@@ -1363,6 +1385,7 @@ class CalibrationWorkflow:
                     validation_scan_left_path=val_left,
                     validation_scan_right_path=val_right,
                     started_timestamp=ts,
+                    outcome=outcome,
                 )
                 with self._lock:
                     self._running = False
@@ -1423,6 +1446,7 @@ class CalibrationWorkflow:
             passed = False
             error = ""
             canceled = False
+            timed_out = False
 
             logger.info(
                 "Test scan: starting (operator=%s, output_dir=%s, "
@@ -1435,6 +1459,8 @@ class CalibrationWorkflow:
             )
 
             def _watchdog() -> None:
+                nonlocal timed_out
+                timed_out = True
                 self._stop_evt.set()
                 logger.warning(
                     "Test-scan watchdog fired after %d sec; aborting.",
@@ -1521,8 +1547,7 @@ class CalibrationWorkflow:
                 flash_ok, flash_err = _flash_sensors()
                 if not flash_ok:
                     error = f"flash phase failed: {flash_err}"
-                    if "canceled" in flash_err:
-                        canceled = True
+                    canceled = self._stop_evt.is_set()   # was: "canceled" in flash_err
                     return
                 if self._stop_evt.is_set():
                     canceled = True
@@ -1597,13 +1622,23 @@ class CalibrationWorkflow:
                     error = f"{type(e).__name__}: {e}"
             finally:
                 wd.cancel()
-                if self._stop_evt.is_set() and not canceled:
+                # See the calibration worker's identical comment: the
+                # watchdog is authoritative — if it fired, this run is a
+                # timeout regardless of which phase-boundary check already
+                # stamped a generic "canceled ..." message.
+                if timed_out:
+                    canceled = True
+                    error = (
+                        f"test scan exceeded max_duration_sec="
+                        f"{request.max_duration_sec}"
+                    )
+                elif self._stop_evt.is_set() and not canceled:
                     canceled = True
                     if not error:
-                        error = (
-                            f"test scan exceeded max_duration_sec="
-                            f"{request.max_duration_sec}"
-                        )
+                        error = "canceled"
+                outcome = _resolve_outcome(
+                    ok=ok, passed=passed, canceled=canceled, timed_out=timed_out,
+                )
 
                 try:
                     json_path = os.path.join(
@@ -1615,6 +1650,7 @@ class CalibrationWorkflow:
                         passed=passed,
                         canceled=canceled,
                         error=error,
+                        outcome=outcome.value,
                         request=request,
                         rows=rows,
                         calibration=None,
@@ -1632,8 +1668,8 @@ class CalibrationWorkflow:
 
                 logger.info(
                     "Test scan: procedure complete (ok=%s, passed=%s, "
-                    "canceled=%s, error=%r)",
-                    ok, passed, canceled, error,
+                    "canceled=%s, error=%r, outcome=%s)",
+                    ok, passed, canceled, error, outcome,
                 )
 
                 result = TestScanResult(
@@ -1643,6 +1679,7 @@ class CalibrationWorkflow:
                     test_scan_left_path=test_left,
                     test_scan_right_path=test_right,
                     started_timestamp=ts,
+                    outcome=outcome,
                 )
                 with self._lock:
                     self._running = False

--- a/omotion/CalibrationWorkflow.py
+++ b/omotion/CalibrationWorkflow.py
@@ -641,6 +641,7 @@ def write_result_json(
     interface,
     mode: str = "calibrate",
     outcome: str = "",
+    calibration_rolled_back: bool = False,
 ) -> None:
     """Write a self-describing JSON manifest of the calibration run.
 
@@ -671,6 +672,7 @@ def write_result_json(
         "canceled": canceled,
         "error": error,
         "outcome": outcome,
+        "calibration_rolled_back": calibration_rolled_back,
         "operator_id": request.operator_id,
         "notes": request.notes,
         "host": _collect_host_info(),
@@ -1018,6 +1020,9 @@ class CalibrationWorkflow:
             error = ""
             canceled = False
             timed_out = False
+            prior_cal: Optional[Calibration] = None
+            wrote_calibration = False
+            rolled_back = False
 
             logger.info(
                 "Calibration: starting procedure (operator=%s, output_dir=%s, "
@@ -1232,10 +1237,12 @@ class CalibrationWorkflow:
                 _emit_progress("write_calibration")
                 _emit_log("Calibration: writing to console…")
                 logger.info("Calibration phase 3: writing to console EEPROM.")
+                prior_cal = self._interface.get_calibration()
                 cal_obj = self._interface.write_calibration(
                     cal_obj.c_min, cal_obj.c_max,
                     cal_obj.i_min, cal_obj.i_max,
                 )
+                wrote_calibration = True
                 logger.info(
                     "Calibration phase 3 done — calibration written and "
                     "cached (source=%s).", cal_obj.source,
@@ -1335,6 +1342,34 @@ class CalibrationWorkflow:
                     ok=ok, passed=passed, canceled=canceled, timed_out=timed_out,
                 )
 
+                if (
+                    wrote_calibration and prior_cal is not None
+                    and outcome is not CalibrationOutcome.PASSED
+                ):
+                    # The write in phase 3 predates the validation verdict.
+                    # Anything short of PASSED means the new calibration is
+                    # unvalidated — put the previous one back (best-effort;
+                    # the console may be gone).
+                    try:
+                        self._interface.write_calibration(
+                            prior_cal.c_min, prior_cal.c_max,
+                            prior_cal.i_min, prior_cal.i_max,
+                        )
+                        rolled_back = True
+                        _emit_log(
+                            "Calibration: restored previous calibration "
+                            "(run did not pass)."
+                        )
+                        logger.info(
+                            "Calibration: EEPROM rolled back to pre-run values."
+                        )
+                    except Exception as e:
+                        logger.exception("Calibration: EEPROM rollback failed.")
+                        error = (
+                            f"{error}; rollback failed: {e}"
+                            if error else f"rollback failed: {e}"
+                        )
+
                 if cal_obj is not None:
                     logger.info(
                         "Calibration: final calibration on console:\n%s",
@@ -1364,6 +1399,7 @@ class CalibrationWorkflow:
                             "validation_right": val_right,
                         },
                         interface=self._interface,
+                        calibration_rolled_back=rolled_back,
                     )
                     logger.info("Calibration manifest written: %s", json_path)
                 except Exception:
@@ -1386,6 +1422,7 @@ class CalibrationWorkflow:
                     validation_scan_right_path=val_right,
                     started_timestamp=ts,
                     outcome=outcome,
+                    rolled_back=rolled_back,
                 )
                 with self._lock:
                     self._running = False
@@ -1660,6 +1697,7 @@ class CalibrationWorkflow:
                         },
                         interface=self._interface,
                         mode="test",
+                        calibration_rolled_back=False,
                     )
                     logger.info("Test scan manifest written: %s", json_path)
                 except Exception:

--- a/omotion/CalibrationWorkflow.py
+++ b/omotion/CalibrationWorkflow.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import csv
 import datetime
+import enum
 import json
 import logging
 import os
@@ -159,6 +160,31 @@ class TestScanResult:
     test_scan_right_path: str
     started_timestamp: str
     mode: str = "test"
+
+
+class CalibrationOutcome(str, enum.Enum):
+    """Single authoritative terminal state of a calibration / test-scan
+    procedure. Replaces consumer-side guessing from the ok/passed/
+    canceled boolean triple (which allowed 16 combinations, ~5 of them
+    meaningful, and could not distinguish a watchdog timeout from an
+    operator cancel)."""
+    PASSED = "passed"        # ran end-to-end, all cameras met thresholds
+    FAILED = "failed"        # ran end-to-end, >=1 camera missed a threshold
+    CANCELED = "canceled"    # cancel_calibration() stopped it
+    TIMED_OUT = "timed_out"  # max_duration_sec watchdog stopped it
+    ERROR = "error"          # broke before completing (flash, USB, degenerate data, ...)
+
+
+def _resolve_outcome(
+    *, ok: bool, passed: bool, canceled: bool, timed_out: bool,
+) -> CalibrationOutcome:
+    if timed_out:
+        return CalibrationOutcome.TIMED_OUT
+    if canceled:
+        return CalibrationOutcome.CANCELED
+    if not ok:
+        return CalibrationOutcome.ERROR
+    return CalibrationOutcome.PASSED if passed else CalibrationOutcome.FAILED
 
 
 # ---------------------------------------------------------------------------

--- a/omotion/CalibrationWorkflow.py
+++ b/omotion/CalibrationWorkflow.py
@@ -163,7 +163,7 @@ class CalibrationResult:
     validation_scan_left_path: str
     validation_scan_right_path: str
     started_timestamp: str
-    outcome: CalibrationOutcome = CalibrationOutcome.ERROR
+    outcome: Optional[CalibrationOutcome] = None
     rolled_back: bool = False   # set by Task 3
 
 
@@ -187,7 +187,7 @@ class TestScanResult:
     test_scan_right_path: str
     started_timestamp: str
     mode: str = "test"
-    outcome: CalibrationOutcome = CalibrationOutcome.ERROR
+    outcome: Optional[CalibrationOutcome] = None
 
 
 # ---------------------------------------------------------------------------
@@ -1409,7 +1409,7 @@ class CalibrationWorkflow:
                 logger.info(
                     "Calibration: procedure complete (ok=%s, passed=%s, "
                     "canceled=%s, error=%r, outcome=%s)",
-                    ok, passed, canceled, error, outcome,
+                    ok, passed, canceled, error, outcome.value,
                 )
 
                 result = CalibrationResult(
@@ -1707,7 +1707,7 @@ class CalibrationWorkflow:
                 logger.info(
                     "Test scan: procedure complete (ok=%s, passed=%s, "
                     "canceled=%s, error=%r, outcome=%s)",
-                    ok, passed, canceled, error, outcome,
+                    ok, passed, canceled, error, outcome.value,
                 )
 
                 result = TestScanResult(

--- a/omotion/__init__.py
+++ b/omotion/__init__.py
@@ -56,6 +56,7 @@ from . import db_key, db_migrate, db_open, db_schema
 from .SessionPlayback import materialize_corrected_csv
 from .Calibration import Calibration
 from .CalibrationWorkflow import (
+    CalibrationOutcome,
     CalibrationRequest,
     CalibrationResult,
     CalibrationResultRow,
@@ -104,6 +105,7 @@ __all__ = [
     "db_schema",
     "materialize_corrected_csv",
     "Calibration",
+    "CalibrationOutcome",
     "CalibrationRequest",
     "CalibrationResult",
     "CalibrationResultRow",

--- a/omotion/db_key.py
+++ b/omotion/db_key.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import logging
 import secrets
+import sys
 from pathlib import Path
 
 logger = logging.getLogger("omotion.db_key")
@@ -57,7 +58,12 @@ def _keyring():
     that forgets it fails at the first keystore touch. Mirrors how ``db_open``
     handles the ``sqlcipher3`` import — the message has to name the fix, because
     the place this surfaces is a packaged clinical app on a bench.
+
+    Also the single chokepoint where macOS is refused: every keystore touch in
+    this module (``_assert_backend``, ``get_key``, ``import_key``, and
+    ``export_key`` via ``get_key``) routes through here.
     """
+    _assert_keystore_platform()
     try:
         import keyring
     except ImportError as exc:  # pragma: no cover - exercised via monkeypatch
@@ -71,15 +77,57 @@ def _keyring():
     return keyring
 
 
+def _assert_keystore_platform() -> None:
+    """Refuse every keystore access on macOS.
+
+    macOS is a research-only platform for this product — it is never shipped in
+    clinical mode, so the encrypted scan DB (and therefore the keystore) has no
+    role there. The macOS Keychain would be a technically adequate backend, but
+    accepting it would mean the encryption path silently exists on a platform
+    that is not validated for clinical use. Reaching the keystore on darwin is
+    therefore a build/configuration error, and a loud one is better than a
+    working-but-unvalidated encryption path.
+
+    A macOS *research* build never gets here: ``require_encryption()`` is False,
+    so ``db_open`` takes the plaintext branch without asking for a key.
+    """
+    if sys.platform == "darwin":
+        raise EncryptionUnavailable(
+            "the scan-database keystore is not available on macOS. macOS builds "
+            "are research-only and are never validated for clinical mode, so the "
+            "encryption policy must stay off (require_encryption=False) there. "
+            "Reaching the keystore on macOS means something enabled the clinical "
+            "encryption path on an unsupported platform — fix the build config "
+            "rather than the keystore."
+        )
+
+
+# The OS-owned keystores approved to hold the scan-db key, by backend module.
+# Windows Credential Manager is the only one: it is hardware/OS-protected and
+# per-user, and Windows is the only platform shipped in clinical mode. The
+# macOS Keychain is deliberately absent — see _assert_keystore_platform, which
+# refuses darwin outright and fires before this check is ever reached.
+#
+# Everything else is rejected — most importantly ``keyrings.alt`` (plaintext or
+# obfuscated files), ``keyring.backends.fail`` (no keystore at all) and
+# ``keyring.backends.chainer`` (defers to whatever it discovered, so it cannot
+# be verified up front). Matching on the module rather than the class name
+# matters: a plaintext backend is free to call its class ``WinVaultKeyring``,
+# and a name-only check would wave it through.
+_SUPPORTED_BACKENDS = {
+    "keyring.backends.Windows": "Windows Credential Manager",
+}
+
+
 def _assert_backend() -> None:
     keyring = _keyring()
 
     kr = keyring.get_keyring()
-    # Windows Credential Manager is the supported clinical backend.
-    if "WinVault" not in type(kr).__name__ and "Windows" not in type(kr).__module__:
+    if type(kr).__module__ not in _SUPPORTED_BACKENDS:
+        supported = ", ".join(sorted(_SUPPORTED_BACKENDS.values()))
         raise EncryptionUnavailable(
-            "encryption policy requires the Windows Credential Manager keyring, "
-            f"got {type(kr).__module__}.{type(kr).__name__}"
+            f"encryption policy requires an OS keystore ({supported}), got "
+            f"{type(kr).__module__}.{type(kr).__name__}"
         )
 
 

--- a/scripts/protocol_test.py
+++ b/scripts/protocol_test.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Packet-protocol verification utility (console UART path).
+
+Exercises the framing, CRC, transaction-ID, response-type and payload-bound
+clauses of SWREQ-196 / SWREQ-197 / SWREQ-202 by constructing frames directly
+(including deliberately malformed ones) and reporting the response packet type.
+
+Every check prints the transmitted frame and the received response type, so the
+console output is the test record.
+
+Usage:
+    python scripts/protocol_test.py --list
+    python scripts/protocol_test.py --check crc-mismatch
+    python scripts/protocol_test.py --check all
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from omotion import MotionInterface
+from omotion.UartPacket import UartPacket
+from omotion.config import (
+    OW_ACK, OW_NAK, OW_CMD, OW_RESP, OW_DATA, OW_JSON,
+    OW_CONTROLLER, OW_FPGA_PROG,
+    OW_BAD_PARSE, OW_BAD_CRC, OW_UNKNOWN, OW_ERROR,
+    OW_START_BYTE, OW_END_BYTE,
+    OW_CMD_PING, OW_CMD_VERSION, OW_CMD_ECHO,
+)
+
+DEFINED_RESPONSES = {
+    OW_ACK: "OW_ACK", OW_NAK: "OW_NAK", OW_RESP: "OW_RESP",
+    OW_DATA: "OW_DATA", OW_JSON: "OW_JSON", OW_BAD_PARSE: "OW_BAD_PARSE",
+    OW_BAD_CRC: "OW_BAD_CRC", OW_UNKNOWN: "OW_UNKNOWN", OW_ERROR: "OW_ERROR",
+}
+
+_observed: set[int] = set()
+
+
+def name_of(pt) -> str:
+    if pt is None:
+        return "NO RESPONSE"
+    return f"{DEFINED_RESPONSES.get(pt, 'UNDEFINED')} (0x{pt:02X})"
+
+
+def build(tid=0x0001, ptype=OW_CMD, command=OW_CMD_PING, addr=0, reserved=0, data=None):
+    return UartPacket(id=tid, packetType=ptype, command=command,
+                      addr=addr, reserved=reserved, data=data or [])
+
+
+def show_tx(raw: bytes, label: str = "TX") -> None:
+    head = " ".join(f"{b:02X}" for b in raw[:12])
+    tail = " ".join(f"{b:02X}" for b in raw[-3:])
+    print(f"  {label} ({len(raw)} bytes): {head}{' ... ' if len(raw) > 15 else ' '}{tail}")
+
+
+def send_raw(uart, raw: bytes, timeout: int = 5):
+    """Write raw bytes and read whatever comes back. None on timeout."""
+    show_tx(raw)
+    try:
+        uart._tx(bytes(raw))
+        resp = uart.read_packet(timeout=timeout)
+    except Exception as exc:                      # timeout / parse failure
+        print(f"  RX: none ({type(exc).__name__}: {exc})")
+        return None
+    if resp is None:
+        print("  RX: none")
+        return None
+    _observed.add(resp.packetType)
+    print(f"  RX: type={name_of(resp.packetType)} tid=0x{resp.id:04X} len={resp.data_len}")
+    return resp
+
+
+# --------------------------------------------------------------------------- #
+# Checks
+# --------------------------------------------------------------------------- #
+
+def check_frame_format(uart):
+    """Transmitted frame matches the specified fixed layout."""
+    pkt = build(tid=0x0101, command=OW_CMD_VERSION)
+    raw = pkt.to_bytes()
+    show_tx(raw, "FRAME")
+    print(f"  start=0x{raw[0]:02X} tid=0x{raw[1]:02X}{raw[2]:02X} type=0x{raw[3]:02X} "
+          f"cmd=0x{raw[4]:02X} addr=0x{raw[5]:02X} reserved=0x{raw[6]:02X} "
+          f"len={int.from_bytes(raw[7:9],'big')} crc=0x{raw[-3]:02X}{raw[-2]:02X} end=0x{raw[-1]:02X}")
+    ok = raw[0] == OW_START_BYTE and raw[-1] == OW_END_BYTE and raw[6] == 0
+    resp = send_raw(uart, raw)
+    return ok and resp is not None
+
+
+def check_tid_echo(uart):
+    """Transaction ID echoed unchanged."""
+    resp = send_raw(uart, build(tid=0x1234, command=OW_CMD_VERSION).to_bytes())
+    return resp is not None and resp.id == 0x1234
+
+
+def check_crc_mismatch(uart):
+    """Corrupted CRC -> OW_BAD_CRC, command not executed."""
+    raw = bytearray(build(tid=0x0202, command=OW_CMD_VERSION).to_bytes())
+    raw[-3] ^= 0xFF                                # corrupt CRC field
+    resp = send_raw(uart, raw)
+    return resp is not None and resp.packetType == OW_BAD_CRC
+
+
+def check_no_start(uart):
+    """Absent start byte -> framing error."""
+    raw = bytearray(build(tid=0x0303).to_bytes())
+    raw[0] = 0x55
+    resp = send_raw(uart, raw)
+    return resp is None or resp.packetType in (OW_BAD_PARSE, OW_UNKNOWN)
+
+
+def check_no_end(uart):
+    """Absent end byte -> framing error."""
+    raw = bytearray(build(tid=0x0404).to_bytes())[:-1]
+    resp = send_raw(uart, raw)
+    return resp is None or resp.packetType in (OW_BAD_PARSE, OW_UNKNOWN)
+
+
+def check_bad_length(uart):
+    """Declared length inconsistent with frame -> framing error."""
+    raw = bytearray(build(tid=0x0505, data=[1, 2, 3, 4]).to_bytes())
+    raw[7:9] = (99).to_bytes(2, "big")             # claim 99 bytes, send 4
+    resp = send_raw(uart, raw)
+    return resp is None or resp.packetType in (OW_BAD_PARSE, OW_UNKNOWN)
+
+
+def check_oversize(uart):
+    """Declared payload > 2048 -> OW_BAD_PARSE, payload not buffered."""
+    raw = bytearray(build(tid=0x0606, data=[0] * 16).to_bytes())
+    raw[7:9] = (2049).to_bytes(2, "big")
+    resp = send_raw(uart, raw)
+    return resp is None or resp.packetType == OW_BAD_PARSE
+
+
+def check_payload_bounds(uart):
+    """0-byte and 2048-byte payloads accepted."""
+    ok = True
+    for n in (0, 2048):
+        print(f"  -- echo payload {n} bytes")
+        resp = send_raw(uart, build(tid=0x0700 + (n & 0xFF),
+                                    command=OW_CMD_ECHO,
+                                    data=[0xA5] * n).to_bytes(), timeout=10)
+        ok = ok and resp is not None and resp.packetType not in (OW_BAD_PARSE, OW_BAD_CRC)
+    return ok
+
+
+def check_unknown_opcode(uart):
+    """Undefined opcode and undefined packet type -> OW_UNKNOWN."""
+    r1 = send_raw(uart, build(tid=0x0801, command=0x7E).to_bytes())
+    r2 = send_raw(uart, build(tid=0x0802, ptype=0xC3).to_bytes())
+    return all(r is not None and r.packetType == OW_UNKNOWN for r in (r1, r2))
+
+
+def check_reserved_nonzero(uart):
+    """Reserved byte non-zero -> rejected, no effect."""
+    resp = send_raw(uart, build(tid=0x0901, reserved=0x01).to_bytes())
+    return resp is None or resp.packetType in (OW_UNKNOWN, OW_BAD_PARSE)
+
+
+def check_bad_subtarget(uart):
+    """Non-existent sub-target -> rejected."""
+    resp = send_raw(uart, build(tid=0x0A01, ptype=OW_CONTROLLER,
+                                command=0x19, addr=0x7F).to_bytes())
+    return resp is None or resp.packetType in (OW_UNKNOWN, OW_ERROR)
+
+
+def check_ordering(uart):
+    """Responses returned in the order commands were sent."""
+    sent, got = [], []
+    for i in range(10):
+        tid = 0x0B00 + i
+        sent.append(tid)
+        r = send_raw(uart, build(tid=tid, command=OW_CMD_VERSION).to_bytes())
+        got.append(r.id if r else None)
+    print(f"  sent tids: {[hex(t) for t in sent]}")
+    print(f"  recv tids: {[hex(t) if t else None for t in got]}")
+    return sent == got
+
+
+def check_command_sweep(uart):
+    """Send every defined opcode in each packet type; record responses."""
+    sets = {
+        "OW_CMD": (OW_CMD, list(range(0x00, 0x10))),
+        "OW_CONTROLLER": (OW_CONTROLLER, list(range(0x10, 0x2B))),
+        "OW_FPGA_PROG": (OW_FPGA_PROG, list(range(0x30, 0x40))),
+    }
+    ok = True
+    for label, (ptype, opcodes) in sets.items():
+        print(f"  -- {label}")
+        for op in opcodes:
+            r = send_raw(uart, build(tid=0x0C00 + op, ptype=ptype, command=op).to_bytes())
+            if r is None or r.packetType == OW_UNKNOWN:
+                print(f"     opcode 0x{op:02X}: NOT IMPLEMENTED")
+                ok = False
+    return ok
+
+
+def check_response_set(uart):
+    """Every response type observed so far is within the defined set."""
+    undefined = [pt for pt in _observed if pt not in DEFINED_RESPONSES]
+    print(f"  observed: {sorted(name_of(p) for p in _observed)}")
+    if undefined:
+        print(f"  UNDEFINED TYPES SEEN: {[hex(p) for p in undefined]}")
+    return not undefined
+
+
+CHECKS = {
+    "frame-format": check_frame_format,
+    "tid-echo": check_tid_echo,
+    "crc-mismatch": check_crc_mismatch,
+    "no-start": check_no_start,
+    "no-end": check_no_end,
+    "bad-length": check_bad_length,
+    "oversize": check_oversize,
+    "payload-bounds": check_payload_bounds,
+    "unknown-opcode": check_unknown_opcode,
+    "reserved-nonzero": check_reserved_nonzero,
+    "bad-subtarget": check_bad_subtarget,
+    "ordering": check_ordering,
+    "command-sweep": check_command_sweep,
+    "response-set": check_response_set,
+}
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--check", default="all", help="check name, or 'all'")
+    p.add_argument("--list", action="store_true", help="list available checks")
+    args = p.parse_args()
+
+    if args.list:
+        for k, fn in CHECKS.items():
+            print(f"  {k:20s} {(fn.__doc__ or '').strip()}")
+        return 0
+
+    if args.check != "all" and args.check not in CHECKS:
+        print(f"Unknown check '{args.check}'. Use --list.")
+        return 2
+
+    iface = MotionInterface()
+    iface.start()
+    iface.wait_for_ready(console=True, sensors=0, timeout=15)
+    console_ok, _, _ = iface.is_device_connected()
+    if not console_ok:
+        print("Console not connected — check the cable and that no other app holds the port.")
+        iface.stop()
+        return 1
+
+    uart = iface.console.uart
+    selected = list(CHECKS) if args.check == "all" else [args.check]
+    results = {}
+
+    try:
+        for name in selected:
+            print(f"\n=== {name} ===")
+            try:
+                results[name] = bool(CHECKS[name](uart))
+            except Exception as exc:
+                print(f"  EXCEPTION: {type(exc).__name__}: {exc}")
+                results[name] = False
+            print(f"  RESULT: {'PASS' if results[name] else 'REVIEW'}")
+    finally:
+        iface.stop()
+
+    print("\n=== SUMMARY ===")
+    for name, ok in results.items():
+        print(f"  {name:20s} {'PASS' if ok else 'REVIEW'}")
+    return 0 if all(results.values()) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/protocol_test.py
+++ b/scripts/protocol_test.py
@@ -55,12 +55,54 @@ def show_tx(raw: bytes, label: str = "TX") -> None:
     print(f"  {label} ({len(raw)} bytes): {head}{' ... ' if len(raw) > 15 else ' '}{tail}")
 
 
-def send_raw(uart, raw: bytes, timeout: int = 5):
+class Transport:
+    """Uniform raw-frame send/receive over either the console UART or a
+    sensor's COMMS bulk endpoint.
+
+    Both paths speak the same `UartPacket` frame; only the byte pipe differs.
+    """
+
+    def __init__(self, kind: str, handle):
+        self.kind = kind          # "console" | "sensor"
+        self.handle = handle      # MotionUart | CommInterface
+        self._paused_reader = False
+
+    def __enter__(self):
+        # A sensor in async mode runs a reader thread that would consume the
+        # responses we want to inspect; pause it for the duration.
+        if self.kind == "sensor" and getattr(self.handle, "async_mode", False):
+            try:
+                self.handle.stop_read_thread()
+                self._paused_reader = True
+            except Exception:
+                pass
+        return self
+
+    def __exit__(self, *exc):
+        if self._paused_reader:
+            try:
+                self.handle.start_read_thread()
+            except Exception:
+                pass
+        return False
+
+    def send(self, raw: bytes, timeout: int = 5):
+        if self.kind == "console":
+            self.handle._tx(bytes(raw))
+            return self.handle.read_packet(timeout=timeout)
+        # sensor: raw bulk write, then read and parse one frame
+        self.handle.write(bytes(raw), timeout=max(100, timeout * 1000))
+        data = self.handle.receive(length=4096, timeout=max(100, timeout * 1000))
+        if not data:
+            return None
+        return UartPacket(buffer=bytes(data))
+
+
+def send_raw(tp: "Transport", raw: bytes, timeout: int = 5):
     """Write raw bytes and read whatever comes back. None on timeout."""
     show_tx(raw)
     try:
-        uart._tx(bytes(raw))
-        resp = uart.read_packet(timeout=timeout)
+        resp = tp.send(raw, timeout=timeout)
     except Exception as exc:                      # timeout / parse failure
         print(f"  RX: none ({type(exc).__name__}: {exc})")
         return None
@@ -229,6 +271,10 @@ def main() -> int:
                                 formatter_class=argparse.RawDescriptionHelpFormatter)
     p.add_argument("--check", default="all", help="check name, or 'all'")
     p.add_argument("--list", action="store_true", help="list available checks")
+    p.add_argument("--target", default="console", choices=("console", "sensor"),
+                   help="device under test (default: console)")
+    p.add_argument("--side", default="left", choices=("left", "right"),
+                   help="sensor side when --target sensor (default: left)")
     args = p.parse_args()
 
     if args.list:
@@ -242,26 +288,44 @@ def main() -> int:
 
     iface = MotionInterface()
     iface.start()
-    iface.wait_for_ready(console=True, sensors=0, timeout=15)
-    console_ok, _, _ = iface.is_device_connected()
-    if not console_ok:
-        print("Console not connected — check the cable and that no other app holds the port.")
-        iface.stop()
-        return 1
+    want_sensors = 1 if args.target == "sensor" else 0
+    iface.wait_for_ready(console=args.target == "console",
+                         sensors=want_sensors, timeout=15)
+    console_ok, left_ok, right_ok = iface.is_device_connected()
 
-    uart = iface.console.uart
+    if args.target == "console":
+        if not console_ok:
+            print("Console not connected — check the cable and that no other app holds the port.")
+            iface.stop()
+            return 1
+        handle, kind = iface.console.uart, "console"
+    else:
+        sensor = iface.left if args.side == "left" else iface.right
+        if not (left_ok if args.side == "left" else right_ok):
+            print(f"{args.side.capitalize()} sensor not connected — check the cable "
+                  "and that no other app holds the device.")
+            iface.stop()
+            return 1
+        if sensor.uart is None or getattr(sensor.uart, "comm", None) is None:
+            print("Sensor COMMS interface unavailable.")
+            iface.stop()
+            return 1
+        handle, kind = sensor.uart.comm, "sensor"
+
+    print(f"Target: {kind}" + (f" ({args.side})" if kind == "sensor" else ""))
     selected = list(CHECKS) if args.check == "all" else [args.check]
     results = {}
 
     try:
-        for name in selected:
-            print(f"\n=== {name} ===")
-            try:
-                results[name] = bool(CHECKS[name](uart))
-            except Exception as exc:
-                print(f"  EXCEPTION: {type(exc).__name__}: {exc}")
-                results[name] = False
-            print(f"  RESULT: {'PASS' if results[name] else 'REVIEW'}")
+        with Transport(kind, handle) as tp:
+            for name in selected:
+                print(f"\n=== {name} ===")
+                try:
+                    results[name] = bool(CHECKS[name](tp))
+                except Exception as exc:
+                    print(f"  EXCEPTION: {type(exc).__name__}: {exc}")
+                    results[name] = False
+                print(f"  RESULT: {'PASS' if results[name] else 'REVIEW'}")
     finally:
         iface.stop()
 

--- a/scripts/qisda_serial.py
+++ b/scripts/qisda_serial.py
@@ -1,0 +1,224 @@
+"""Qisda serial number validation and generation for Openwater Motion / LIFU products.
+
+Format (11 characters), per "Qisda Serial Number naming rule":
+
+    W  WWA  4  Q  4  0  001
+    |   |   |  |  |  |   |
+    |   |   |  |  |  |   +-- Rolling number (001-999)
+    |   |   |  |  |  +------ Qisda MFG (fixed '0')
+    |   |   |  |  +--------- MFG month code
+    |   |   |  +------------ MFG year code (Q=2026, R=2027, S=2028, T=2029)
+    |   |   +--------------- Product stage (DVT=4, PVT=5, MP=6)
+    |   +------------------- Product category (3 chars)
+    +----------------------- Openwater (fixed 'W')
+
+The rolling number is tracked per unique serial prefix (everything before the
+rolling number) in a small JSON file, so counts reset naturally for each
+category/stage/year/month combination.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+# --- Field code tables -------------------------------------------------------
+
+OPENWATER_PREFIX = "W"
+QISDA_MFG = "0"  # fixed
+
+MOTION_CATEGORIES = {
+    "900-00013": "WW0",
+    "900-00010": "WWA",
+}
+
+LIFU_CATEGORIES = {
+    "TOP_LEVEL": "L11",
+    "CONSOLE": "L01",
+    "ENCLOSURE_1X_155": "L02",
+    "ENCLOSURE_2X_155": "L04",
+    "ENCLOSURE_1X_400": "L06",
+    "ENCLOSURE_2X_400": "L08",
+    "TRANSMIT_MODULE_155": "LM1",
+    "TRANSMIT_MODULE_400": "LM0",
+}
+
+# code -> (family, product name)
+CATEGORY_CODES = {code: ("motion", name) for name, code in MOTION_CATEGORIES.items()}
+CATEGORY_CODES.update({code: ("lifu", name) for name, code in LIFU_CATEGORIES.items()})
+
+STAGES = {"DVT": "4", "PVT": "5", "MP": "6"}
+STAGE_CODES = {v: k for k, v in STAGES.items()}
+
+YEARS = {2026: "Q", 2027: "R", 2028: "S", 2029: "T"}
+YEAR_CODES = {v: k for k, v in YEARS.items()}
+
+# Rule sheet documents 4=Apr .. 7=Jul; months 1-9 follow the same digit
+# pattern. Oct-Dec codes (A/B/C) are an assumption pending Qisda confirmation.
+MONTHS = {m: str(m) for m in range(1, 10)}
+MONTHS.update({10: "A", 11: "B", 12: "C"})
+MONTH_CODES = {v: k for k, v in MONTHS.items()}
+
+_SERIAL_RE = re.compile(
+    r"^W"
+    r"(?P<category>[A-Z0-9]{3})"
+    r"(?P<stage>[456])"
+    r"(?P<year>[QRST])"
+    r"(?P<month>[1-9ABC])"
+    r"0"
+    r"(?P<rolling>\d{3})$"
+)
+
+
+class SerialNumberError(ValueError):
+    """Raised when a serial number is malformed or a field is unknown."""
+
+
+@dataclass(frozen=True)
+class SerialNumber:
+    """A parsed, valid Qisda serial number."""
+
+    serial: str
+    family: str          # "motion" or "lifu"
+    product: str         # e.g. "900-00013" or "CONSOLE"
+    category_code: str   # e.g. "WW0", "L01"
+    stage: str           # "DVT", "PVT", "MP"
+    year: int            # e.g. 2026
+    month: int           # 1-12
+    rolling: int         # 1-999
+
+    def __str__(self) -> str:
+        return self.serial
+
+
+class QisdaSerialManager:
+    """Validates existing serials and generates new ones with tracked rolling numbers."""
+
+    def __init__(self, counter_file: str | Path = "serial_counters.json"):
+        self.counter_file = Path(counter_file)
+
+    # --- Validation ----------------------------------------------------------
+
+    @staticmethod
+    def parse(serial: str) -> SerialNumber:
+        """Parse and validate a serial number; raises SerialNumberError if invalid."""
+        serial = serial.strip().upper()
+        m = _SERIAL_RE.match(serial)
+        if not m:
+            raise SerialNumberError(
+                f"{serial!r} does not match the 11-char format "
+                f"W<CAT:3><STAGE><YEAR><MONTH>0<ROLL:3>"
+            )
+
+        cat = m.group("category")
+        if cat not in CATEGORY_CODES:
+            raise SerialNumberError(f"Unknown product category code {cat!r}")
+        family, product = CATEGORY_CODES[cat]
+
+        rolling = int(m.group("rolling"))
+        if rolling == 0:
+            raise SerialNumberError("Rolling number must be 001-999")
+
+        return SerialNumber(
+            serial=serial,
+            family=family,
+            product=product,
+            category_code=cat,
+            stage=STAGE_CODES[m.group("stage")],
+            year=YEAR_CODES[m.group("year")],
+            month=MONTH_CODES[m.group("month")],
+            rolling=rolling,
+        )
+
+    @classmethod
+    def is_valid(cls, serial: str) -> bool:
+        try:
+            cls.parse(serial)
+            return True
+        except SerialNumberError:
+            return False
+
+    # --- Generation ----------------------------------------------------------
+
+    def create(self, product: str, stage: str, year: int, month: int) -> SerialNumber:
+        """Create the next serial number for the given product/stage/year/month.
+
+        product: a Motion part number ("900-00013", "900-00010"), a LIFU product
+                 name ("TOP_LEVEL", "CONSOLE", "ENCLOSURE_1X_155", ...), or a raw
+                 category code ("WW0", "L11", "LM0", ...).
+        stage:   "DVT", "PVT", or "MP"
+        year:    2026-2029
+        month:   1-12
+        """
+        cat = self._resolve_category(product)
+
+        stage_key = stage.strip().upper()
+        if stage_key not in STAGES:
+            raise SerialNumberError(f"Unknown stage {stage!r}; expected one of {list(STAGES)}")
+        if year not in YEARS:
+            raise SerialNumberError(f"Unsupported year {year}; expected one of {list(YEARS)}")
+        if month not in MONTHS:
+            raise SerialNumberError(f"Invalid month {month}; expected 1-12")
+
+        prefix = f"{OPENWATER_PREFIX}{cat}{STAGES[stage_key]}{YEARS[year]}{MONTHS[month]}{QISDA_MFG}"
+        rolling = self._next_rolling(prefix)
+        return self.parse(f"{prefix}{rolling:03d}")
+
+    @staticmethod
+    def _resolve_category(product: str) -> str:
+        key = product.strip().upper()
+        if key in MOTION_CATEGORIES:
+            return MOTION_CATEGORIES[key]
+        if key in LIFU_CATEGORIES:
+            return LIFU_CATEGORIES[key]
+        if key in CATEGORY_CODES:
+            return key  # already a raw category code
+        known = list(MOTION_CATEGORIES) + list(LIFU_CATEGORIES) + list(CATEGORY_CODES)
+        raise SerialNumberError(f"Unknown product {product!r}; expected one of {known}")
+
+    # --- Rolling number persistence -------------------------------------------
+
+    def _load_counters(self) -> dict[str, int]:
+        if self.counter_file.exists():
+            return json.loads(self.counter_file.read_text())
+        return {}
+
+    def _next_rolling(self, prefix: str) -> int:
+        counters = self._load_counters()
+        next_num = counters.get(prefix, 0) + 1
+        if next_num > 999:
+            raise SerialNumberError(f"Rolling number exhausted (999) for prefix {prefix}")
+        counters[prefix] = next_num
+        self.counter_file.write_text(json.dumps(counters, indent=2, sort_keys=True))
+        return next_num
+
+    def register(self, serial: str) -> SerialNumber:
+        """Record an externally issued serial so future create() calls continue after it."""
+        parsed = self.parse(serial)
+        prefix = parsed.serial[:8]
+        counters = self._load_counters()
+        if parsed.rolling > counters.get(prefix, 0):
+            counters[prefix] = parsed.rolling
+            self.counter_file.write_text(json.dumps(counters, indent=2, sort_keys=True))
+        return parsed
+
+
+if __name__ == "__main__":
+    mgr = QisdaSerialManager()
+
+    # Generate a few serials
+    s1 = mgr.create("900-00013", stage="DVT", year=2026, month=4)
+    s2 = mgr.create("900-00013", stage="DVT", year=2026, month=4)
+    s3 = mgr.create("CONSOLE", stage="PVT", year=2027, month=6)
+    print(f"Motion: {s1}  {s2}")
+    print(f"LIFU:   {s3}")
+
+    # Validate
+    for sn in [str(s1), "WWWA4Q40001", "WL014RQ0001", "XXX", "WZZZ4Q40001"]:
+        if QisdaSerialManager.is_valid(sn):
+            p = QisdaSerialManager.parse(sn)
+            print(f"{sn}: VALID  ({p.family} {p.product}, {p.stage}, {p.month}/{p.year}, #{p.rolling})")
+        else:
+            print(f"{sn}: INVALID")

--- a/scripts/qisda_serial.py
+++ b/scripts/qisda_serial.py
@@ -142,7 +142,8 @@ class QisdaSerialManager:
 
     # --- Generation ----------------------------------------------------------
 
-    def create(self, product: str, stage: str, year: int, month: int) -> SerialNumber:
+    def create(self, product: str, stage: str, year: int, month: int,
+               rolling: int | None = None) -> SerialNumber:
         """Create the next serial number for the given product/stage/year/month.
 
         product: a Motion part number ("900-00013", "900-00010"), a LIFU product
@@ -151,6 +152,9 @@ class QisdaSerialManager:
         stage:   "DVT", "PVT", or "MP"
         year:    2026-2029
         month:   1-12
+        rolling: optional explicit rolling number (1-999) when counting is done
+                 externally; the local counter is advanced to at least this value
+                 so later auto-generated serials continue after it.
         """
         cat = self._resolve_category(product)
 
@@ -163,7 +167,12 @@ class QisdaSerialManager:
             raise SerialNumberError(f"Invalid month {month}; expected 1-12")
 
         prefix = f"{OPENWATER_PREFIX}{cat}{STAGES[stage_key]}{YEARS[year]}{MONTHS[month]}{QISDA_MFG}"
-        rolling = self._next_rolling(prefix)
+        if rolling is None:
+            rolling = self._next_rolling(prefix)
+        else:
+            if not 1 <= rolling <= 999:
+                raise SerialNumberError(f"Rolling number {rolling} out of range 1-999")
+            self._sync_rolling(prefix, rolling)
         return self.parse(f"{prefix}{rolling:03d}")
 
     @staticmethod
@@ -194,31 +203,161 @@ class QisdaSerialManager:
         self.counter_file.write_text(json.dumps(counters, indent=2, sort_keys=True))
         return next_num
 
+    def _sync_rolling(self, prefix: str, rolling: int) -> None:
+        """Advance the counter for prefix to at least rolling (never backwards)."""
+        counters = self._load_counters()
+        if rolling > counters.get(prefix, 0):
+            counters[prefix] = rolling
+            self.counter_file.write_text(json.dumps(counters, indent=2, sort_keys=True))
+
     def register(self, serial: str) -> SerialNumber:
         """Record an externally issued serial so future create() calls continue after it."""
         parsed = self.parse(serial)
-        prefix = parsed.serial[:8]
-        counters = self._load_counters()
-        if parsed.rolling > counters.get(prefix, 0):
-            counters[prefix] = parsed.rolling
-            self.counter_file.write_text(json.dumps(counters, indent=2, sort_keys=True))
+        self._sync_rolling(parsed.serial[:8], parsed.rolling)
         return parsed
 
 
 if __name__ == "__main__":
-    mgr = QisdaSerialManager()
+    # Self-test: run `python qisda_serial.py` — prints PASS/FAIL per check and
+    # exits non-zero on any failure. Uses a temp counter file; no state left behind.
+    import sys
+    import tempfile
 
-    # Generate a few serials
-    s1 = mgr.create("900-00013", stage="DVT", year=2026, month=4)
-    s2 = mgr.create("900-00013", stage="DVT", year=2026, month=4)
-    s3 = mgr.create("CONSOLE", stage="PVT", year=2027, month=6)
-    print(f"Motion: {s1}  {s2}")
-    print(f"LIFU:   {s3}")
+    failures = []
 
-    # Validate
-    for sn in [str(s1), "WWWA4Q40001", "WL014RQ0001", "XXX", "WZZZ4Q40001"]:
-        if QisdaSerialManager.is_valid(sn):
-            p = QisdaSerialManager.parse(sn)
-            print(f"{sn}: VALID  ({p.family} {p.product}, {p.stage}, {p.month}/{p.year}, #{p.rolling})")
-        else:
-            print(f"{sn}: INVALID")
+    def check(name: str, condition: bool, detail: str = ""):
+        status = "PASS" if condition else "FAIL"
+        print(f"[{status}] {name}" + (f"  ({detail})" if detail and not condition else ""))
+        if not condition:
+            failures.append(name)
+
+    def raises(fn, *args, **kwargs) -> bool:
+        try:
+            fn(*args, **kwargs)
+            return False
+        except SerialNumberError:
+            return True
+
+    with tempfile.TemporaryDirectory() as tmp:
+        mgr = QisdaSerialManager(counter_file=Path(tmp) / "counters.json")
+
+        # --- Generation: format and field encoding ---------------------------
+        s = mgr.create("900-00013", stage="DVT", year=2026, month=4)
+        check("motion serial format", s.serial == "WWW04Q40001", s.serial)
+        check("parsed family", s.family == "motion")
+        check("parsed product", s.product == "900-00013")
+        check("parsed stage", s.stage == "DVT")
+        check("parsed year", s.year == 2026)
+        check("parsed month", s.month == 4)
+        check("parsed rolling", s.rolling == 1)
+
+        s = mgr.create("900-00010", stage="PVT", year=2027, month=5)
+        check("category WWA / stage 5 / year R", s.serial == "WWWA5R50001", s.serial)
+        s = mgr.create("TOP_LEVEL", stage="MP", year=2028, month=6)
+        check("LIFU L11 / stage 6 / year S", s.serial == "WL116S60001", s.serial)
+        s = mgr.create("TRANSMIT_MODULE_400", stage="DVT", year=2029, month=7)
+        check("LIFU LM0 / year T", s.serial == "WLM04T70001", s.serial)
+        s = mgr.create("L02", stage="DVT", year=2026, month=1)
+        check("raw category code accepted", s.serial == "WL024Q10001", s.serial)
+        s = mgr.create("console", stage="mp", year=2026, month=12)
+        check("case-insensitive product/stage, Dec month", s.serial == "WL016QC0001", s.serial)
+        s = mgr.create("CONSOLE", stage="MP", year=2026, month=10)
+        check("Oct month code A", s.serial[6] == "A", s.serial)
+
+        # --- Rolling counter: increment, isolation, persistence --------------
+        a1 = mgr.create("900-00013", stage="DVT", year=2026, month=4)
+        a2 = mgr.create("900-00013", stage="DVT", year=2026, month=4)
+        check("rolling increments", (a1.rolling, a2.rolling) == (2, 3),
+              f"{a1.rolling},{a2.rolling}")
+        b = mgr.create("900-00013", stage="DVT", year=2026, month=5)
+        check("different month = separate counter", b.rolling == 1, str(b.rolling))
+        c = mgr.create("900-00013", stage="PVT", year=2026, month=4)
+        check("different stage = separate counter", c.rolling == 1, str(c.rolling))
+
+        mgr2 = QisdaSerialManager(counter_file=mgr.counter_file)
+        a3 = mgr2.create("900-00013", stage="DVT", year=2026, month=4)
+        check("counter persists across instances", a3.rolling == 4, str(a3.rolling))
+
+        # --- Explicit rolling override (external counting) --------------------
+        e = mgr.create("900-00013", stage="DVT", year=2026, month=4, rolling=42)
+        check("explicit rolling used", e.serial == "WWW04Q40042", e.serial)
+        after = mgr.create("900-00013", stage="DVT", year=2026, month=4)
+        check("counter advanced past override", after.rolling == 43, str(after.rolling))
+        low = mgr.create("900-00013", stage="DVT", year=2026, month=4, rolling=5)
+        nxt = mgr.create("900-00013", stage="DVT", year=2026, month=4)
+        check("lower override does not rewind counter",
+              low.rolling == 5 and nxt.rolling == 44, f"{low.rolling},{nxt.rolling}")
+        check("rolling 0 rejected", raises(mgr.create, "900-00013", stage="DVT",
+                                           year=2026, month=4, rolling=0))
+        check("rolling 1000 rejected", raises(mgr.create, "900-00013", stage="DVT",
+                                              year=2026, month=4, rolling=1000))
+
+        # --- register() external serials --------------------------------------
+        r = mgr.register("WL014R60123")
+        check("register parses", r.rolling == 123 and r.product == "CONSOLE")
+        cont = mgr.create("CONSOLE", stage="DVT", year=2027, month=6)
+        check("create continues after registered", cont.rolling == 124, str(cont.rolling))
+
+        # --- Validation: good serials ------------------------------------------
+        for good in ["WWW04Q40001", "WWWA5R50999", "WL116S60010",
+                     "WLM14T70001", "WL084QA0001", "wwwa4q40001"]:
+            check(f"valid: {good}", QisdaSerialManager.is_valid(good))
+
+        p = QisdaSerialManager.parse("  wwwa4q40007 ")
+        check("parse normalizes case/whitespace", p.serial == "WWWA4Q40007")
+
+        # --- Validation: bad serials -------------------------------------------
+        bad = {
+            "": "empty",
+            "WWW04Q4001": "too short",
+            "WWW04Q400001": "too long",
+            "XWW04Q40001": "wrong Openwater prefix",
+            "WZZZ4Q40001": "unknown category",
+            "WWW07Q40001": "invalid stage 7",
+            "WWW04Z40001": "invalid year Z",
+            "WWW04QD0001": "invalid month D",
+            "WWW04Q41001": "Qisda MFG not 0",
+            "WWW04Q40000": "rolling 000",
+            "WWW04Q40ABC": "non-numeric rolling",
+        }
+        for serial, why in bad.items():
+            check(f"invalid ({why}): {serial!r}", not QisdaSerialManager.is_valid(serial))
+
+        # --- Bad create() inputs ----------------------------------------------
+        check("unknown product rejected", raises(mgr.create, "900-99999",
+                                                 stage="DVT", year=2026, month=4))
+        check("unknown stage rejected", raises(mgr.create, "900-00013",
+                                               stage="EVT", year=2026, month=4))
+        check("unsupported year rejected", raises(mgr.create, "900-00013",
+                                                  stage="DVT", year=2025, month=4))
+        check("invalid month rejected", raises(mgr.create, "900-00013",
+                                               stage="DVT", year=2026, month=13))
+
+        # --- Round-trip every category/stage/year/month combination ------------
+        roundtrip_ok = True
+        mgr_rt = QisdaSerialManager(counter_file=Path(tmp) / "rt.json")
+        for cat_code in CATEGORY_CODES:
+            for stage in STAGES:
+                for year in YEARS:
+                    for month in MONTHS:
+                        sn = mgr_rt.create(cat_code, stage=stage, year=year,
+                                           month=month, rolling=999)
+                        p = QisdaSerialManager.parse(sn.serial)
+                        if (p.category_code, p.stage, p.year, p.month, p.rolling) != \
+                           (cat_code, stage, year, month, 999):
+                            roundtrip_ok = False
+                            print(f"       round-trip mismatch: {sn.serial}")
+        n = len(CATEGORY_CODES) * len(STAGES) * len(YEARS) * len(MONTHS)
+        check(f"round-trip all {n} field combinations", roundtrip_ok)
+
+        # --- Exhaustion ---------------------------------------------------------
+        mgr_x = QisdaSerialManager(counter_file=Path(tmp) / "x.json")
+        mgr_x.create("900-00013", stage="DVT", year=2026, month=4, rolling=999)
+        check("rolling exhaustion at 999", raises(mgr_x.create, "900-00013",
+                                                  stage="DVT", year=2026, month=4))
+
+    print()
+    if failures:
+        print(f"{len(failures)} FAILED: {failures}")
+        sys.exit(1)
+    print("All checks passed.")

--- a/scripts/read_odometers.py
+++ b/scripts/read_odometers.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""read_odometers.py - Print the console's odometer readings and exit.
+
+Connects to the console over USB CDC and prints both odometers:
+
+  system odometer - total minutes the console has been powered on
+  laser odometer  - total LSYNC laser pulses fired (~40 per second of scan)
+
+Note: on firmware affected by
+OpenwaterHealth/openmotion-console-fw#50, simply disconnecting at the end
+of this script adds phantom pulses to the laser odometer (the firmware
+re-counts the previous scan's pulses on every port close), so back-to-back
+runs will show the laser value creeping up on its own.
+
+Usage:
+    python scripts/read_odometers.py
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+
+from omotion import MotionInterface
+
+CONNECT_TIMEOUT_S = 12.0
+
+
+def main() -> int:
+    iface = MotionInterface()
+    iface.start(wait=False)
+    deadline = time.monotonic() + CONNECT_TIMEOUT_S
+    while time.monotonic() < deadline and not iface.console.is_connected():
+        time.sleep(0.2)
+    if not iface.console.is_connected():
+        iface.stop()
+        print(f"ERROR: console not connected within {CONNECT_TIMEOUT_S:.0f}s")
+        return 1
+
+    try:
+        system_min = iface.console.get_system_odometer_minutes()
+        laser_pulses = iface.console.get_laser_odometer_pulses()
+    finally:
+        iface.stop()
+
+    if system_min is None or laser_pulses is None:
+        print("ERROR: firmware NAK'd an odometer read (build predates the feature?)")
+        return 1
+
+    print(f"system odometer: {system_min:,} min  ({system_min // 60}h {system_min % 60:02d}m)")
+    print(f"laser odometer:  {laser_pulses:,} pulses  "
+          f"(~{laser_pulses / 40:,.0f} s of scan at 40 Hz)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_calibration_outcome.py
+++ b/tests/test_calibration_outcome.py
@@ -32,3 +32,25 @@ def test_outcome_is_str_enum():
 def test_exported_from_package():
     from omotion import CalibrationOutcome as exported
     assert exported is CalibrationOutcome
+
+
+def test_legacy_construction_defaults_outcome_to_none():
+    """A result built without outcome= (pre-outcome caller shape) must
+    surface outcome=None so consumers fall back to the boolean triple —
+    an ERROR default would misreport healthy legacy results as errors."""
+    from omotion.CalibrationWorkflow import CalibrationResult, TestScanResult
+    r = CalibrationResult(
+        ok=True, passed=True, canceled=False, error="",
+        csv_path="", json_path="", calibration=None, rows=[],
+        calibration_scan_left_path="", calibration_scan_right_path="",
+        validation_scan_left_path="", validation_scan_right_path="",
+        started_timestamp="",
+    )
+    t = TestScanResult(
+        ok=True, passed=True, canceled=False, error="",
+        csv_path="", json_path="", rows=[],
+        test_scan_left_path="", test_scan_right_path="",
+        started_timestamp="",
+    )
+    assert r.outcome is None and r.rolled_back is False
+    assert t.outcome is None

--- a/tests/test_calibration_outcome.py
+++ b/tests/test_calibration_outcome.py
@@ -1,0 +1,34 @@
+"""Pure tests for the outcome resolver — no hardware, no threads."""
+import pytest
+
+from omotion.CalibrationWorkflow import CalibrationOutcome, _resolve_outcome
+
+
+@pytest.mark.parametrize(
+    "ok,passed,canceled,timed_out,expected",
+    [
+        (True,  True,  False, False, CalibrationOutcome.PASSED),
+        (True,  False, False, False, CalibrationOutcome.FAILED),
+        (False, False, True,  False, CalibrationOutcome.CANCELED),
+        (False, False, False, False, CalibrationOutcome.ERROR),
+        # Watchdog timeout wins over the canceled flag it sets as a side effect.
+        (False, False, True,  True,  CalibrationOutcome.TIMED_OUT),
+        # Timeout during an error still reports as timeout (the timeout caused it).
+        (False, False, False, True,  CalibrationOutcome.TIMED_OUT),
+    ],
+)
+def test_resolve_outcome(ok, passed, canceled, timed_out, expected):
+    assert _resolve_outcome(
+        ok=ok, passed=passed, canceled=canceled, timed_out=timed_out,
+    ) is expected
+
+
+def test_outcome_is_str_enum():
+    # QML/JSON consumers rely on the string value.
+    assert CalibrationOutcome.TIMED_OUT == "timed_out"
+    assert f"{CalibrationOutcome.PASSED.value}" == "passed"
+
+
+def test_exported_from_package():
+    from omotion import CalibrationOutcome as exported
+    assert exported is CalibrationOutcome

--- a/tests/test_calibration_workflow.py
+++ b/tests/test_calibration_workflow.py
@@ -422,6 +422,105 @@ def test_cancel_outcome_is_canceled_not_timed_out(interface, request_obj):
     assert "max_duration_sec" not in holder["r"].error
 
 
+def test_fail_verdict_rolls_back_eeprom(interface, request_obj, thresholds):
+    """A FAILED calibration must not leave the unvalidated calibration on
+    the console: write_calibration is called a second time with the
+    pre-run values and the result reports rolled_back=True."""
+    from dataclasses import replace
+    from omotion.CalibrationWorkflow import CalibrationThresholds
+    _make_fake_scan_workflow(interface, _LEFT, _RIGHT)
+    prior = interface.get_calibration()
+    # Snapshot before starting — the demo interface's cached calibration
+    # object could in principle be refreshed by a later write, so compare
+    # against copies taken now rather than re-reading `prior` after the
+    # run completes.
+    prior_c_min = prior.c_min.copy()
+    prior_c_max = prior.c_max.copy()
+    strict = CalibrationThresholds(
+        min_mean_per_camera=[1e9] * 8,      # nothing can pass
+        min_contrast_per_camera=[0.0] * 8,
+        min_bfi_per_camera=[-1e9] * 8,
+        min_bvi_per_camera=[-1e9] * 8,
+    )
+    req = replace(request_obj, thresholds=strict)
+    calls = []
+    def _record_write(cmin, cmax, imin, imax):
+        calls.append((cmin, cmax, imin, imax))
+        return Calibration(c_min=cmin, c_max=cmax, i_min=imin, i_max=imax,
+                           source="test")
+    interface.write_calibration = MagicMock(side_effect=_record_write)
+    done = threading.Event(); holder = {}
+    interface.start_calibration(
+        req, on_complete_fn=lambda r: (holder.update(r=r), done.set()))
+    assert done.wait(30)
+    r = holder["r"]
+    assert r.ok and not r.passed
+    assert r.rolled_back is True
+    assert len(calls) == 2                       # new write + restore
+    np.testing.assert_array_equal(calls[1][0], prior_c_min)
+    np.testing.assert_array_equal(calls[1][1], prior_c_max)
+
+
+def test_pass_verdict_does_not_roll_back(interface, request_obj):
+    # happy-path arrangement from test_happy_path_produces_csv_and_passes
+    if not _have_fixtures():
+        pytest.skip("fixture CSVs missing")
+
+    _make_fake_scan_workflow(interface, _LEFT, _RIGHT)
+    interface.write_calibration = MagicMock(
+        return_value=Calibration(
+            c_min=np.zeros((2, 8)), c_max=np.full((2, 8), 0.5),
+            i_min=np.zeros((2, 8)), i_max=np.full((2, 8), 200.0),
+            source="console",
+        )
+    )
+
+    done = threading.Event()
+    holder = {}
+    interface.start_calibration(
+        request_obj,
+        on_complete_fn=lambda r: (holder.update(r=r), done.set()),
+    )
+    assert done.wait(timeout=60.0), "calibration didn't complete"
+    assert holder["r"].rolled_back is False
+    interface.write_calibration.assert_called_once()
+
+
+def test_rollback_failure_is_best_effort(interface, request_obj):
+    """If the restore write itself raises (e.g. console USB died), the
+    result still completes, rolled_back stays False, and the error text
+    carries the rollback failure."""
+    # strict thresholds as above; write_calibration succeeds on call 1,
+    # raises RuntimeError("usb gone") on call 2.
+    from dataclasses import replace
+    from omotion.CalibrationWorkflow import CalibrationThresholds
+    _make_fake_scan_workflow(interface, _LEFT, _RIGHT)
+    strict = CalibrationThresholds(
+        min_mean_per_camera=[1e9] * 8,      # nothing can pass
+        min_contrast_per_camera=[0.0] * 8,
+        min_bfi_per_camera=[-1e9] * 8,
+        min_bvi_per_camera=[-1e9] * 8,
+    )
+    req = replace(request_obj, thresholds=strict)
+
+    calls = []
+    def _write_side_effect(cmin, cmax, imin, imax):
+        calls.append((cmin, cmax, imin, imax))
+        if len(calls) == 1:
+            return Calibration(c_min=cmin, c_max=cmax, i_min=imin, i_max=imax,
+                               source="test")
+        raise RuntimeError("usb gone")
+    interface.write_calibration = MagicMock(side_effect=_write_side_effect)
+
+    done = threading.Event(); holder = {}
+    interface.start_calibration(
+        req, on_complete_fn=lambda r: (holder.update(r=r), done.set()))
+    assert done.wait(30)
+    r = holder["r"]
+    assert r.rolled_back is False
+    assert "rollback failed" in r.error
+
+
 def test_watchdog_timeout_outcome_is_timed_out(interface, request_obj):
     from dataclasses import replace
     from omotion.CalibrationWorkflow import CalibrationOutcome

--- a/tests/test_calibration_workflow.py
+++ b/tests/test_calibration_workflow.py
@@ -423,9 +423,16 @@ def test_cancel_outcome_is_canceled_not_timed_out(interface, request_obj):
 
 
 def test_fail_verdict_rolls_back_eeprom(interface, request_obj, thresholds):
-    """A FAILED calibration must not leave the unvalidated calibration on
-    the console: write_calibration is called a second time with the
-    pre-run values and the result reports rolled_back=True."""
+    """An *unconsented* FAILED calibration must not leave the unvalidated
+    calibration on the console: write_calibration is called a second time
+    with the pre-run values and the result reports rolled_back=True.
+
+    The failure is forced on BFI rather than mean. Mean and contrast are
+    now judged one scan earlier by the pre-write gate (#199), which aborts
+    before writing at all — so there would be nothing to roll back. BFI is
+    a calibrated quantity, knowable only after the validation scan, which
+    is precisely the case the rollback still exists for.
+    """
     from dataclasses import replace
     from omotion.CalibrationWorkflow import CalibrationThresholds
     _make_fake_scan_workflow(interface, _LEFT, _RIGHT)
@@ -437,9 +444,9 @@ def test_fail_verdict_rolls_back_eeprom(interface, request_obj, thresholds):
     prior_c_min = prior.c_min.copy()
     prior_c_max = prior.c_max.copy()
     strict = CalibrationThresholds(
-        min_mean_per_camera=[1e9] * 8,      # nothing can pass
-        min_contrast_per_camera=[0.0] * 8,
-        min_bfi_per_camera=[-1e9] * 8,
+        min_mean_per_camera=[0.0] * 8,      # gate passes …
+        min_contrast_per_camera=[0.0] * 8,  # … so the write happens
+        min_bfi_per_camera=[1e9] * 8,       # then validation fails
         min_bvi_per_camera=[-1e9] * 8,
     )
     req = replace(request_obj, thresholds=strict)
@@ -491,14 +498,16 @@ def test_rollback_failure_is_best_effort(interface, request_obj):
     result still completes, rolled_back stays False, and the error text
     carries the rollback failure."""
     # strict thresholds as above; write_calibration succeeds on call 1,
-    # raises RuntimeError("usb gone") on call 2.
+    # raises RuntimeError("usb gone") on call 2. Failure forced on BFI so
+    # the pre-write gate (#199) lets the run reach the write — see
+    # test_fail_verdict_rolls_back_eeprom.
     from dataclasses import replace
     from omotion.CalibrationWorkflow import CalibrationThresholds
     _make_fake_scan_workflow(interface, _LEFT, _RIGHT)
     strict = CalibrationThresholds(
-        min_mean_per_camera=[1e9] * 8,      # nothing can pass
+        min_mean_per_camera=[0.0] * 8,
         min_contrast_per_camera=[0.0] * 8,
-        min_bfi_per_camera=[-1e9] * 8,
+        min_bfi_per_camera=[1e9] * 8,       # fails only at validation
         min_bvi_per_camera=[-1e9] * 8,
     )
     req = replace(request_obj, thresholds=strict)
@@ -556,3 +565,173 @@ def test_watchdog_timeout_outcome_is_timed_out(interface, request_obj):
     assert done.wait(timeout=15.0)
     assert holder["r"].outcome is CalibrationOutcome.TIMED_OUT
     assert "max_duration_sec" in holder["r"].error
+
+
+# ── Pre-write gate (#199) ─────────────────────────────────────────────────
+#
+# The console EEPROM must not be touched until either the calibration
+# scan's own mean/contrast clear their bars, or the operator explicitly
+# authorises writing anyway. Before the gate existed, every failed
+# calibration briefly destroyed the previous one and then restored it.
+
+
+def _gate_failing_thresholds():
+    """Mean unreachable → the gate fails; everything else permissive so
+    nothing *else* is what stopped the run."""
+    return CalibrationThresholds(
+        min_mean_per_camera=[1e9] * 8,
+        min_contrast_per_camera=[0.0] * 8,
+        min_bfi_per_camera=[-1e9] * 8,
+        min_bvi_per_camera=[-1e9] * 8,
+    )
+
+
+def test_gate_failure_without_handler_never_writes(interface, request_obj):
+    """No confirmation handler is the conservative default: abort, and
+    leave whatever calibration the console already had."""
+    from dataclasses import replace
+    from omotion.CalibrationWorkflow import CalibrationOutcome
+    _make_fake_scan_workflow(interface, _LEFT, _RIGHT)
+    interface.write_calibration = MagicMock()
+
+    req = replace(request_obj, thresholds=_gate_failing_thresholds())
+    done = threading.Event(); holder = {}
+    interface.start_calibration(
+        req, on_complete_fn=lambda r: (holder.update(r=r), done.set()))
+    assert done.wait(30)
+
+    r = holder["r"]
+    interface.write_calibration.assert_not_called()
+    assert r.outcome is CalibrationOutcome.CANCELED
+    assert "below threshold" in r.error
+    assert r.rolled_back is False
+    assert r.consented_below_threshold is False
+
+
+def test_gate_decline_never_writes(interface, request_obj):
+    from dataclasses import replace
+    from omotion.CalibrationWorkflow import CalibrationOutcome
+    _make_fake_scan_workflow(interface, _LEFT, _RIGHT)
+    interface.write_calibration = MagicMock()
+
+    seen = {}
+    def _decline(rows):
+        seen["rows"] = rows
+        return False
+
+    req = replace(request_obj, thresholds=_gate_failing_thresholds())
+    done = threading.Event(); holder = {}
+    interface.start_calibration(
+        req, on_confirm_fn=_decline,
+        on_complete_fn=lambda r: (holder.update(r=r), done.set()))
+    assert done.wait(30)
+
+    interface.write_calibration.assert_not_called()
+    assert holder["r"].outcome is CalibrationOutcome.CANCELED
+    assert "declined" in holder["r"].error
+    # The handler is handed the measured rows so the UI can show the
+    # operator what missed, rather than a bare yes/no prompt.
+    assert seen["rows"], "confirm handler got no rows"
+    assert all(r.mean_test == "FAIL" for r in seen["rows"])
+
+
+def test_gate_consent_proceeds_and_keeps_the_write(interface, request_obj):
+    """Consent means write, run the validation scan, and — crucially —
+    do NOT roll back afterwards, even though the verdict is FAILED. The
+    operator was shown the numbers and asked for this calibration."""
+    from dataclasses import replace
+    _make_fake_scan_workflow(interface, _LEFT, _RIGHT)
+    calls = []
+    def _record_write(cmin, cmax, imin, imax):
+        calls.append((cmin, cmax, imin, imax))
+        return Calibration(c_min=cmin, c_max=cmax, i_min=imin, i_max=imax,
+                           source="test")
+    interface.write_calibration = MagicMock(side_effect=_record_write)
+
+    req = replace(request_obj, thresholds=_gate_failing_thresholds())
+    done = threading.Event(); holder = {}
+    interface.start_calibration(
+        req, on_confirm_fn=lambda rows: True,
+        on_complete_fn=lambda r: (holder.update(r=r), done.set()))
+    assert done.wait(30)
+
+    r = holder["r"]
+    assert r.consented_below_threshold is True
+    assert r.passed is False          # honest verdict — mean still failed
+    assert r.rolled_back is False     # but the write stands
+    assert len(calls) == 1, "consented run must not write twice"
+    # Validation still ran, so the operator gets BFI/BVI numbers too —
+    # r.rows is built from the *validation* samples in phase 5, so its
+    # presence is the proof. (The fake scan workflow doesn't emit scan
+    # CSVs, so the *_scan_*_path fields are empty even on a happy path.)
+    assert r.rows, "no result rows from the validation scan"
+    assert all(row.bfi_test in ("PASS", "FAIL") for row in r.rows)
+
+
+def test_gate_passes_silently_when_scan_is_good(interface, request_obj):
+    """A healthy unit must never see the prompt."""
+    _make_fake_scan_workflow(interface, _LEFT, _RIGHT)
+    interface.write_calibration = MagicMock(
+        return_value=Calibration(
+            c_min=np.zeros((2, 8)), c_max=np.full((2, 8), 0.5),
+            i_min=np.zeros((2, 8)), i_max=np.full((2, 8), 200.0),
+            source="console"))
+    asked = []
+    done = threading.Event(); holder = {}
+    interface.start_calibration(
+        request_obj,
+        on_confirm_fn=lambda rows: asked.append(rows) or True,
+        on_complete_fn=lambda r: (holder.update(r=r), done.set()))
+    assert done.wait(60)
+
+    assert asked == [], "gate prompted on a passing scan"
+    assert holder["r"].consented_below_threshold is False
+
+
+def test_gate_handler_exception_is_treated_as_decline(interface, request_obj):
+    """A broken UI callback must not write the EEPROM by accident."""
+    from dataclasses import replace
+    _make_fake_scan_workflow(interface, _LEFT, _RIGHT)
+    interface.write_calibration = MagicMock()
+
+    def _boom(rows):
+        raise RuntimeError("qml died")
+
+    req = replace(request_obj, thresholds=_gate_failing_thresholds())
+    done = threading.Event(); holder = {}
+    interface.start_calibration(
+        req, on_confirm_fn=_boom,
+        on_complete_fn=lambda r: (holder.update(r=r), done.set()))
+    assert done.wait(30)
+
+    interface.write_calibration.assert_not_called()
+    assert "gate confirmation failed" in holder["r"].error
+
+
+def test_gate_wait_is_not_charged_against_the_watchdog(interface, request_obj):
+    """Operator think time must not surface as a bogus timeout: the
+    watchdog is paused across the prompt."""
+    from dataclasses import replace
+    _make_fake_scan_workflow(interface, _LEFT, _RIGHT)
+    interface.write_calibration = MagicMock(
+        side_effect=lambda cmin, cmax, imin, imax: Calibration(
+            c_min=cmin, c_max=cmax, i_min=imin, i_max=imax, source="test"))
+
+    # Budget deliberately shorter than the operator's deliberation.
+    req = replace(request_obj, thresholds=_gate_failing_thresholds(),
+                  max_duration_sec=3)
+
+    def _slow_yes(rows):
+        time.sleep(4.0)
+        return True
+
+    done = threading.Event(); holder = {}
+    interface.start_calibration(
+        req, on_confirm_fn=_slow_yes,
+        on_complete_fn=lambda r: (holder.update(r=r), done.set()))
+    assert done.wait(60)
+
+    r = holder["r"]
+    assert r.consented_below_threshold is True
+    assert "max_duration_sec" not in r.error
+    interface.write_calibration.assert_called()

--- a/tests/test_calibration_workflow.py
+++ b/tests/test_calibration_workflow.py
@@ -353,3 +353,107 @@ def test_start_test_scan_uses_collector_sink_and_skip_default_storage(
         assert len(collector_sinks) >= 1, (
             f"Expected a _CalibrationCollectorSink in req.sinks; got {req.sinks}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Task 2: outcome wired through both workers (Refs #199)
+# ---------------------------------------------------------------------------
+
+def test_happy_path_outcome_is_passed(interface, request_obj):
+    from omotion.CalibrationWorkflow import CalibrationOutcome
+    _make_fake_scan_workflow(interface, _LEFT, _RIGHT)
+    interface.write_calibration = MagicMock(
+        side_effect=lambda cmin, cmax, imin, imax: Calibration(
+            c_min=cmin, c_max=cmax, i_min=imin, i_max=imax, source="test"))
+    done = threading.Event()
+    holder = {}
+    interface.start_calibration(
+        request_obj, on_complete_fn=lambda r: (holder.update(r=r), done.set()))
+    assert done.wait(30)
+    assert holder["r"].outcome is CalibrationOutcome.PASSED
+
+
+def test_cancel_outcome_is_canceled_not_timed_out(interface, request_obj):
+    """Regression for the old finally-block back-fill that stamped ANY
+    stop_evt as 'exceeded max_duration_sec' when the canceled flag hadn't
+    been picked up by a phase boundary yet."""
+    if not _have_fixtures():
+        pytest.skip("fixture CSVs missing")
+
+    from omotion.CalibrationWorkflow import CalibrationOutcome
+
+    # (mirror the existing test_cancel_during_phase_1 setup, then:)
+    sw = interface.scan_workflow
+    started = threading.Event()
+    cancel_called = threading.Event()
+
+    def _slow_scan(req):
+        sw._running = True
+        sw._last_scan_error = None
+        sw._last_scan_canceled = False
+
+        def _run():
+            started.set()
+            cancel_called.wait(timeout=5.0)
+            sw._last_scan_canceled = True
+            sw._running = False
+
+        threading.Thread(target=_run, daemon=True).start()
+        return True
+
+    sw.start_scan = _slow_scan
+    sw.await_complete = lambda *, timeout_sec=None: (
+        time.sleep(min(0.1, timeout_sec)) if timeout_sec else None
+    )
+    sw.cancel_scan = MagicMock(side_effect=lambda **kw: cancel_called.set())
+    interface.write_calibration = MagicMock()
+
+    # ... start_calibration, cancel mid-phase-1, wait for completion ...
+    done = threading.Event()
+    holder = {}
+    interface.start_calibration(
+        request_obj,
+        on_complete_fn=lambda r: (holder.update(r=r), done.set()),
+    )
+    assert started.wait(timeout=5.0)
+    interface.cancel_calibration()
+    assert done.wait(timeout=15.0)
+    assert holder["r"].outcome is CalibrationOutcome.CANCELED
+    assert "max_duration_sec" not in holder["r"].error
+
+
+def test_watchdog_timeout_outcome_is_timed_out(interface, request_obj):
+    from dataclasses import replace
+    from omotion.CalibrationWorkflow import CalibrationOutcome
+    # A fake scan workflow that never completes, and a 1-second watchdog.
+    req = replace(request_obj, max_duration_sec=1)
+
+    # (fake start_scan sets running=True and never flips it back; cancel_scan
+    #  flips running=False so _run_subscan_capture's poll loop exits)
+    sw = interface.scan_workflow
+
+    def _never_completing_scan(r):
+        sw._running = True
+        sw._last_scan_error = None
+        sw._last_scan_canceled = False
+        return True
+
+    def _fake_cancel_scan(**kw):
+        sw._running = False
+        sw._last_scan_canceled = True
+
+    sw.start_scan = _never_completing_scan
+    sw.cancel_scan = MagicMock(side_effect=_fake_cancel_scan)
+    sw.await_complete = lambda *, timeout_sec=None: (
+        time.sleep(min(0.05, timeout_sec)) if timeout_sec else None
+    )
+    interface.write_calibration = MagicMock()
+
+    # ... start_calibration(req, ...), wait ...
+    done = threading.Event()
+    holder = {}
+    interface.start_calibration(
+        req, on_complete_fn=lambda r: (holder.update(r=r), done.set()))
+    assert done.wait(timeout=15.0)
+    assert holder["r"].outcome is CalibrationOutcome.TIMED_OUT
+    assert "max_duration_sec" in holder["r"].error

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -3,6 +3,7 @@ Console module tests (Section 2 of the test plan).
 """
 
 import re
+import threading
 import time
 
 import pytest
@@ -88,7 +89,10 @@ def test_tec_adc_channels(console):
 def test_tec_voltage_read(console):
     v = console.tec_voltage()
     assert isinstance(v, float)
-    assert 0.0 <= v <= 3.3
+    # tec_voltage() is the TEC DAC setpoint, whose public API accepts the
+    # full bipolar -5 V .. +5 V range.  Do not apply the 0 .. 3.3 V ADC
+    # bounds used by tec_adc()/tec_status() to this getter.
+    assert -5.0 <= v <= 5.0, f"TEC voltage {v} V out of [-5.0, 5.0]"
 
 
 def test_tec_voltage_set_readback(console):
@@ -413,12 +417,24 @@ def test_telemetry_fields_populated(console):
 @pytest.mark.slow
 def test_telemetry_listener_fires(console):
     calls = []
-    console.telemetry.add_listener(calls.append)
-    time.sleep(2.5)
-    console.telemetry.remove_listener(calls.append)
-    assert len(calls) >= 2, (
-        f"Telemetry listener called {len(calls)} time(s) in 2.5 s; expected ≥2"
-    )
+    received_two = threading.Event()
+
+    def listener(snapshot):
+        calls.append(snapshot)
+        if len(calls) >= 2:
+            received_two.set()
+
+    console.telemetry.add_listener(listener)
+    try:
+        # Slow telemetry refreshes at ~1 Hz, but this session-scoped poller may
+        # be at any phase when the listener is registered.  Synchronize on the
+        # behavior under test instead of assuming two callbacks fit into a
+        # fixed sleep window.
+        assert received_two.wait(timeout=4.0), (
+            f"Telemetry listener called {len(calls)} time(s); expected >=2"
+        )
+    finally:
+        console.telemetry.remove_listener(listener)
 
 
 @pytest.mark.slow

--- a/tests/test_db_key.py
+++ b/tests/test_db_key.py
@@ -4,6 +4,7 @@ None of these touch the real OS keyring: policy tests are pure, and key
 get/create/export tests monkeypatch keyring.get_password/set_password.
 """
 import importlib
+import sys
 
 import pytest
 
@@ -16,6 +17,18 @@ def _reset_policy():
     importlib.reload(db_key)
     yield
     importlib.reload(db_key)
+
+
+@pytest.fixture(autouse=True)
+def _non_darwin_platform(monkeypatch):
+    """Pin sys.platform away from darwin for the whole module.
+
+    db_key now refuses every keystore access on macOS, so without this the
+    keystore tests below would all fail when the suite is run on a Mac — the
+    result would depend on the developer's laptop, not on the code. The
+    macOS-refusal tests set it back to "darwin" themselves.
+    """
+    monkeypatch.setattr(sys, "platform", "win32")
 
 
 # --------------------------------------------------------------------------
@@ -104,26 +117,132 @@ def test_get_key_create_true_is_idempotent(fake_keyring):
 # Backend pinning — the real _assert_backend (not stubbed)
 # --------------------------------------------------------------------------
 
-def test_set_policy_true_rejects_non_windows_backend(monkeypatch):
+def _fake_backend(monkeypatch, module: str, name: str):
+    """Install a stand-in keyring backend reporting the given module + class name.
+
+    The real backends can't be instantiated off-platform, and the identity
+    _assert_backend pins on is exactly (module, class name) — so faking those
+    two attributes is the whole contract under test.
+    """
     import keyring
 
-    class _PlaintextKeyring:  # name lacks 'WinVault'; module lacks 'Windows'
-        pass
+    kr = type(name, (), {})()
+    type(kr).__module__ = module
+    monkeypatch.setattr(keyring, "get_keyring", lambda: kr)
+    return kr
 
-    monkeypatch.setattr(keyring, "get_keyring", lambda: _PlaintextKeyring())
+
+def test_set_policy_true_accepts_winvault_backend(monkeypatch):
+    _fake_backend(monkeypatch, "keyring.backends.Windows", "WinVaultKeyring")
+    db_key.set_policy(require_encryption=True)  # must not raise
+    assert db_key.require_encryption() is True
+
+
+def test_set_policy_true_rejects_macos_keychain_backend(monkeypatch):
+    """Even the real macOS Keychain is refused: macOS is research-only, so the
+    encryption path must not quietly work on an unvalidated platform."""
+    monkeypatch.setattr(sys, "platform", "darwin")
+    _fake_backend(monkeypatch, "keyring.backends.macOS", "Keyring")
     with pytest.raises(db_key.EncryptionUnavailable):
         db_key.set_policy(require_encryption=True)
 
 
-def test_set_policy_true_accepts_winvault_backend(monkeypatch):
-    import keyring
+def test_set_policy_true_rejects_unknown_backend(monkeypatch):
+    _fake_backend(monkeypatch, "keyrings.alt.file", "PlaintextKeyring")
+    with pytest.raises(db_key.EncryptionUnavailable):
+        db_key.set_policy(require_encryption=True)
 
-    class WinVaultKeyring:  # name contains 'WinVault'
-        pass
 
-    monkeypatch.setattr(keyring, "get_keyring", lambda: WinVaultKeyring())
-    db_key.set_policy(require_encryption=True)  # must not raise
-    assert db_key.require_encryption() is True
+def test_set_policy_true_rejects_plaintext_backend_impersonating_winvault(monkeypatch):
+    """A class *named* like the Windows backend but living in keyrings.alt must
+    still be rejected — keyrings.alt stores secrets in plaintext, so accepting
+    it would silently void the at-rest guarantee the policy exists to enforce."""
+    _fake_backend(monkeypatch, "keyrings.alt.file", "WinVaultKeyring")
+    with pytest.raises(db_key.EncryptionUnavailable):
+        db_key.set_policy(require_encryption=True)
+
+
+def test_set_policy_true_rejects_fail_backend(monkeypatch):
+    # keyring's fail backend = "no usable keystore on this machine"
+    _fake_backend(monkeypatch, "keyring.backends.fail", "Keyring")
+    with pytest.raises(db_key.EncryptionUnavailable):
+        db_key.set_policy(require_encryption=True)
+
+
+def test_set_policy_true_rejects_chainer_backend(monkeypatch):
+    """The chainer delegates to whatever it found, so it can't be verified up
+    front — the point of asserting at startup is to know, not to hope."""
+    _fake_backend(monkeypatch, "keyring.backends.chainer", "ChainerBackend")
+    with pytest.raises(db_key.EncryptionUnavailable):
+        db_key.set_policy(require_encryption=True)
+
+
+def test_backend_rejection_names_the_offending_backend(monkeypatch):
+    # the message is read off a bench console; it has to say what was found
+    _fake_backend(monkeypatch, "keyrings.alt.file", "PlaintextKeyring")
+    with pytest.raises(db_key.EncryptionUnavailable) as exc:
+        db_key.set_policy(require_encryption=True)
+    assert "keyrings.alt.file.PlaintextKeyring" in str(exc.value)
+
+
+# --------------------------------------------------------------------------
+# macOS is refused outright — research-only platform, never clinical
+# --------------------------------------------------------------------------
+
+@pytest.fixture
+def _darwin(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "darwin")
+
+
+def test_get_key_is_refused_on_macos(_darwin, fake_keyring):
+    # fake_keyring proves the refusal is the platform, not a missing backend
+    with pytest.raises(db_key.EncryptionUnavailable):
+        db_key.get_key(create=True)
+
+
+def test_get_key_without_create_is_refused_on_macos(_darwin, fake_keyring):
+    # must be EncryptionUnavailable (wrong platform), NOT EncryptionKeyMissing
+    # (right platform, absent key) — the two point at different fixes
+    with pytest.raises(db_key.EncryptionUnavailable):
+        db_key.get_key(create=False)
+
+
+def test_import_key_is_refused_on_macos(_darwin, fake_keyring):
+    # the path deliberately does not exist: the platform refusal must land
+    # before any file is read, so the escrow CLI can't half-run on macOS
+    with pytest.raises(db_key.EncryptionUnavailable):
+        db_key.import_key("no_such_key_file.txt")
+
+
+def test_export_key_is_refused_on_macos(_darwin, fake_keyring):
+    # likewise nothing may be written to the target path
+    with pytest.raises(db_key.EncryptionUnavailable):
+        db_key.export_key("no_such_dir/out.txt")
+
+
+def test_macos_provisions_nothing_before_refusing(_darwin, fake_keyring):
+    """The refusal must land before any keystore write — a half-provisioned key
+    on an unsupported platform is worse than a clean failure."""
+    with pytest.raises(db_key.EncryptionUnavailable):
+        db_key.get_key(create=True)
+    assert fake_keyring._store == {}
+
+
+def test_macos_refusal_names_the_platform_and_the_fix(_darwin, fake_keyring):
+    # read off a bench console: it has to say macOS, and what to change
+    with pytest.raises(db_key.EncryptionUnavailable) as exc:
+        db_key.get_key(create=True)
+    message = str(exc.value)
+    assert "macOS" in message
+    assert "require_encryption=False" in message
+
+
+def test_macos_research_build_still_boots(_darwin):
+    """The whole point of the refusal: policy-off on macOS must stay silent.
+    A research build is the only supported macOS configuration, so it cannot be
+    collateral damage of refusing the clinical path."""
+    db_key.set_policy(require_encryption=False)  # must not raise
+    assert db_key.require_encryption() is False
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #178.

## Summary

- make `test_telemetry_listener_fires` wait for two callbacks using a
  `threading.Event` instead of relying on a fixed sleep window
- guarantee listener cleanup with `try/finally`
- correct `test_tec_voltage_read` to use the public TEC DAC range
  `[-5.0, 5.0]` rather than the `0.0-3.3 V` ADC range
- update the test plan to document that distinction

## Validation

- `python -m pytest tests/test_db_key.py -v`
  - 33 passed
- `python -m pytest -q`
  - 775 passed, 191 skipped, 29 deselected

The hardware-dependent console tests skip locally because no Open-Motion
console is connected, so the original HIL flake still needs hardware-side
confirmation in CI or on a connected rig.