### PR TITLE
feat: lead the pre-bootloader rollback refusal with the active bootloader

### DIFF
--- a/omotion/firmware_update.py
+++ b/omotion/firmware_update.py
@@ -170,10 +170,15 @@ def resolve_asset(
         return name
 
     if mode is BootMode.BOOTLOADER:
+        # Lead with the device state, not the release: an operator picking an
+        # old release is trying to roll back, and the real answer is that a
+        # converted unit cannot leave the bootloader over USB (#225).
         raise UnsupportedReleaseError(
-            f"this release has no signed image ({preferences[0]}), so it predates "
-            f"bootloader support; {kind.value} needs {_MIN_BOOTLOADER_TAG[kind]} "
-            "or newer to update a device that has the bootloader installed"
+            f"the bootloader is active on this {kind.value}, and rolling back to "
+            f"a pre-bootloader release is not possible over USB: the bootloader "
+            f"only accepts signed images, and this release has none "
+            f"({preferences[0]}). Use {_MIN_BOOTLOADER_TAG[kind]} or newer; "
+            "removing the bootloader requires SWD access to the board"
         )
     raise UnsupportedReleaseError(
         f"this release has none of {', '.join(preferences)}; cannot update a "

--- a/tests/test_firmware_asset_resolution.py
+++ b/tests/test_firmware_asset_resolution.py
@@ -57,10 +57,12 @@ def test_resolve_asset(kind, mode, names, expected):
     (FirmwareKind.CONSOLE, LEGACY_CONSOLE, "1.8.1"),
 ])
 def test_bootloader_unit_rejects_prebootloader_release(kind, names, minimum):
-    """A legacy release has no signed image. Say so, and name the minimum
-    version, rather than silently flashing something else."""
+    """The refusal must lead with the device state — the active bootloader is
+    why the rollback is impossible, the missing signed asset is only the
+    mechanism (#225). Keep naming the minimum version the unit can take."""
     with pytest.raises(UnsupportedReleaseError) as exc:
         resolve_asset(kind, BootMode.BOOTLOADER, names)
+    assert "bootloader is active" in str(exc.value)
     assert minimum in str(exc.value)
 
 


### PR DESCRIPTION
Refs #225

When a bootloader-converted device is pointed at a pre-bootloader release, the refusal now reads:

> the bootloader is active on this sensor, and rolling back to a pre-bootloader release is not possible over USB: the bootloader only accepts signed images, and this release has none (motion-sensor-fw-signed.bin). Use 1.8.2 or newer; removing the bootloader requires SWD access to the board

instead of leading with "this release has no signed image", which framed a device property as a release defect and misdirected a bench investigation (#218's backstory).

Message text only — no behavior change. `test_bootloader_unit_rejects_prebootloader_release` now pins the "bootloader is active" lead alongside the existing minimum-version assertion. 78 tests pass across the firmware suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)