### PR TITLE
fix: downgrade per-call RGB LED set logging from INFO to DEBUG

### DIFF
--- a/omotion/MotionConsole.py
+++ b/omotion/MotionConsole.py
@@ -1221,7 +1221,7 @@ class MotionConsole(SignalWrapper):
             if self.uart.demo_mode:
                 return rgb_state
 
-            logger.info("Setting RGB LED state.")
+            logger.debug("Setting RGB LED state.")
 
             # Send the RGB state as the reserved byte in the packet
             r = self.uart.send_packet(
@@ -1237,7 +1237,7 @@ class MotionConsole(SignalWrapper):
                 logger.error("Error setting RGB LED state")
                 return -1
 
-            logger.info(f"Set RGB LED state to {rgb_state}")
+            logger.debug(f"Set RGB LED state to {rgb_state}")
             return rgb_state
 
         except ValueError as v:


### PR DESCRIPTION
## Summary

`MotionConsole.set_rgb_led()` logged two INFO lines on every call ("Setting RGB LED state." / "Set RGB LED state to N"). The bloodflow app's E-303 critical modal blinks the console LED at ~1 Hz, so a field debug bundle accumulated ~570 lines of LED spam in 2.5 minutes — about a third of the log file (open-motion-20260810_220752.log lines 1104–1673), burying the lines relevant to the E-303 itself.

This downgrades both per-call lines to DEBUG. Error-path logging is unchanged: the OW_ERROR response still logs "Error setting RGB LED state" at ERROR, and the ValueError/exception handlers are untouched.

Refs #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)