### PR TITLE
fix: harden timestamp repair and tolerate isolated frame-ID corruption

### DIFF
--- a/docs/superpowers/plans/2026-08-11-frame-id-consensus-repair.md
+++ b/docs/superpowers/plans/2026-08-11-frame-id-consensus-repair.md
@@ -1,0 +1,25 @@
+# Frame-ID Consensus Repair — Implementation Plan
+
+**Goal:** Prevent one corrupt histogram frame ID from poisoning timestamp repair, while leaving enough bounded log evidence to diagnose unusual inbound data without raw CSV or SQLite metadata.
+
+## 1. Lock down the behavior with tests
+
+- Keep a coalesced `(side, timestamp)` histogram packet in one source batch.
+- Recover exactly one frame-ID outlier only when the rest of a packet agrees and the corrected ID is a valid continuation for that camera.
+- Preserve the raw wire frame ID and log ambiguous/corrected packets before mutation.
+- Make timestamp repair compare absolute IDs and emit detailed pre-repair and gap-fill anomaly events.
+- Cap detailed anomaly logging per event type and keep these events out of SQLite.
+- Reproduce issue #220 end-to-end and assert no repair cascade or NaN insertion.
+
+## 2. Implement the smallest production changes
+
+- Add packet-aware batching in `LiveUsbSource`.
+- Add a strict packet-consensus pass ahead of frame-ID unwrapping.
+- Add explicit anomaly event types and bounded human-readable log formatting.
+- Simplify timestamp-repair state into named records and small detector helpers while changing its packet consistency check to absolute IDs.
+
+## 3. Verify
+
+- Run focused tests after every red/green cycle.
+- Run the complete software pipeline suite.
+- Review the final diff for raw-ID preservation, pre-mutation logging, bounded output, and accidental scope creep.

--- a/docs/superpowers/specs/2026-08-11-frame-id-consensus-repair-design.md
+++ b/docs/superpowers/specs/2026-08-11-frame-id-consensus-repair-design.md
@@ -1,0 +1,252 @@
+# Packet-Consensus Frame-ID Recovery and Diagnostics
+
+**Date:** 2026-08-11  
+**Issues:** openmotion-sdk #220, #229  
+**Target branch:** `fix/229-timestamp-repair-anchors`
+
+## Problem
+
+The 2026-08-06 field incident showed that one corrupted camera `frame_id` can
+poison the per-camera 8-bit unwrapper and then be amplified by
+`TimestampRepairStage`:
+
+1. A high-bit-corrupted raw ID can look like a valid modular forward jump.
+2. The unwrapper accepts the jump and creates a persistent absolute-ID offset.
+3. Timestamp repair treats an in-packet ID disagreement as timestamp
+   corruption, rewrites truthful timestamps, and inserts NaN rows for a gap
+   that never existed.
+4. Side averaging and terminal-dark matching consume the damaged absolute IDs,
+   producing partial averages, non-monotonic plot time, and false terminal-dark
+   failures.
+
+The existing logs report the downstream repair window but omit the packet-level
+wire evidence needed to distinguish a timestamp fault from a single-camera ID
+fault.
+
+Sensor firmware emits one coalesced histogram packet per capture. Individual
+camera histograms are not independently buffered, so histograms sharing that
+packet timestamp were captured together. When every valid histogram but one
+agrees on the raw frame ID, the majority is authoritative for pipeline frame
+identity. The outlier histogram remains scientifically valid at the packet's
+original timestamp.
+
+## Goals
+
+- Prevent a single raw-ID outlier from corrupting unwrapper state.
+- Accept the outlier histogram at its truthful packet timestamp.
+- Preserve the observed wire ID for raw export and forensic logging.
+- Keep downstream `abs_frame_ids` aligned for dark scheduling, terminal-dark
+  matching, and side averaging.
+- Emit self-contained diagnostics that make the fault root-causeable from an
+  ordinary support log.
+- Bound log volume during sustained corruption.
+- Preserve the genuine timestamp-repair behavior on actual timestamp faults.
+
+## Non-goals
+
+- Guess between two cameras that disagree one-to-one.
+- Repair packets with no strict majority or more than one outlier.
+- Store frame-ID forensic examples in SQLite or `session_meta`.
+- Change raw histogram contents or capture timestamps.
+- Redesign the 8-bit firmware counter protocol.
+
+## Design
+
+### 1. Keep coalesced packets atomic at the source boundary
+
+`LiveUsbSource` currently flushes a batch as soon as its row count reaches the
+configured threshold. That can split camera rows sharing one packet timestamp
+across two `FrameBatch` objects.
+
+The source will treat a same-side, same-timestamp row group as atomic:
+
+- Rows are appended while the timestamp equals the current group's timestamp.
+- A size or time flush becomes eligible at the threshold but occurs only when
+  the next timestamp begins.
+- The completed group is flushed before the first row of the next group is
+  appended.
+- The final partial group is flushed when the parser exits.
+
+A batch may exceed `batch_size_frames` by at most one packet group. This adds no
+meaningful latency beyond waiting for the next 40 Hz packet and preserves the
+packet-consensus invariant for classification.
+
+### 2. Derive a temporary effective raw ID by strict packet consensus
+
+`FrameClassificationStage.process()` will group rows by exact
+`(side_id, timestamp_s)`. Each group is validated before any unwrapper is
+mutated.
+
+A group is eligible for consensus correction only when all of these hold:
+
+1. It contains at least three distinct camera IDs.
+2. Camera IDs are unique within the group.
+3. Exactly one row has a different raw `frame_id`.
+4. Every other row has the same raw `frame_id` (a strict majority).
+5. The outlier camera already has prior accepted unwrapper state.
+6. The consensus raw ID is a valid forward continuation for the outlier
+   camera's current unwrapper state.
+
+For an eligible group, classification creates a temporary effective-ID vector:
+
+- The outlier's effective raw ID is the consensus ID.
+- Every other row's effective raw ID equals its observed raw ID.
+- The outlier unwrapper consumes the effective consensus ID, so its
+  `abs_frame_id` and future state stay aligned with its siblings.
+- `batch.frame_ids` is never mutated. It remains the observed wire record used
+  by the raw tee and raw CSV export.
+- The histogram and `batch.timestamp_s` are unchanged and remain valid.
+
+No new per-row batch field is required. The effective ID exists only during
+classification; the emitted diagnostic carries the observed and substituted
+values.
+
+If a group is ambiguous, classification does not substitute an ID. Existing
+conservative classification and timestamp-repair handling continue, augmented
+with a packet-anomaly diagnostic.
+
+### 3. Compare classified absolute IDs in timestamp repair
+
+After classification, `abs_frame_ids` are the authoritative pipeline identity.
+`TimestampRepairStage` will therefore evaluate in-packet disagreement using
+`batch.abs_frame_ids`, not the preserved raw `batch.frame_ids`.
+
+Consequences:
+
+- A consensus-corrected packet has matching absolute IDs and is not treated as
+  timestamp corruption.
+- It receives no timestamp rewrite and no NaN fill.
+- A non-correctable disagreement remains visible because its classified
+  absolute IDs still disagree.
+- Condition 1, which detects genuine timestamp deviation from cadence, remains
+  unchanged apart from the anchor corrections already present on #229.
+
+### 4. Emit bounded, self-contained log diagnostics
+
+Two diagnostics-channel event types will describe packet-level ID faults:
+
+- `FrameIdConsensusCorrection`: one outlier was safely substituted by strict
+  packet consensus.
+- `FrameIdPacketAnomaly`: the packet disagreed but was ambiguous and was not
+  changed.
+
+A consensus-correction event contains:
+
+- side and packet timestamp;
+- outlier camera ID;
+- observed raw ID and consensus raw ID;
+- previous accepted raw and absolute IDs for the outlier camera;
+- corrected absolute ID;
+- complete packet snapshot as ordered `(camera_id, observed_raw_id)` pairs;
+- an explicit action stating that the histogram was accepted at the original
+  packet timestamp and only its pipeline frame identity was normalized.
+
+An ambiguous-anomaly event contains the side, packet timestamp, complete packet
+snapshot, prior per-camera unwrap context where available, and the reason no
+substitution was made.
+
+`DiagnosticsLogSink` will:
+
+- log the first eight events of each frame-ID diagnostic type in full;
+- show raw IDs in decimal and hexadecimal;
+- emit one suppression notice when the per-type limit is exceeded;
+- continue counting suppressed events; and
+- include corrected and ambiguous totals in the scan-completion summary.
+
+The eight-example cap applies per event type per scan. It gives complete
+evidence for the three-frame #220 burst while bounding a sustained fault.
+
+`ScanDBSink` will explicitly ignore these two event types. No frame-ID details,
+counts, or examples are added to SQLite `session_meta`; the ordinary application
+log is the forensic record.
+
+## Error handling and safety rules
+
+- A two-camera disagreement is ambiguous and is never guessed.
+- A 2-vs-2 or other no-majority packet is never guessed.
+- Multiple outliers are never guessed.
+- Duplicate camera IDs invalidate consensus for that timestamp group.
+- A consensus ID that is not a valid forward continuation for the outlier's
+  existing unwrapper state is not applied.
+- A first-seen outlier camera has no history for validation and is not corrected.
+- Ambiguous cases retain current downstream behavior and gain detailed logging.
+- Raw IDs and timestamps are immutable evidence throughout the pipeline.
+
+## Data flow
+
+```text
+coalesced USB histogram packet
+  -> LiveUsbSource keeps timestamp group atomic
+  -> FrameClassificationStage
+       observed raw IDs retained in batch.frame_ids
+       strict-majority outlier gets temporary effective consensus ID
+       effective ID feeds that camera's unwrapper
+       packet diagnostic appended to batch.events
+  -> TimestampRepairStage compares abs_frame_ids
+       corrected consensus group passes unchanged
+       genuine/ambiguous divergence remains detectable
+  -> dark correction and side averaging consume aligned abs_frame_ids
+  -> DiagnosticsLogSink writes bounded forensic detail
+  -> ScanDBSink ignores frame-ID packet diagnostics
+```
+
+## Testing strategy
+
+### Source batching
+
+- A batch threshold reached midway through a timestamp group does not split the
+  group.
+- The next timestamp triggers the pending flush.
+- Parser shutdown flushes the final complete group.
+
+### Classification
+
+- Four-camera packet with one corrupted ID uses the three-camera consensus.
+- `batch.frame_ids` retains the corrupt observed byte.
+- All four `abs_frame_ids` match after classification.
+- The outlier camera's next genuine frame unwraps normally.
+- The correction event contains every required field.
+- Two-camera, 2-vs-2, duplicate-camera, multiple-outlier, first-seen, and
+  cadence-inconsistent cases are not corrected and emit an ambiguity event.
+
+### Timestamp repair
+
+- Condition 2 compares `abs_frame_ids`.
+- A consensus-corrected group produces no timestamp correction or NaN fill.
+- A genuine absolute-ID disagreement remains detected.
+- Existing condition-1 timestamp burst, terminal artifact, re-anchor, and
+  NaN-gap tests continue to pass.
+
+### End-to-end #220 regression
+
+Replay the real four-camera, 40 Hz high-bit-corruption signature through
+classification, timestamp repair, and side averaging. Assert:
+
+- no real frames become stale;
+- no timestamps are rewritten;
+- no NaN rows are fabricated;
+- the timeline remains monotonic;
+- every side average contains all enabled cameras;
+- each outlier histogram is retained at its packet timestamp; and
+- the expected correction diagnostics identify the wire IDs and consensus.
+
+### Logging and persistence
+
+- Full log lines contain side, timestamp, camera, observed/consensus IDs in
+  decimal and hex, prior state, corrected absolute ID, packet snapshot, and
+  action.
+- The ninth same-type event produces one suppression notice, not a ninth full
+  record.
+- Completion reports full corrected/ambiguous totals.
+- `ScanDBSink` writes no frame-ID diagnostic entry into `session_meta`.
+
+## Compatibility and performance
+
+- Public scan APIs and persisted science schemas do not change.
+- Raw CSV frame IDs remain wire-authentic.
+- Corrected CSV/DB science output continues to use downstream absolute frame
+  identity as before.
+- Consensus work is linear in each small packet group (at most eight cameras).
+- Packet-aligned batching can increase a batch by at most one packet and adds at
+  most one packet interval of flush latency.
+

--- a/docs/superpowers/specs/2026-08-11-frame-id-consensus-repair-design.md
+++ b/docs/superpowers/specs/2026-08-11-frame-id-consensus-repair-design.md
@@ -35,6 +35,9 @@ original timestamp.
 - Prevent a single raw-ID outlier from corrupting unwrapper state.
 - Accept the outlier histogram at its truthful packet timestamp.
 - Preserve the observed wire ID for raw export and forensic logging.
+- Capture suspicious inbound values in the ordinary log before any stage
+  rewrites, substitutes, or fills them, so a raw CSV is not required to
+  reconstruct the pipeline's decision.
 - Keep downstream `abs_frame_ids` aligned for dark scheduling, terminal-dark
   matching, and side averaging.
 - Emit self-contained diagnostics that make the fault root-causeable from an
@@ -49,6 +52,7 @@ original timestamp.
 - Store frame-ID forensic examples in SQLite or `session_meta`.
 - Change raw histogram contents or capture timestamps.
 - Redesign the 8-bit firmware counter protocol.
+- Log ordinary healthy packets or unbounded histogram payloads.
 
 ## Design
 
@@ -121,14 +125,28 @@ Consequences:
 - Condition 1, which detects genuine timestamp deviation from cadence, remains
   unchanged apart from the anchor corrections already present on #229.
 
-### 4. Emit bounded, self-contained log diagnostics
+### 4. Log suspicious input before mutation
 
-Two diagnostics-channel event types will describe packet-level ID faults:
+The observability rule is: **log the evidence first, then mutate**. A future
+investigation must be able to reconstruct why the pipeline acted even when the
+raw CSV was disabled or is no longer available.
+
+Every anomaly log begins with the explicit marker `INBOUND DATA ANOMALY` and
+states whether the associated histogram is being accepted, corrected,
+NaN-filled, or left for conservative downstream handling. Values in these
+records are captured before timestamp rewriting, frame-ID substitution, or
+synthetic-row insertion.
+
+Four diagnostics-channel event types describe suspicious inbound data:
 
 - `FrameIdConsensusCorrection`: one outlier was safely substituted by strict
   packet consensus.
 - `FrameIdPacketAnomaly`: the packet disagreed but was ambiguous and was not
   changed.
+- `TimestampRepairInputAnomaly`: a frame was flagged for timestamp repair by
+  cadence deviation, unresolved absolute-ID disagreement, or both.
+- `FrameGapFillAnomaly`: an accepted absolute-ID gap will cause synthetic NaN
+  rows to be inserted.
 
 A consensus-correction event contains:
 
@@ -145,20 +163,46 @@ An ambiguous-anomaly event contains the side, packet timestamp, complete packet
 snapshot, prior per-camera unwrap context where available, and the reason no
 substitution was made.
 
+A timestamp-input event contains:
+
+- side, camera, observed raw ID, classified absolute ID, and original timestamp;
+- the previous genuine anchor's raw ID, absolute ID, and timestamp;
+- the nominal period, frame-ID gap, expected timestamp, signed residual, and
+  configured tolerance;
+- all rows in the same side/timestamp group as ordered
+  `(camera_id, observed_raw_id, abs_frame_id)` triples;
+- which detector fired (`timestamp_deviation`, `frame_id_disagreement`, or
+  both); and
+- the action the stage will take.
+
+A gap-fill event contains:
+
+- side and camera;
+- the preceding and current observed raw IDs, classified absolute IDs, and
+  original timestamps;
+- the inferred missing-frame count and synthetic absolute-ID range; and
+- the action stating that NaN rows will be inserted because the accepted
+  absolute IDs indicate a gap.
+
+These events contain metadata only. Histogram bins are not copied into the log.
+The raw histogram remains available through the existing optional raw CSV, but
+the CSV is not necessary to see the IDs, timestamps, anchors, residuals, or
+pipeline decision.
+
 `DiagnosticsLogSink` will:
 
-- log the first eight events of each frame-ID diagnostic type in full;
+- log the first eight events of each inbound-anomaly type in full;
 - show raw IDs in decimal and hexadecimal;
 - emit one suppression notice when the per-type limit is exceeded;
 - continue counting suppressed events; and
-- include corrected and ambiguous totals in the scan-completion summary.
+- include per-type totals in the scan-completion summary.
 
 The eight-example cap applies per event type per scan. It gives complete
 evidence for the three-frame #220 burst while bounding a sustained fault.
 
-`ScanDBSink` will explicitly ignore these two event types. No frame-ID details,
-counts, or examples are added to SQLite `session_meta`; the ordinary application
-log is the forensic record.
+`ScanDBSink` will explicitly ignore all four inbound-anomaly event types. No
+details, counts, or examples are added to SQLite `session_meta`; the ordinary
+application log is the forensic record.
 
 ## Error handling and safety rules
 
@@ -170,7 +214,11 @@ log is the forensic record.
   existing unwrapper state is not applied.
 - A first-seen outlier camera has no history for validation and is not corrected.
 - Ambiguous cases retain current downstream behavior and gain detailed logging.
-- Raw IDs and timestamps are immutable evidence throughout the pipeline.
+- Anomaly events preserve observed raw IDs and pre-mutation timestamps as
+  immutable evidence even when a later stage repairs `batch.timestamp_s`.
+- An anomaly is logged even when consensus correction makes the resulting data
+  scientifically usable; successful healing never makes the input anomaly
+  invisible.
 
 ## Data flow
 
@@ -185,9 +233,10 @@ coalesced USB histogram packet
   -> TimestampRepairStage compares abs_frame_ids
        corrected consensus group passes unchanged
        genuine/ambiguous divergence remains detectable
+       timestamp deviations and inferred gaps emit pre-mutation evidence
   -> dark correction and side averaging consume aligned abs_frame_ids
   -> DiagnosticsLogSink writes bounded forensic detail
-  -> ScanDBSink ignores frame-ID packet diagnostics
+  -> ScanDBSink ignores inbound-data anomaly diagnostics
 ```
 
 ## Testing strategy
@@ -214,6 +263,10 @@ coalesced USB histogram packet
 - Condition 2 compares `abs_frame_ids`.
 - A consensus-corrected group produces no timestamp correction or NaN fill.
 - A genuine absolute-ID disagreement remains detected.
+- A genuine cadence deviation emits its original timestamp, genuine anchor,
+  expected timestamp, residual, tolerance, and packet context before repair.
+- A missing-ID gap emits its bounding observations and proposed synthetic range
+  before any NaN rows are inserted.
 - Existing condition-1 timestamp burst, terminal artifact, re-anchor, and
   NaN-gap tests continue to pass.
 
@@ -232,13 +285,18 @@ classification, timestamp repair, and side averaging. Assert:
 
 ### Logging and persistence
 
-- Full log lines contain side, timestamp, camera, observed/consensus IDs in
+- Every suspicious-input line begins with `INBOUND DATA ANOMALY`.
+- Frame-ID lines contain side, timestamp, camera, observed/consensus IDs in
   decimal and hex, prior state, corrected absolute ID, packet snapshot, and
   action.
+- Timestamp lines contain the original value, genuine anchor, expected value,
+  residual, tolerance, detector, packet snapshot, and action.
+- Gap-fill lines contain both bounding observations, missing count, synthetic
+  range, and action.
 - The ninth same-type event produces one suppression notice, not a ninth full
   record.
-- Completion reports full corrected/ambiguous totals.
-- `ScanDBSink` writes no frame-ID diagnostic entry into `session_meta`.
+- Completion reports full per-type anomaly totals.
+- `ScanDBSink` writes no inbound-anomaly diagnostic entry into `session_meta`.
 
 ## Compatibility and performance
 
@@ -249,4 +307,3 @@ classification, timestamp repair, and side averaging. Assert:
 - Consensus work is linear in each small packet group (at most eight cameras).
 - Packet-aligned batching can increase a batch by at most one packet and adds at
   most one packet interval of flush latency.
-

--- a/omotion/pipeline/batch.py
+++ b/omotion/pipeline/batch.py
@@ -111,6 +111,78 @@ class TimestampMisalignmentWindow(BatchEvent):
 
 
 @dataclass
+class FrameIdConsensusCorrection(BatchEvent):
+    """One wire frame ID differed from an otherwise unanimous packet.
+
+    The raw ID remains in ``FrameBatch.frame_ids``; only the effective value
+    passed to that camera's unwrapper is replaced by the packet consensus.
+    """
+    side: int
+    timestamp_s: float
+    cam_id: int
+    observed_raw_frame_id: int
+    consensus_raw_frame_id: int
+    previous_raw_frame_id: int
+    previous_abs_frame_id: int
+    corrected_abs_frame_id: int
+    packet: tuple[tuple[int, int], ...]
+    action: str = "used_consensus_for_unwrap"
+
+
+@dataclass
+class FrameIdPacketAnomaly(BatchEvent):
+    """A packet contained mismatched frame IDs but was unsafe to correct."""
+    side: int
+    timestamp_s: float
+    reason: str
+    packet: tuple[tuple[int, int], ...]
+    action: str = "left_unchanged"
+    cam_id: Optional[int] = None
+    observed_raw_frame_id: Optional[int] = None
+    consensus_raw_frame_id: Optional[int] = None
+    previous_raw_frame_id: Optional[int] = None
+    previous_abs_frame_id: Optional[int] = None
+
+
+@dataclass
+class TimestampRepairInputAnomaly(BatchEvent):
+    """Pre-mutation evidence for one frame timestamp repair decision."""
+    side: int
+    cam_id: int
+    raw_frame_id: int
+    abs_frame_id: int
+    original_timestamp_s: float
+    previous_raw_frame_id: Optional[int]
+    previous_abs_frame_id: Optional[int]
+    previous_timestamp_s: Optional[float]
+    nominal_period_s: float
+    frame_id_gap: Optional[int]
+    expected_timestamp_s: Optional[float]
+    signed_residual_s: Optional[float]
+    tolerance_s: float
+    packet: tuple[tuple[int, int, int], ...]
+    detector: str
+    action: str
+
+
+@dataclass
+class FrameGapFillAnomaly(BatchEvent):
+    """Pre-mutation evidence for synthetic rows inserted across an ID gap."""
+    side: int
+    cam_id: int
+    previous_raw_frame_id: int
+    previous_abs_frame_id: int
+    previous_timestamp_s: float
+    current_raw_frame_id: int
+    current_abs_frame_id: int
+    current_timestamp_s: float
+    missing_count: int
+    first_missing_abs_frame_id: int
+    last_missing_abs_frame_id: int
+    action: str = "inserted_nan_fill_rows"
+
+
+@dataclass
 class PipelineError(BatchEvent):
     """A stage raised during pipeline.process(); the batch was dropped.
 

--- a/omotion/pipeline/sinks.py
+++ b/omotion/pipeline/sinks.py
@@ -507,6 +507,36 @@ def _is_integrity_event(event) -> bool:
     return True
 
 
+def _is_inbound_data_anomaly(event) -> bool:
+    """True for high-detail acquisition anomalies retained in logs only."""
+    from .batch import (
+        FrameGapFillAnomaly,
+        FrameIdConsensusCorrection,
+        FrameIdPacketAnomaly,
+        TimestampRepairInputAnomaly,
+    )
+    return isinstance(event, (
+        FrameIdConsensusCorrection,
+        FrameIdPacketAnomaly,
+        TimestampRepairInputAnomaly,
+        FrameGapFillAnomaly,
+    ))
+
+
+def _format_inbound_data_anomaly(event) -> str:
+    """Render every captured field explicitly for production diagnosis."""
+    from dataclasses import fields
+
+    def display(value):
+        return value if isinstance(value, str) else repr(value)
+
+    evidence = ", ".join(
+        f"{item.name}={display(getattr(event, item.name))}"
+        for item in fields(event)
+    )
+    return f"INBOUND DATA ANOMALY [{type(event).__name__}]: {evidence}"
+
+
 def _event_frame(event):
     """Best-effort frame/time locator for an event, for summaries."""
     for attr in ("abs_frame_id", "onset_fid", "first_timestamp_s"):
@@ -525,10 +555,9 @@ class DiagnosticsLogSink:
     StencilFallback, PipelineError (batch dropped) — are logged at WARNING
     instead of silently evaporating, with a per-type summary at scan end.
 
-    The durable counterpart lives in ScanDBSink, which also subscribes to
-    "diagnostics" and writes the same summary into the session's
-    session_meta so the DB record itself shows whether a scan had
-    integrity warnings.
+    ScanDBSink retains ordinary integrity summaries. High-detail inbound-data
+    anomalies are deliberately log-only: raw acquisition evidence does not
+    belong in session_meta.
     """
 
     channels = {"diagnostics"}
@@ -547,6 +576,18 @@ class DiagnosticsLogSink:
         from .batch import TimestampMisalignmentWindow
         name = type(event).__name__
         self._counts[name] = self._counts.get(name, 0) + 1
+        count = self._counts[name]
+        if _is_inbound_data_anomaly(event):
+            if count <= 8:
+                logger.warning(_format_inbound_data_anomaly(event))
+            elif count == 9:
+                logger.warning(
+                    "INBOUND DATA ANOMALY [%s]: further detail suppressed "
+                    "after 8 events; total remains in the scan completion "
+                    "summary",
+                    name,
+                )
+            return
         # TimestampRepairStage already logs each window with full context
         # under its own logger — count it for the summary, don't double-log.
         if not isinstance(event, TimestampMisalignmentWindow):
@@ -571,10 +612,9 @@ class ScanDBSink:
                   stencilled leading dark frame — a gapless 40 Hz record.
                   Reduced mode: only the side-average frames (cam_id=-1)
                   emitted by SideAverageStage are persisted.
-        "diagnostics" — integrity events are tallied and a per-type summary
-                  (count + first/last frame) is written into the session's
-                  session_meta at scan end, so the DB record itself shows
-                  whether the scan had correction-integrity warnings.
+        "diagnostics" — ordinary integrity events are summarized in
+                  session_meta. Inbound-data anomalies are ignored here and
+                  retained only by DiagnosticsLogSink.
 
     The DB is the corrected (final-branch) record only. Realtime values
     reach the GUI via the "live" / "live_side" channels and are never
@@ -686,6 +726,8 @@ class ScanDBSink:
 
     def _consume_diagnostic(self, event) -> None:
         """Tally integrity events for the session_meta summary."""
+        if _is_inbound_data_anomaly(event):
+            return
         if not _is_integrity_event(event):
             return
         name = type(event).__name__

--- a/omotion/pipeline/sources.py
+++ b/omotion/pipeline/sources.py
@@ -348,17 +348,33 @@ class LiveUsbSource(_BaseSource):
 
         side_idx = 0 if side_name == "left" else 1
         accumulated: list = []
+        packet_cams: set[int] = set()
+        packet_ts = None
         last_flush = time.monotonic()
 
         def on_row(cam_id, frame_id, ts, histogram, row_sum, temp):
-            nonlocal last_flush
-            accumulated.append((cam_id, frame_id, ts, histogram, row_sum, temp))
+            nonlocal last_flush, packet_ts
             now = time.monotonic()
-            if (len(accumulated) >= self._batch_size
-                    or now - last_flush >= self._flush_interval):
+            threshold_reached = (
+                len(accumulated) >= self._batch_size
+                or now - last_flush >= self._flush_interval
+            )
+            starts_new_packet = bool(packet_cams) and (
+                ts != packet_ts or cam_id in packet_cams
+            )
+            stuck_timestamp_boundary = starts_new_packet and ts == packet_ts
+            if starts_new_packet and (threshold_reached
+                                      or stuck_timestamp_boundary):
                 self._batch_queue.put(self._build_batch(side_idx, accumulated))
                 accumulated.clear()
                 last_flush = now
+            if starts_new_packet:
+                packet_cams.clear()
+                packet_ts = ts
+            elif packet_ts is None:
+                packet_ts = ts
+            packet_cams.add(cam_id)
+            accumulated.append((cam_id, frame_id, ts, histogram, row_sum, temp))
 
         buf = bytearray()
         parse_histogram_stream(

--- a/omotion/pipeline/stages/classify.py
+++ b/omotion/pipeline/stages/classify.py
@@ -15,10 +15,15 @@ See docs/SciencePipeline.md §3 (unwrapping) and §4 (classification).
 from __future__ import annotations
 
 import logging
+from collections import Counter, defaultdict
 
 import numpy as np
 
-from ..batch import FrameBatch
+from ..batch import (
+    FrameBatch,
+    FrameIdConsensusCorrection,
+    FrameIdPacketAnomaly,
+)
 
 
 logger = logging.getLogger("openmotion.sdk.pipeline.stages.frame_classification")
@@ -69,17 +74,27 @@ class _FrameUnwrapper:
             self.last_raw = raw_frame_id
             return raw_frame_id, True
 
-        # Signed step in [-128, 127]: positive = forward, <= 0 = backward
-        # (stale leftover) or duplicate.
-        step = ((raw_frame_id - self.last_raw + 128) & 0xFF) - 128
-        if step <= 0:
-            return self.epoch * _FRAME_ID_MODULUS + raw_frame_id, False
-
-        # Forward step (1..127). A wrap shows up as raw <= last_raw.
+        abs_id, accepted = self.preview(raw_frame_id)
+        if not accepted:
+            return abs_id, False
         if raw_frame_id <= self.last_raw:
             self.epoch += 1
         self.last_raw = raw_frame_id
-        return self.epoch * _FRAME_ID_MODULUS + raw_frame_id, True
+        return abs_id, True
+
+    def preview(self, raw_frame_id: int) -> tuple[int, bool]:
+        """Return the unwrap result without advancing counter state."""
+        if not self.seen_first:
+            return raw_frame_id, True
+        step = ((raw_frame_id - self.last_raw + 128) & 0xFF) - 128
+        if step <= 0:
+            return self.epoch * _FRAME_ID_MODULUS + raw_frame_id, False
+        epoch = self.epoch + int(raw_frame_id <= self.last_raw)
+        return epoch * _FRAME_ID_MODULUS + raw_frame_id, True
+
+    @property
+    def last_abs(self) -> int:
+        return self.epoch * _FRAME_ID_MODULUS + self.last_raw
 
 
 class FrameClassificationStage:
@@ -101,10 +116,12 @@ class FrameClassificationStage:
         n = batch.frame_ids.shape[0]
         abs_ids = np.zeros(n, dtype=np.int64)
         types = np.empty(n, dtype="<U8")
+        effective_ids = self._packet_consensus_ids(batch)
 
         for i in range(n):
             cam_id = int(batch.cam_ids[i])
             raw_id = int(batch.frame_ids[i])
+            effective_id = int(effective_ids[i])
             # Side is authoritatively set by the source (see FrameBatch.side_ids
             # docstring). Inferring from raw_histograms would misclassify any
             # zero-filled row — e.g. a firmware-dropped frame — as side 0.
@@ -116,7 +133,7 @@ class FrameClassificationStage:
                 unwrapper = _FrameUnwrapper()
                 self._unwrappers[key] = unwrapper
 
-            abs_id, accepted = unwrapper.unwrap(raw_id)
+            abs_id, accepted = unwrapper.unwrap(effective_id)
             abs_ids[i] = abs_id
 
             if not accepted:
@@ -140,6 +157,86 @@ class FrameClassificationStage:
         batch.abs_frame_ids = abs_ids
         batch.frame_type = types
         return batch
+
+    def _packet_consensus_ids(self, batch: FrameBatch) -> np.ndarray:
+        """Return effective IDs for unwrapping while preserving wire values.
+
+        Only a single outlier in a packet of at least three unique cameras is
+        corrected, and only when the consensus is a valid forward continuation
+        for that camera's existing unwrapper.
+        """
+        effective = batch.frame_ids.copy()
+        groups: dict[tuple[int, float], list[int]] = defaultdict(list)
+        for i in range(len(batch.cam_ids)):
+            groups[(int(batch.side_ids[i]), float(batch.timestamp_s[i]))].append(i)
+
+        for (side, timestamp_s), indices in groups.items():
+            raw_ids = [int(batch.frame_ids[i]) for i in indices]
+            if len(set(raw_ids)) == 1:
+                continue
+
+            packet = tuple(
+                (int(batch.cam_ids[i]), int(batch.frame_ids[i]))
+                for i in indices
+            )
+            camera_ids = [cam_id for cam_id, _ in packet]
+            reason = "no_single_outlier_consensus"
+            outlier_i = None
+            consensus = None
+
+            if len(set(camera_ids)) != len(camera_ids):
+                reason = "duplicate_camera_ids"
+            elif len(indices) < 3:
+                reason = "fewer_than_three_cameras"
+            else:
+                counts = Counter(raw_ids)
+                candidate, count = counts.most_common(1)[0]
+                outliers = [i for i in indices
+                            if int(batch.frame_ids[i]) != candidate]
+                if count == len(indices) - 1 and len(outliers) == 1:
+                    consensus = candidate
+                    outlier_i = outliers[0]
+                    cam_id = int(batch.cam_ids[outlier_i])
+                    unwrapper = self._unwrappers.get((side, cam_id))
+                    if unwrapper is None or not unwrapper.seen_first:
+                        reason = "outlier_has_no_prior_state"
+                    else:
+                        corrected_abs, accepted = unwrapper.preview(consensus)
+                        if accepted:
+                            batch.events.append(FrameIdConsensusCorrection(
+                                side=side,
+                                timestamp_s=timestamp_s,
+                                cam_id=cam_id,
+                                observed_raw_frame_id=int(batch.frame_ids[outlier_i]),
+                                consensus_raw_frame_id=consensus,
+                                previous_raw_frame_id=unwrapper.last_raw,
+                                previous_abs_frame_id=unwrapper.last_abs,
+                                corrected_abs_frame_id=corrected_abs,
+                                packet=packet,
+                            ))
+                            effective[outlier_i] = consensus
+                            continue
+                        reason = "consensus_is_not_forward_continuation"
+
+            cam_id = (int(batch.cam_ids[outlier_i])
+                      if outlier_i is not None else None)
+            unwrapper = (self._unwrappers.get((side, cam_id))
+                         if cam_id is not None else None)
+            batch.events.append(FrameIdPacketAnomaly(
+                side=side,
+                timestamp_s=timestamp_s,
+                reason=reason,
+                packet=packet,
+                cam_id=cam_id,
+                observed_raw_frame_id=(int(batch.frame_ids[outlier_i])
+                                       if outlier_i is not None else None),
+                consensus_raw_frame_id=consensus,
+                previous_raw_frame_id=(unwrapper.last_raw
+                                       if unwrapper is not None else None),
+                previous_abs_frame_id=(unwrapper.last_abs
+                                       if unwrapper is not None else None),
+            ))
+        return effective
 
     def _note_stale(self, side_idx: int, cam_id: int, raw_id: int,
                     reason: str) -> None:

--- a/omotion/pipeline/stages/timestamp_repair.py
+++ b/omotion/pipeline/stages/timestamp_repair.py
@@ -1,41 +1,10 @@
-"""TimestampRepairStage — EMI timestamp correction + NaN-fill.
+"""Repair timestamp EMI without letting a fabricated value become an anchor.
 
-Detects EMI-induced timestamp misalignment via two conditions:
-  1. Timestamp deviation: |actual_Δt - expected_Δt| > tolerance
-  2. In-packet frame_id disagreement: cameras at the same timestamp
-     report different frame_ids
-
-Bad frames get their timestamps corrected in-place by interpolating
-between the camera's last GENUINE good frame and the next frame in the
-batch that is cadence-consistent with that anchor (per spec §4.5 both
-anchors must be real device timestamps of good frames — a
-still-corrupted frame can never serve as a re-anchor, and a fabricated
-corrected value is never stored as the reference anchor). With no valid
-right anchor in the batch, the correction falls back to nominal-period
-steps from the left anchor. Missing abs_frame_id gaps get synthetic
-NaN-fill rows inserted (the only case that rebuilds the batch).
-
-A PERSISTENT timeline shift — e.g. a camera resuming after a long
-dropout with a different timestamp↔frame_id relationship — would
-otherwise be "corrected" against the stale anchor for the rest of the
-scan. After ``_RESYNC_CONSISTENT_FRAMES`` consecutive flagged frames
-whose ORIGINAL timestamps are mutually cadence-consistent, the stage
-re-anchors on the new timeline (one WARNING) and stops rewriting.
-Transient EMI signatures don't trip this: a stuck timestamp counter is
-never self-consistent, and short offset bursts end before the threshold.
-
-Misalignment windows are tracked PER SIDE but close only when every
-camera that diverged in the window has produced a good frame again — an
-interleaved healthy camera can't split one divergent episode into
-per-frame windows (spec R3: one coalesced WARNING per window, never one
-line per frame). Each window also emits a TimestampMisalignmentWindow
-diagnostics event so the scan DB's session_meta summary records it. The
-firmware's terminal stop frame — the laser-off frame fired ~150 ms off
-the 25 ms grid at every scan stop — is recognised at on_scan_stop and
-reclassified as an expected artifact (INFO, excluded from the
-misalignment record).
-
-See docs/superpowers/specs/2026-06-05-eft-timestamp-repair-design.md.
+A frame is suspect when its timestamp departs from its camera's genuine
+frame-ID cadence or when one coalesced packet contains different absolute
+IDs. Suspect runs are re-anchored, persistent coherent shifts are accepted,
+and genuine ID gaps receive synthetic rows. Detector inputs are buffered with
+each window so the expected terminal stop artifact produces no false alarm.
 """
 
 from __future__ import annotations
@@ -47,7 +16,12 @@ from typing import Optional
 
 import numpy as np
 
-from ..batch import FrameBatch, TimestampMisalignmentWindow
+from ..batch import (
+    FrameBatch,
+    FrameGapFillAnomaly,
+    TimestampMisalignmentWindow,
+    TimestampRepairInputAnomaly,
+)
 
 logger = logging.getLogger("openmotion.sdk.pipeline.stages.timestamp_repair")
 
@@ -63,10 +37,7 @@ _RESYNC_CONSISTENT_FRAMES = 8
 
 @dataclass
 class _WindowStats:
-    """Running stats for one contiguous per-side misalignment window, used
-    for coalesced logging: the frame-id/time span it spans, how many frames
-    within it were re-timestamped vs NaN-filled, and which (side, cam)
-    frames it flagged (for the terminal stop-frame check)."""
+    """One coalesced per-side repair window and its original evidence."""
     side: int
     onset_fid: int
     onset_t: float
@@ -77,39 +48,54 @@ class _WindowStats:
     # (key, abs_fid) of each flagged frame — consulted at scan stop to
     # recognise the firmware's terminal stop-frame artifact.
     frames: list = field(default_factory=list)
+    input_anomalies: list[TimestampRepairInputAnomaly] = field(
+        default_factory=list,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class _FramePoint:
+    """One genuine frame as received, before any repair mutation."""
+    raw_id: int
+    abs_id: int
+    timestamp_s: float
+
+
+@dataclass(frozen=True, slots=True)
+class _CadenceCheck:
+    """The evidence used by timestamp-deviation detection."""
+    anchor: _FramePoint
+    frame_id_gap: int
+    expected_timestamp_s: float
+    signed_residual_s: float
+
+
+@dataclass(frozen=True, slots=True)
+class _GapPoint:
+    raw_id: int
+    abs_id: int
+    input_timestamp_s: float
+    timeline_timestamp_s: float
 
 
 class TimestampRepairStage:
-    """Pipeline stage that repairs EMI-corrupted capture timestamps.
-
-    See the module docstring for the algorithm. One instance per scan;
-    cross-batch state (nominal-period estimate, per-camera genuine
-    anchors, divergent-run tracking, the open misalignment windows)
-    persists across process() calls and is cleared by reset()."""
+    """Stateful, per-scan repair described in the module docstring."""
 
     name = "timestamp_repair"
 
     def __init__(self, *, tolerance_s: float = _DEFAULT_TOLERANCE_S):
-        """Configure the stage.
-
-        Args:
-            tolerance_s: max |actual Δt − expected Δt| (seconds) before a
-                frame's timestamp is treated as EMI-corrupted (condition 1).
-        """
+        """Set the maximum allowed timestamp-cadence residual in seconds."""
         self._tolerance = float(tolerance_s)
         self._reset_state()
 
     def _reset_state(self) -> None:
-        """Clear all per-scan state — nominal-period estimate, per-camera
-        genuine anchors and divergent-run tracking, the open per-side windows
-        with their divergent-camera sets, and the running totals. Called from
-        __init__ and reset()."""
+        """Clear anchors, divergence windows, and scan totals."""
         self._nominal_period = _INITIAL_NOMINAL_PERIOD_S
         # Last GENUINE good frame per (side, cam) — never a fabricated
         # corrected timestamp. Both condition 1 and re-anchor validation
         # measure against this, so a bad burst can't drag the reference
         # off the true timeline.
-        self._last_good: dict[tuple[int, int], tuple[int, float]] = {}
+        self._last_good: dict[tuple[int, int], _FramePoint] = {}
         # Divergent-run tracking per (side, cam) for timeline re-sync:
         # the last flagged frame's ORIGINAL (fid, ts) and the count of
         # consecutive mutually-consistent flagged frames.
@@ -122,7 +108,7 @@ class TimestampRepairStage:
         self._divergent: dict[int, set] = {0: set(), 1: set()}
         self._scan_windows: list[_WindowStats] = []
         self._total_frames_seen = 0
-        self._nan_last_seen: dict[tuple[int, int], tuple[int, float]] = {}
+        self._nan_last_seen: dict[tuple[int, int], _GapPoint] = {}
         self._total_corrected = 0
         self._total_nan = 0
         self._terminal_frames = 0
@@ -130,14 +116,7 @@ class TimestampRepairStage:
     # ── Main entry ──────────────────────────────────────────────────────
 
     def process(self, batch: FrameBatch) -> FrameBatch:
-        """Detect and repair EMI timestamp corruption for one batch.
-
-        Flags each non-warmup/stale frame via condition 2 (in-packet
-        frame_id disagreement) or condition 1 (timestamp deviation vs the
-        frame_id cadence), rewrites bad timestamps in place by re-anchoring
-        interpolation, and inserts synthetic NaN-fill rows for missing
-        abs_frame_id gaps. Sets ``batch.quality`` and returns the batch
-        (a new, larger batch when NaN-fills were inserted)."""
+        """Repair suspect timestamps and insert rows for absolute-ID gaps."""
         if batch.abs_frame_ids is None or batch.frame_type is None:
             return batch
 
@@ -148,9 +127,9 @@ class TimestampRepairStage:
 
         self._total_frames_seen += n
         quality = np.full(n, "ok", dtype="<U14")
+        input_timestamps = batch.timestamp_s.copy()
 
-        # Condition 2 (batch-wide): in-packet frame_id disagreement
-        bad_cond2 = self._detect_frame_id_disagreement(batch)
+        packet_by_row, bad_cond2 = self._packet_context(batch)
 
         # Per-camera row pool for re-anchoring. Condition 1 is validated
         # per candidate at interpolation time (needs _last_good context).
@@ -164,12 +143,19 @@ class TimestampRepairStage:
 
             cam_id = int(batch.cam_ids[i])
             side_idx = int(batch.side_ids[i])
+            raw_fid = int(batch.frame_ids[i])
             abs_fid = int(batch.abs_frame_ids[i])
             ts = float(batch.timestamp_s[i])
             key = (side_idx, cam_id)
 
             # Condition 1: timestamp deviation vs the genuine anchor
-            is_bad = i in bad_cond2 or self._deviates(key, abs_fid, ts)
+            cadence = self._cadence_check(key, abs_fid, ts)
+            cond1 = (cadence is not None and
+                     abs(cadence.signed_residual_s)
+                     > self._tolerance + _TOLERANCE_EPS_S)
+            detector = ("absolute_frame_id_disagreement"
+                        if i in bad_cond2 else "timestamp_deviation")
+            is_bad = i in bad_cond2 or cond1
 
             if is_bad and self._note_divergent_run(key, abs_fid, ts):
                 # RESYNC: enough consecutive flagged frames agree with
@@ -186,25 +172,38 @@ class TimestampRepairStage:
                 )
                 is_bad = False
 
+            anomaly = None
+            if i in bad_cond2 or cond1:
+                anomaly = self._make_input_anomaly(
+                    side_idx, cam_id, raw_fid, abs_fid, ts,
+                    cadence, packet_by_row[i], detector,
+                    "timestamp_corrected" if is_bad else "accepted_as_new_timeline",
+                )
+
             if is_bad:
                 corrected_ts = self._interpolate(key, abs_fid, cam_rows.get(key))
                 batch.timestamp_s[i] = corrected_ts
                 quality[i] = "ts_corrected"
                 self._total_corrected += 1
-                self._track_window_open(side_idx, key, abs_fid, ts)
+                self._track_window_open(
+                    side_idx, key, abs_fid, ts, anomaly,
+                )
                 # Deliberately NOT stored in _last_good: a fabricated
                 # timestamp must never become the reference anchor.
             else:
+                window = self._open_window[side_idx]
+                if anomaly is not None and window is not None:
+                    window.input_anomalies.append(anomaly)
                 self._run_last.pop(key, None)
                 self._run_len.pop(key, None)
                 self._update_nominal_period(key, abs_fid, ts)
-                self._last_good[key] = (abs_fid, ts)
+                self._last_good[key] = _FramePoint(raw_fid, abs_fid, ts)
                 self._note_good(side_idx, key, batch.events)
 
         batch.quality = quality
 
         # Insert NaN-fill rows for missing abs_frame_id gaps
-        nan_fills = self._collect_nan_fills(batch)
+        nan_fills = self._collect_nan_fills(batch, input_timestamps)
         if nan_fills:
             batch = self._insert_nan_fills(batch, nan_fills)
 
@@ -212,36 +211,86 @@ class TimestampRepairStage:
 
     # ── Detection ───────────────────────────────────────────────────────
 
-    def _detect_frame_id_disagreement(self, batch: FrameBatch) -> set[int]:
-        """Condition 2: cameras at the same timestamp with different frame_ids."""
-        bad: set[int] = set()
+    def _packet_context(
+        self, batch: FrameBatch,
+    ) -> tuple[dict[int, tuple[tuple[int, int, int], ...]], set[int]]:
+        """Return packet evidence and rows with disagreeing absolute IDs."""
         groups: dict[tuple[int, float], list[int]] = defaultdict(list)
         for i in range(len(batch.cam_ids)):
-            ft = str(batch.frame_type[i])
-            if ft in ("warmup", "stale"):
-                continue
             groups[(int(batch.side_ids[i]), float(batch.timestamp_s[i]))].append(i)
+        contexts = {}
+        bad = set()
         for indices in groups.values():
-            if len(indices) < 2:
-                continue
-            if len({int(batch.frame_ids[j]) for j in indices}) > 1:
-                bad.update(indices)
-        return bad
+            packet = tuple(
+                (int(batch.cam_ids[i]), int(batch.frame_ids[i]),
+                 int(batch.abs_frame_ids[i]))
+                for i in indices
+            )
+            contexts.update((i, packet) for i in indices)
+            active = [i for i in indices
+                      if str(batch.frame_type[i]) not in ("warmup", "stale")]
+            if len({int(batch.abs_frame_ids[i]) for i in active}) > 1:
+                bad.update(active)
+        return contexts, bad
 
-    def _deviates(self, key: tuple[int, int], abs_fid: int, ts: float) -> bool:
-        """Condition 1: does (abs_fid, ts) deviate from the frame-id cadence
-        implied by this camera's genuine anchor? False when the camera has
-        no anchor yet (nothing to measure against)."""
+    def _cadence_check(
+        self, key: tuple[int, int], abs_fid: int, ts: float,
+    ) -> Optional[_CadenceCheck]:
+        """Return expected timing and residual against the genuine anchor."""
         anchor = self._last_good.get(key)
         if anchor is None:
-            return False
-        prev_fid, prev_ts = anchor
-        fid_gap = abs_fid - prev_fid
+            return None
+        fid_gap = abs_fid - anchor.abs_id
         if fid_gap <= 0:
-            return False
-        expected_dt = fid_gap * self._nominal_period
-        actual_dt = ts - prev_ts
-        return abs(actual_dt - expected_dt) > self._tolerance + _TOLERANCE_EPS_S
+            return None
+        expected_ts = anchor.timestamp_s + fid_gap * self._nominal_period
+        return _CadenceCheck(
+            anchor=anchor,
+            frame_id_gap=fid_gap,
+            expected_timestamp_s=expected_ts,
+            signed_residual_s=ts - expected_ts,
+        )
+
+    def _deviates(self, key: tuple[int, int], abs_fid: int, ts: float) -> bool:
+        check = self._cadence_check(key, abs_fid, ts)
+        return (check is not None and
+                abs(check.signed_residual_s)
+                > self._tolerance + _TOLERANCE_EPS_S)
+
+    def _make_input_anomaly(
+        self,
+        side: int,
+        cam_id: int,
+        raw_fid: int,
+        abs_fid: int,
+        timestamp_s: float,
+        cadence: Optional[_CadenceCheck],
+        packet: tuple[tuple[int, int, int], ...],
+        detector: str,
+        action: str,
+    ) -> TimestampRepairInputAnomaly:
+        """Capture the detector inputs before timestamp mutation."""
+        anchor = cadence.anchor if cadence is not None else self._last_good.get((side, cam_id))
+        return TimestampRepairInputAnomaly(
+            side=side,
+            cam_id=cam_id,
+            raw_frame_id=raw_fid,
+            abs_frame_id=abs_fid,
+            original_timestamp_s=timestamp_s,
+            previous_raw_frame_id=anchor.raw_id if anchor else None,
+            previous_abs_frame_id=anchor.abs_id if anchor else None,
+            previous_timestamp_s=anchor.timestamp_s if anchor else None,
+            nominal_period_s=self._nominal_period,
+            frame_id_gap=cadence.frame_id_gap if cadence else None,
+            expected_timestamp_s=(cadence.expected_timestamp_s
+                                  if cadence else None),
+            signed_residual_s=(cadence.signed_residual_s
+                               if cadence else None),
+            tolerance_s=self._tolerance,
+            packet=packet,
+            detector=detector,
+            action=action,
+        )
 
     def _note_divergent_run(self, key: tuple[int, int],
                             abs_fid: int, ts: float) -> bool:
@@ -306,7 +355,6 @@ class TimestampRepairStage:
         anchor = self._last_good.get(key)
         if anchor is None:
             return abs_fid * self._nominal_period
-        left_fid, left_ts = anchor
 
         if rows:
             for right_fid, right_ts, c2bad in rows:
@@ -314,12 +362,15 @@ class TimestampRepairStage:
                     continue
                 if self._deviates(key, right_fid, right_ts):
                     continue  # still-corrupted — not a valid re-anchor
-                fid_span = right_fid - left_fid
+                fid_span = right_fid - anchor.abs_id
                 if fid_span > 0:
-                    return left_ts + (abs_fid - left_fid) / fid_span * (right_ts - left_ts)
+                    fraction = (abs_fid - anchor.abs_id) / fid_span
+                    return (anchor.timestamp_s
+                            + fraction * (right_ts - anchor.timestamp_s))
 
         # Fallback: nominal period from left anchor
-        return left_ts + (abs_fid - left_fid) * self._nominal_period
+        return (anchor.timestamp_s
+                + (abs_fid - anchor.abs_id) * self._nominal_period)
 
     # ── Nominal period tracking ─────────────────────────────────────────
 
@@ -331,9 +382,9 @@ class TimestampRepairStage:
         the expected-Δt check in process() doesn't drift off nominal."""
         if key not in self._last_good:
             return
-        prev_fid, prev_ts = self._last_good[key]
-        if abs_fid - prev_fid == 1:
-            dt = ts - prev_ts
+        previous = self._last_good[key]
+        if abs_fid - previous.abs_id == 1:
+            dt = ts - previous.timestamp_s
             if dt > 0:
                 self._nominal_period = (
                     (1 - _EMA_ALPHA) * self._nominal_period + _EMA_ALPHA * dt
@@ -342,7 +393,8 @@ class TimestampRepairStage:
     # ── Window tracking (coalesced logging) ─────────────────────────────
 
     def _track_window_open(self, side: int, key: tuple[int, int],
-                           abs_fid: int, ts: float) -> None:
+                           abs_fid: int, ts: float,
+                           anomaly: Optional[TimestampRepairInputAnomaly]) -> None:
         """Open this side's misalignment window (or extend it), mark the
         camera divergent, and count the re-timestamped frame for coalesced
         per-window logging. ``ts`` is the original pre-correction device
@@ -355,6 +407,8 @@ class TimestampRepairStage:
         w.end_t = ts
         w.n_corrected += 1
         w.frames.append((key, abs_fid))
+        if anomaly is not None:
+            w.input_anomalies.append(anomaly)
         self._divergent[side].add(key)
 
     def _note_good(self, side: int, key: tuple[int, int], events: list) -> None:
@@ -385,6 +439,7 @@ class TimestampRepairStage:
             w.side, w.onset_fid, w.end_fid, w.onset_t, w.end_t,
             w.n_corrected, w.n_nan,
         )
+        events.extend(w.input_anomalies)
         events.append(TimestampMisalignmentWindow(
             side=w.side, onset_fid=w.onset_fid, end_fid=w.end_fid,
             onset_t=w.onset_t, end_t=w.end_t,
@@ -407,13 +462,15 @@ class TimestampRepairStage:
                 return False  # >1 flagged frame for this camera — real run
             seen_keys.add(key)
             last = self._nan_last_seen.get(key)
-            if last is None or fid != last[0]:
+            if last is None or fid != last.abs_id:
                 return False  # frames followed it — not the terminal frame
         return True
 
     # ── NaN-fill for missing frames ─────────────────────────────────────
 
-    def _collect_nan_fills(self, batch: FrameBatch) -> list[tuple[int, dict]]:
+    def _collect_nan_fills(
+        self, batch: FrameBatch, input_timestamps: np.ndarray,
+    ) -> list[tuple[int, dict]]:
         """Find gaps in abs_frame_id per (side, cam) and build fill descriptors.
 
         Returns [(insert_after_idx, fill_dict), ...] sorted by insert position.
@@ -424,21 +481,37 @@ class TimestampRepairStage:
             if ft in ("warmup", "stale"):
                 continue
             key = (int(batch.side_ids[i]), int(batch.cam_ids[i]))
+            raw_fid = int(batch.frame_ids[i])
             abs_fid = int(batch.abs_frame_ids[i])
             ts = float(batch.timestamp_s[i])
+            input_ts = float(input_timestamps[i])
 
             if key in self._nan_last_seen:
-                prev_fid, prev_ts = self._nan_last_seen[key]
-                gap = abs_fid - prev_fid
+                previous = self._nan_last_seen[key]
+                gap = abs_fid - previous.abs_id
                 if gap > 1:
-                    for fid in range(prev_fid + 1, abs_fid):
-                        frac = (fid - prev_fid) / gap
+                    batch.events.append(FrameGapFillAnomaly(
+                        side=key[0],
+                        cam_id=key[1],
+                        previous_raw_frame_id=previous.raw_id,
+                        previous_abs_frame_id=previous.abs_id,
+                        previous_timestamp_s=previous.input_timestamp_s,
+                        current_raw_frame_id=raw_fid,
+                        current_abs_frame_id=abs_fid,
+                        current_timestamp_s=input_ts,
+                        missing_count=gap - 1,
+                        first_missing_abs_frame_id=previous.abs_id + 1,
+                        last_missing_abs_frame_id=abs_fid - 1,
+                    ))
+                    for fid in range(previous.abs_id + 1, abs_fid):
+                        frac = (fid - previous.abs_id) / gap
                         fills.append((i, {
                             "cam_id": key[1],
                             "frame_id": fid & 0xFF,
                             "side_idx": key[0],
                             "abs_frame_id": fid,
-                            "timestamp_s": prev_ts + frac * (ts - prev_ts),
+                            "timestamp_s": (previous.timeline_timestamp_s
+                                            + frac * (ts - previous.timeline_timestamp_s)),
                             "frame_type": "light",
                             "quality": "nan_filled",
                         }))
@@ -447,7 +520,9 @@ class TimestampRepairStage:
                         if w is not None:
                             w.n_nan += 1
 
-            self._nan_last_seen[key] = (abs_fid, ts)
+            self._nan_last_seen[key] = _GapPoint(
+                raw_fid, abs_fid, input_ts, ts,
+            )
 
         fills.sort(key=lambda x: x[0])
         return fills

--- a/omotion/pipeline/stages/timestamp_repair.py
+++ b/omotion/pipeline/stages/timestamp_repair.py
@@ -5,18 +5,35 @@ Detects EMI-induced timestamp misalignment via two conditions:
   2. In-packet frame_id disagreement: cameras at the same timestamp
      report different frame_ids
 
-Bad frames get their timestamps corrected in-place. Within the batch,
-the stage looks ahead for a re-anchor (the next good frame from the
-same camera). If no re-anchor exists in the batch, it falls back to
-nominal-period interpolation. Missing abs_frame_id gaps get synthetic
+Bad frames get their timestamps corrected in-place by interpolating
+between the camera's last GENUINE good frame and the next frame in the
+batch that is cadence-consistent with that anchor (per spec §4.5 both
+anchors must be real device timestamps of good frames — a
+still-corrupted frame can never serve as a re-anchor, and a fabricated
+corrected value is never stored as the reference anchor). With no valid
+right anchor in the batch, the correction falls back to nominal-period
+steps from the left anchor. Missing abs_frame_id gaps get synthetic
 NaN-fill rows inserted (the only case that rebuilds the batch).
 
-Misalignment windows are tracked PER SIDE, log one coalesced WARNING
-each, and emit a TimestampMisalignmentWindow diagnostics event so the
-scan DB's session_meta summary records them. The firmware's terminal
-stop frame — the laser-off frame fired ~150 ms off the 25 ms grid at
-every scan stop — is recognised at on_scan_stop and reclassified as an
-expected artifact (INFO, excluded from the misalignment record).
+A PERSISTENT timeline shift — e.g. a camera resuming after a long
+dropout with a different timestamp↔frame_id relationship — would
+otherwise be "corrected" against the stale anchor for the rest of the
+scan. After ``_RESYNC_CONSISTENT_FRAMES`` consecutive flagged frames
+whose ORIGINAL timestamps are mutually cadence-consistent, the stage
+re-anchors on the new timeline (one WARNING) and stops rewriting.
+Transient EMI signatures don't trip this: a stuck timestamp counter is
+never self-consistent, and short offset bursts end before the threshold.
+
+Misalignment windows are tracked PER SIDE but close only when every
+camera that diverged in the window has produced a good frame again — an
+interleaved healthy camera can't split one divergent episode into
+per-frame windows (spec R3: one coalesced WARNING per window, never one
+line per frame). Each window also emits a TimestampMisalignmentWindow
+diagnostics event so the scan DB's session_meta summary records it. The
+firmware's terminal stop frame — the laser-off frame fired ~150 ms off
+the 25 ms grid at every scan stop — is recognised at on_scan_stop and
+reclassified as an expected artifact (INFO, excluded from the
+misalignment record).
 
 See docs/superpowers/specs/2026-06-05-eft-timestamp-repair-design.md.
 """
@@ -38,6 +55,10 @@ _INITIAL_NOMINAL_PERIOD_S = 0.025
 _DEFAULT_TOLERANCE_S = 0.008
 _TOLERANCE_EPS_S = 1e-9
 _EMA_ALPHA = 0.01
+# Consecutive flagged frames whose original timestamps agree with each
+# other before the stage accepts them as a genuine timeline shift (200 ms
+# at 40 Hz) rather than transient EMI corruption.
+_RESYNC_CONSISTENT_FRAMES = 8
 
 
 @dataclass
@@ -62,34 +83,43 @@ class TimestampRepairStage:
     """Pipeline stage that repairs EMI-corrupted capture timestamps.
 
     See the module docstring for the algorithm. One instance per scan;
-    cross-batch state (nominal-period estimate, per-camera last-good
-    anchors, the open misalignment window) persists across process() calls
-    and is cleared by reset()."""
+    cross-batch state (nominal-period estimate, per-camera genuine
+    anchors, divergent-run tracking, the open misalignment windows)
+    persists across process() calls and is cleared by reset()."""
 
     name = "timestamp_repair"
 
-    def __init__(self, *, tolerance_s: float = _DEFAULT_TOLERANCE_S,
-                 max_buffer_frames: int = 16):
+    def __init__(self, *, tolerance_s: float = _DEFAULT_TOLERANCE_S):
         """Configure the stage.
 
         Args:
             tolerance_s: max |actual Δt − expected Δt| (seconds) before a
                 frame's timestamp is treated as EMI-corrupted (condition 1).
-            max_buffer_frames: reserved bound on the look-ahead used when
-                re-anchoring a divergent run.
         """
         self._tolerance = float(tolerance_s)
-        self._max_buffer = int(max_buffer_frames)
         self._reset_state()
 
     def _reset_state(self) -> None:
         """Clear all per-scan state — nominal-period estimate, per-camera
-        last-good anchors, the open per-side windows and window list, and the
-        running re-timestamped / NaN-filled totals. Called from __init__ and
-        reset()."""
+        genuine anchors and divergent-run tracking, the open per-side windows
+        with their divergent-camera sets, and the running totals. Called from
+        __init__ and reset()."""
         self._nominal_period = _INITIAL_NOMINAL_PERIOD_S
+        # Last GENUINE good frame per (side, cam) — never a fabricated
+        # corrected timestamp. Both condition 1 and re-anchor validation
+        # measure against this, so a bad burst can't drag the reference
+        # off the true timeline.
         self._last_good: dict[tuple[int, int], tuple[int, float]] = {}
+        # Divergent-run tracking per (side, cam) for timeline re-sync:
+        # the last flagged frame's ORIGINAL (fid, ts) and the count of
+        # consecutive mutually-consistent flagged frames.
+        self._run_last: dict[tuple[int, int], tuple[int, float]] = {}
+        self._run_len: dict[tuple[int, int], int] = {}
         self._open_window: dict[int, Optional[_WindowStats]] = {0: None, 1: None}
+        # Cameras currently divergent per side — the open window closes
+        # only when this set empties (a healthy interleaved camera must
+        # not close a window another camera still holds open).
+        self._divergent: dict[int, set] = {0: set(), 1: set()}
         self._scan_windows: list[_WindowStats] = []
         self._total_frames_seen = 0
         self._nan_last_seen: dict[tuple[int, int], tuple[int, float]] = {}
@@ -122,10 +152,9 @@ class TimestampRepairStage:
         # Condition 2 (batch-wide): in-packet frame_id disagreement
         bad_cond2 = self._detect_frame_id_disagreement(batch)
 
-        # Pre-build good-frame lookahead for re-anchoring.
-        # A frame is "provisionally good" if it passes condition 2.
-        # Condition 1 is checked inline below (needs _last_good context).
-        good_ahead = self._build_good_lookahead(batch, bad_cond2)
+        # Per-camera row pool for re-anchoring. Condition 1 is validated
+        # per candidate at interpolation time (needs _last_good context).
+        cam_rows = self._collect_cam_rows(batch, bad_cond2)
 
         # Single pass: detect condition 1 inline, correct, track windows
         for i in range(n):
@@ -139,28 +168,38 @@ class TimestampRepairStage:
             ts = float(batch.timestamp_s[i])
             key = (side_idx, cam_id)
 
-            # Condition 1: timestamp deviation (checked inline with _last_good)
-            is_bad = i in bad_cond2
-            if not is_bad and key in self._last_good:
-                prev_fid, prev_ts = self._last_good[key]
-                fid_gap = abs_fid - prev_fid
-                if fid_gap > 0:
-                    expected_dt = fid_gap * self._nominal_period
-                    actual_dt = ts - prev_ts
-                    if abs(actual_dt - expected_dt) > self._tolerance + _TOLERANCE_EPS_S:
-                        is_bad = True
+            # Condition 1: timestamp deviation vs the genuine anchor
+            is_bad = i in bad_cond2 or self._deviates(key, abs_fid, ts)
+
+            if is_bad and self._note_divergent_run(key, abs_fid, ts):
+                # RESYNC: enough consecutive flagged frames agree with
+                # each other — a genuine timeline shift (e.g. recovery
+                # after a long dropout), not transient EMI. Adopt it.
+                logger.warning(
+                    "Timestamp timeline re-anchored: side=%d cam=%d — %d "
+                    "consecutive flagged frames were mutually "
+                    "cadence-consistent (genuine timeline shift, not "
+                    "transient EMI); accepting device timestamps from "
+                    "frame %d (t=%.3fs) onward",
+                    side_idx, cam_id, _RESYNC_CONSISTENT_FRAMES,
+                    abs_fid, ts,
+                )
+                is_bad = False
 
             if is_bad:
-                corrected_ts = self._interpolate(key, abs_fid, good_ahead.get(key))
+                corrected_ts = self._interpolate(key, abs_fid, cam_rows.get(key))
                 batch.timestamp_s[i] = corrected_ts
                 quality[i] = "ts_corrected"
                 self._total_corrected += 1
                 self._track_window_open(side_idx, key, abs_fid, ts)
-                self._last_good[key] = (abs_fid, corrected_ts)
+                # Deliberately NOT stored in _last_good: a fabricated
+                # timestamp must never become the reference anchor.
             else:
-                self._track_window_close(side_idx, batch.events)
+                self._run_last.pop(key, None)
+                self._run_len.pop(key, None)
                 self._update_nominal_period(key, abs_fid, ts)
                 self._last_good[key] = (abs_fid, ts)
+                self._note_good(side_idx, key, batch.events)
 
         batch.quality = quality
 
@@ -189,46 +228,95 @@ class TimestampRepairStage:
                 bad.update(indices)
         return bad
 
-    # ── Look-ahead for re-anchoring ─────────────────────────────────────
+    def _deviates(self, key: tuple[int, int], abs_fid: int, ts: float) -> bool:
+        """Condition 1: does (abs_fid, ts) deviate from the frame-id cadence
+        implied by this camera's genuine anchor? False when the camera has
+        no anchor yet (nothing to measure against)."""
+        anchor = self._last_good.get(key)
+        if anchor is None:
+            return False
+        prev_fid, prev_ts = anchor
+        fid_gap = abs_fid - prev_fid
+        if fid_gap <= 0:
+            return False
+        expected_dt = fid_gap * self._nominal_period
+        actual_dt = ts - prev_ts
+        return abs(actual_dt - expected_dt) > self._tolerance + _TOLERANCE_EPS_S
 
-    def _build_good_lookahead(self, batch: FrameBatch,
-                              bad_set: set[int]) -> dict[tuple[int, int], list]:
-        """Collect, per (side, cam), the (abs_fid, ts) of frames not flagged
-        by condition 2 and not warmup/stale — the candidate right-anchors
-        that ``_interpolate`` searches when re-anchoring a bad frame."""
-        ahead: dict[tuple[int, int], list] = defaultdict(list)
+    def _note_divergent_run(self, key: tuple[int, int],
+                            abs_fid: int, ts: float) -> bool:
+        """Track this camera's run of consecutive flagged frames using their
+        ORIGINAL (fid, ts). Returns True when the run reaches
+        ``_RESYNC_CONSISTENT_FRAMES`` mutually cadence-consistent frames —
+        the caller then accepts the frame as a genuine timeline shift. A
+        flagged frame inconsistent with its flagged predecessor (e.g. a
+        stuck timestamp counter, Δt=0) restarts the run at 1."""
+        prev = self._run_last.get(key)
+        if prev is not None:
+            prev_fid, prev_ts = prev
+            fid_gap = abs_fid - prev_fid
+            expected_dt = fid_gap * self._nominal_period
+            consistent = (fid_gap > 0 and
+                          abs((ts - prev_ts) - expected_dt)
+                          <= self._tolerance + _TOLERANCE_EPS_S)
+            if consistent:
+                self._run_len[key] = self._run_len.get(key, 1) + 1
+            else:
+                self._run_len[key] = 1
+        else:
+            self._run_len[key] = 1
+        self._run_last[key] = (abs_fid, ts)
+        if self._run_len[key] >= _RESYNC_CONSISTENT_FRAMES:
+            self._run_last.pop(key, None)
+            self._run_len.pop(key, None)
+            return True
+        return False
+
+    # ── Re-anchoring ────────────────────────────────────────────────────
+
+    def _collect_cam_rows(self, batch: FrameBatch,
+                          bad_cond2: set[int]) -> dict[tuple[int, int], list]:
+        """Collect, per (side, cam), every non-warmup/stale row's
+        (abs_fid, original ts, cond2-flagged) in batch order — the candidate
+        right-anchor pool that ``_interpolate`` searches (with condition-1
+        validation per candidate) when re-anchoring a bad frame."""
+        rows: dict[tuple[int, int], list] = defaultdict(list)
         for i in range(len(batch.cam_ids)):
-            if i in bad_set:
-                continue
             ft = str(batch.frame_type[i])
             if ft in ("warmup", "stale"):
                 continue
             key = (int(batch.side_ids[i]), int(batch.cam_ids[i]))
-            ahead[key].append((int(batch.abs_frame_ids[i]), float(batch.timestamp_s[i])))
-        return ahead
+            rows[key].append((int(batch.abs_frame_ids[i]),
+                              float(batch.timestamp_s[i]),
+                              i in bad_cond2))
+        return rows
 
     def _interpolate(self, key: tuple[int, int], abs_fid: int,
-                     good_frames: list | None) -> float:
+                     rows: list | None) -> float:
         """Re-anchor a bad frame's timestamp by interpolation.
 
-        Interpolates between the last good timestamp for this (side, cam)
-        and the next good one in ``good_frames`` (the within-batch
-        look-ahead), distributed by frame_id count. Falls back to the last
-        good anchor plus the nominal period when there's no right anchor,
-        and to abs_fid × nominal period when there's no anchor at all
-        (start of scan)."""
-        if key in self._last_good:
-            left_fid, left_ts = self._last_good[key]
-        else:
+        Interpolates between the camera's genuine left anchor and the next
+        VALID right anchor in the batch — a later frame that passes
+        condition 2 and is cadence-consistent with the left anchor
+        (condition 1), so a still-corrupted frame mid-burst can never pull
+        the correction off the true timeline. Falls back to the left anchor
+        plus nominal-period steps when no valid right anchor exists in the
+        batch, and to abs_fid × nominal period when there's no anchor at
+        all (start of scan)."""
+        anchor = self._last_good.get(key)
+        if anchor is None:
             return abs_fid * self._nominal_period
+        left_fid, left_ts = anchor
 
-        # Try to find a right anchor from the look-ahead
-        if good_frames:
-            for right_fid, right_ts in good_frames:
-                if right_fid > abs_fid:
-                    fid_span = right_fid - left_fid
-                    if fid_span > 0:
-                        return left_ts + (abs_fid - left_fid) / fid_span * (right_ts - left_ts)
+        if rows:
+            for right_fid, right_ts, c2bad in rows:
+                if right_fid <= abs_fid or c2bad:
+                    continue
+                if self._deviates(key, right_fid, right_ts):
+                    continue  # still-corrupted — not a valid re-anchor
+                fid_span = right_fid - left_fid
+                if fid_span > 0:
+                    return left_ts + (abs_fid - left_fid) / fid_span * (right_ts - left_ts)
 
         # Fallback: nominal period from left anchor
         return left_ts + (abs_fid - left_fid) * self._nominal_period
@@ -255,9 +343,10 @@ class TimestampRepairStage:
 
     def _track_window_open(self, side: int, key: tuple[int, int],
                            abs_fid: int, ts: float) -> None:
-        """Open this side's misalignment window (or extend it) and count the
-        re-timestamped frame, for coalesced per-window logging. ``ts`` is the
-        original pre-correction device timestamp."""
+        """Open this side's misalignment window (or extend it), mark the
+        camera divergent, and count the re-timestamped frame for coalesced
+        per-window logging. ``ts`` is the original pre-correction device
+        timestamp."""
         w = self._open_window[side]
         if w is None:
             w = _WindowStats(side=side, onset_fid=abs_fid, onset_t=ts)
@@ -266,17 +355,29 @@ class TimestampRepairStage:
         w.end_t = ts
         w.n_corrected += 1
         w.frames.append((key, abs_fid))
+        self._divergent[side].add(key)
 
-    def _track_window_close(self, side: int, events: list) -> None:
+    def _note_good(self, side: int, key: tuple[int, int], events: list) -> None:
+        """A good frame from ``key``: its divergence (if any) has ended. The
+        side's window closes only once NO camera on the side is still
+        divergent — a healthy camera interleaved with a diverging one must
+        not close (and re-open) the window on every row (spec R3)."""
+        divergent = self._divergent[side]
+        if key in divergent:
+            divergent.discard(key)
+        if self._open_window[side] is not None and not divergent:
+            self._close_window(side, events)
+
+    def _close_window(self, side: int, events: list) -> None:
         """Close this side's open misalignment window, if any: record it,
         emit one coalesced WARNING for the whole window (per spec R3 — never
         one line per frame), and append a TimestampMisalignmentWindow event
-        so the diagnostics channel / scan-DB summary record it. Called on the
-        first good same-side frame after a divergent run."""
+        so the diagnostics channel / scan-DB summary record it."""
         w = self._open_window[side]
         if w is None:
             return
         self._open_window[side] = None
+        self._divergent[side].clear()
         self._scan_windows.append(w)
         logger.warning(
             "Misalignment window: side=%d frames %d-%d (t=%.2f-%.2fs), "
@@ -353,7 +454,11 @@ class TimestampRepairStage:
 
     def _insert_nan_fills(self, batch: FrameBatch,
                           fills: list[tuple[int, dict]]) -> FrameBatch:
-        """Rebuild the batch with NaN-fill rows inserted at the right positions."""
+        """Rebuild the batch with NaN-fill rows inserted at the right positions.
+
+        Telemetry stamps (pdc/tcm/tcl) survive the rebuild when present:
+        original rows keep their values, fill rows get the no-sample
+        sentinels (NaN / 0, matching TelemetryIngestStage — spec §4.6)."""
         n_orig = len(batch.cam_ids)
         n_fills = len(fills)
         n_new = n_orig + n_fills
@@ -367,6 +472,12 @@ class TimestampRepairStage:
         new_q = np.empty(n_new, dtype="<U14")
         new_hist = np.zeros((n_new, 2, 8, 1024), dtype=np.uint32)
         new_temp = np.zeros((n_new, 2, 8), dtype=np.float32)
+        new_pdc = (None if batch.pdc is None
+                   else np.full(n_new, np.nan, dtype=batch.pdc.dtype))
+        new_tcm = (None if batch.tcm is None
+                   else np.zeros(n_new, dtype=batch.tcm.dtype))
+        new_tcl = (None if batch.tcl is None
+                   else np.zeros(n_new, dtype=batch.tcl.dtype))
 
         # Build insertion map: for each original index, which fills precede it
         fill_before: dict[int, list[dict]] = defaultdict(list)
@@ -393,12 +504,18 @@ class TimestampRepairStage:
             new_q[out] = str(batch.quality[i])
             new_hist[out] = batch.raw_histograms[i]
             new_temp[out] = batch.temperature_c[i]
+            if new_pdc is not None:
+                new_pdc[out] = batch.pdc[i]
+            if new_tcm is not None:
+                new_tcm[out] = batch.tcm[i]
+            if new_tcl is not None:
+                new_tcl[out] = batch.tcl[i]
             out += 1
 
         new_batch = FrameBatch(
             cam_ids=new_cam, frame_ids=new_fid, side_ids=new_sid,
             raw_histograms=new_hist, temperature_c=new_temp,
-            timestamp_s=new_ts, pdc=None, tcm=None, tcl=None,
+            timestamp_s=new_ts, pdc=new_pdc, tcm=new_tcm, tcl=new_tcl,
         )
         new_batch.abs_frame_ids = new_abs
         new_batch.frame_type = new_ft
@@ -424,6 +541,7 @@ class TimestampRepairStage:
                 continue
             if self._is_terminal_artifact(w):
                 self._open_window[side] = None
+                self._divergent[side].clear()
                 self._total_corrected -= w.n_corrected
                 self._terminal_frames += w.n_corrected
                 logger.info(
@@ -433,7 +551,7 @@ class TimestampRepairStage:
                     "as misalignment", side, w.n_corrected,
                 )
             else:
-                self._track_window_close(side, batch.events)
+                self._close_window(side, batch.events)
 
         if self._total_corrected or self._total_nan:
             pct = (self._total_corrected + self._total_nan) / max(1, self._total_frames_seen) * 100

--- a/tests/test_pipeline/test_classify_stage.py
+++ b/tests/test_pipeline/test_classify_stage.py
@@ -3,6 +3,7 @@
 import logging
 
 import numpy as np
+import pytest
 from omotion.pipeline.batch import FrameBatch
 from omotion.pipeline.stages.classify import FrameClassificationStage
 
@@ -177,3 +178,109 @@ def test_reset_clears_unwrapper_state():
     stage.process(batch2)
     assert batch2.abs_frame_ids[0] == 1
     assert batch2.frame_type[0] == "warmup"
+
+
+def _packet(raw_ids, timestamp_s, *, side=0, cam_ids=None):
+    """One coalesced packet: camera index follows row position."""
+    n = len(raw_ids)
+    if cam_ids is None:
+        cam_ids = range(n)
+    return FrameBatch(
+        cam_ids=np.array(cam_ids, dtype=np.int8),
+        frame_ids=np.array(raw_ids, dtype=np.uint8),
+        side_ids=np.full(n, side, dtype=np.int8),
+        raw_histograms=np.zeros((n, 2, 8, 1024), dtype=np.uint32),
+        temperature_c=np.zeros((n, 2, 8), dtype=np.float32),
+        timestamp_s=np.full(n, timestamp_s, dtype=np.float64),
+        pdc=None, tcm=None, tcl=None,
+    )
+
+
+def test_single_frame_id_outlier_uses_packet_consensus_without_changing_raw_id():
+    """A lone corrupt wire ID must not poison the outlier camera's unwrapper.
+
+    Removing the consensus pass would make camera 1 stale at the second
+    packet and leave its absolute ID at 130 instead of capture 2.
+    """
+    stage = FrameClassificationStage()
+    stage.process(_packet([1, 1, 1], 0.000))
+    batch = _packet([2, 130, 2], 0.025)
+
+    result = stage.process(batch)
+
+    np.testing.assert_array_equal(result.frame_ids, [2, 130, 2])
+    np.testing.assert_array_equal(result.abs_frame_ids, [2, 2, 2])
+    np.testing.assert_array_equal(result.frame_type, ["warmup"] * 3)
+    corrections = [e for e in result.events
+                   if type(e).__name__ == "FrameIdConsensusCorrection"]
+    assert len(corrections) == 1
+    event = corrections[0]
+    assert event.side == 0
+    assert event.timestamp_s == 0.025
+    assert event.cam_id == 1
+    assert event.observed_raw_frame_id == 130
+    assert event.consensus_raw_frame_id == 2
+    assert event.previous_raw_frame_id == 1
+    assert event.previous_abs_frame_id == 1
+    assert event.corrected_abs_frame_id == 2
+    assert event.packet == ((0, 2), (1, 130), (2, 2))
+
+
+def test_ambiguous_two_camera_packet_is_logged_but_not_guessed():
+    """With no strict packet consensus, keep ordinary stale handling and
+    record the pre-mutation packet evidence instead of inventing an ID."""
+    stage = FrameClassificationStage()
+    stage.process(_packet([1, 1], 0.000))
+    batch = _packet([2, 130], 0.025)
+
+    result = stage.process(batch)
+
+    np.testing.assert_array_equal(result.abs_frame_ids, [2, 130])
+    np.testing.assert_array_equal(result.frame_type, ["warmup", "stale"])
+    anomalies = [e for e in result.events
+                 if type(e).__name__ == "FrameIdPacketAnomaly"]
+    assert len(anomalies) == 1
+    assert anomalies[0].reason == "fewer_than_three_cameras"
+    assert anomalies[0].packet == ((0, 2), (1, 130))
+    assert anomalies[0].action == "left_unchanged"
+
+
+def test_first_seen_outlier_is_logged_but_not_consensus_corrected():
+    """Consensus cannot safely seed a camera whose prior counter is unknown."""
+    stage = FrameClassificationStage()
+    batch = _packet([1, 1, 130], 0.000)
+
+    result = stage.process(batch)
+
+    assert result.abs_frame_ids[2] == 130
+    assert result.frame_type[2] == "stale"
+    anomalies = [e for e in result.events
+                 if type(e).__name__ == "FrameIdPacketAnomaly"]
+    assert len(anomalies) == 1
+    assert anomalies[0].reason == "outlier_has_no_prior_state"
+
+
+@pytest.mark.parametrize(
+    ("raw_ids", "cam_ids", "reason"),
+    [
+        ([2, 2, 130, 130], None, "no_single_outlier_consensus"),
+        ([200, 200, 2], None, "consensus_is_not_forward_continuation"),
+        ([2, 130, 2], [0, 1, 1], "duplicate_camera_ids"),
+    ],
+)
+def test_unsafe_packet_shapes_are_logged_without_consensus_correction(
+        raw_ids, cam_ids, reason):
+    stage = FrameClassificationStage()
+    stage.process(_packet([1] * len(raw_ids), 0.000))
+    batch = _packet(raw_ids, 0.025, cam_ids=cam_ids)
+
+    stage.process(batch)
+
+    assert not any(type(e).__name__ == "FrameIdConsensusCorrection"
+                   for e in batch.events)
+    anomalies = [e for e in batch.events
+                 if type(e).__name__ == "FrameIdPacketAnomaly"]
+    assert len(anomalies) == 1
+    assert anomalies[0].reason == reason
+    if reason == "no_single_outlier_consensus":
+        assert anomalies[0].consensus_raw_frame_id is None

--- a/tests/test_pipeline/test_diagnostics_sink.py
+++ b/tests/test_pipeline/test_diagnostics_sink.py
@@ -1,10 +1,8 @@
 """Diagnostics consumers — DiagnosticsLogSink + ScanDBSink session_meta summary.
 
-Integrity events (DarkIntegrityWarning, TerminalDarkResult(found=False),
-StencilFallback, PipelineError) must not evaporate: the log sink WARNs on
-each, and ScanDBSink folds a per-type summary into the session's
-session_meta at scan end. Routine events (TriggerStateEvent, successful
-TerminalDarkResult) are excluded from the integrity record.
+Ordinary integrity events are logged and summarized in session_meta. Detailed
+inbound-data anomalies are explicitly formatted and bounded in logs, but never
+stored in SQLite. Routine operational events are ignored by both records.
 """
 
 import json
@@ -14,8 +12,12 @@ from types import SimpleNamespace
 
 from omotion.pipeline.batch import (
     DarkIntegrityWarning,
+    FrameGapFillAnomaly,
+    FrameIdConsensusCorrection,
+    FrameIdPacketAnomaly,
     PipelineError,
     TerminalDarkResult,
+    TimestampRepairInputAnomaly,
     TriggerStateEvent,
 )
 from omotion.pipeline.sinks import DiagnosticsLogSink, ScanDBSink, ScanMetadata
@@ -75,6 +77,81 @@ def test_log_sink_ignores_routine_events(caplog):
     assert caplog.text == ""
 
 
+def _inbound_events():
+    return [
+        FrameIdConsensusCorrection(
+            side=1, timestamp_s=1.25, cam_id=3,
+            observed_raw_frame_id=5, consensus_raw_frame_id=197,
+            previous_raw_frame_id=196, previous_abs_frame_id=196,
+            corrected_abs_frame_id=197,
+            packet=((0, 197), (1, 197), (2, 197), (3, 5)),
+        ),
+        FrameIdPacketAnomaly(
+            side=0, timestamp_s=2.5, reason="no_single_outlier_consensus",
+            packet=((0, 10), (1, 11), (2, 10), (3, 11)),
+        ),
+        TimestampRepairInputAnomaly(
+            side=1, cam_id=3, raw_frame_id=5, abs_frame_id=197,
+            original_timestamp_s=4.925,
+            previous_raw_frame_id=196, previous_abs_frame_id=196,
+            previous_timestamp_s=4.900, nominal_period_s=0.025,
+            frame_id_gap=1, expected_timestamp_s=4.925,
+            signed_residual_s=0.0, tolerance_s=0.008,
+            packet=((0, 197, 197), (1, 197, 197), (2, 197, 197),
+                    (3, 5, 197)),
+            detector="absolute_frame_id_disagreement",
+            action="timestamp_corrected",
+        ),
+        FrameGapFillAnomaly(
+            side=1, cam_id=3,
+            previous_raw_frame_id=196, previous_abs_frame_id=196,
+            previous_timestamp_s=4.900,
+            current_raw_frame_id=199, current_abs_frame_id=199,
+            current_timestamp_s=4.975, missing_count=2,
+            first_missing_abs_frame_id=197,
+            last_missing_abs_frame_id=198,
+        ),
+    ]
+
+
+def test_log_sink_spells_out_all_inbound_anomaly_evidence(caplog):
+    sink = DiagnosticsLogSink()
+    sink.on_scan_start(_meta())
+    with caplog.at_level(logging.WARNING, logger="openmotion.sdk.pipeline.sinks"):
+        for event in _inbound_events():
+            sink.consume("diagnostics", event)
+
+    assert caplog.text.count("INBOUND DATA ANOMALY") == 4
+    for name in (
+        "FrameIdConsensusCorrection", "FrameIdPacketAnomaly",
+        "TimestampRepairInputAnomaly", "FrameGapFillAnomaly",
+    ):
+        assert name in caplog.text
+    for evidence in (
+        "observed_raw_frame_id=5", "consensus_raw_frame_id=197",
+        "previous_abs_frame_id=196", "corrected_abs_frame_id=197",
+        "reason=no_single_outlier_consensus", "original_timestamp_s=4.925",
+        "expected_timestamp_s=4.925", "signed_residual_s=0.0",
+        "missing_count=2", "first_missing_abs_frame_id=197",
+        "action=inserted_nan_fill_rows",
+    ):
+        assert evidence in caplog.text
+
+
+def test_log_sink_caps_inbound_detail_but_counts_every_event(caplog):
+    sink = DiagnosticsLogSink()
+    sink.on_scan_start(_meta())
+    event = _inbound_events()[0]
+    with caplog.at_level(logging.WARNING, logger="openmotion.sdk.pipeline.sinks"):
+        for _ in range(10):
+            sink.consume("diagnostics", event)
+        sink.on_complete()
+
+    assert caplog.text.count("action=used_consensus_for_unwrap") == 8
+    assert caplog.text.count("further detail suppressed after 8 events") == 1
+    assert "FrameIdConsensusCorrection\u00d710" in caplog.text
+
+
 def test_scan_db_sink_writes_diagnostics_summary_to_session_meta(tmp_path):
     db_path = str(tmp_path / "scan.db")
     sink = ScanDBSink(db_path=db_path)
@@ -107,6 +184,22 @@ def test_scan_db_sink_meta_has_no_diagnostics_key_when_clean(tmp_path):
     sink = ScanDBSink(db_path=db_path)
     sink.on_scan_start(_meta())
     sink.consume("final", _final_interval())
+    sink.on_complete()
+
+    conn = sqlite3.connect(db_path)
+    meta = json.loads(conn.execute(
+        "SELECT session_meta FROM sessions").fetchone()[0])
+    conn.close()
+    assert "diagnostics" not in meta
+
+
+def test_scan_db_sink_does_not_retain_inbound_anomaly_events(tmp_path):
+    db_path = str(tmp_path / "scan.db")
+    sink = ScanDBSink(db_path=db_path)
+    sink.on_scan_start(_meta())
+    sink.consume("final", _final_interval())
+    for event in _inbound_events():
+        sink.consume("diagnostics", event)
     sink.on_complete()
 
     conn = sqlite3.connect(db_path)

--- a/tests/test_pipeline/test_frame_id_consensus_repro.py
+++ b/tests/test_pipeline/test_frame_id_consensus_repro.py
@@ -1,0 +1,88 @@
+"""Regression for issue #220's one-camera frame-ID corruption cascade."""
+
+import numpy as np
+
+from omotion.pipeline.batch import FrameBatch, LiveEmit
+from omotion.pipeline.stages.classify import FrameClassificationStage
+from omotion.pipeline.stages.side_avg import SideAverageStage
+from omotion.pipeline.stages.timestamp_repair import TimestampRepairStage
+
+
+def _batch(rows):
+    n = len(rows)
+    return FrameBatch(
+        cam_ids=np.array([row[0] for row in rows], dtype=np.int8),
+        frame_ids=np.array([row[1] for row in rows], dtype=np.uint8),
+        side_ids=np.ones(n, dtype=np.int8),
+        raw_histograms=np.zeros((n, 2, 8, 1024), dtype=np.uint32),
+        temperature_c=np.zeros((n, 2, 8), dtype=np.float32),
+        timestamp_s=np.array([row[2] for row in rows], dtype=np.float64),
+        pdc=None, tcm=None, tcl=None,
+    )
+
+
+def _stamp_bfi(batch):
+    levels = (1.0, 2.0, 3.0, 6.0)
+    values = np.full((len(batch.cam_ids), 2, 8), np.nan, dtype=np.float32)
+    for i, cam_id in enumerate(batch.cam_ids):
+        if batch.frame_type[i] not in ("warmup", "stale"):
+            values[i, 1, int(cam_id)] = levels[int(cam_id)]
+    batch.bfi_live = values
+    batch.bvi_live = values.copy()
+
+
+def test_issue_220_single_bad_wire_id_does_not_destroy_the_scan():
+    classify = FrameClassificationStage()
+    repair = TimestampRepairStage()
+    side_average = SideAverageStage(
+        enabled=True, left_camera_mask=0, right_camera_mask=0x0F,
+    )
+    corrections = []
+    output_rows = []
+    samples = []
+
+    wire_rows = []
+    for capture in range(1, 221):
+        for cam_id in range(4):
+            raw_id = capture & 0xFF
+            if capture == 198 and cam_id == 3:
+                raw_id &= 0x3F  # 0xC6 -> 0x06, the production signature
+            wire_rows.append((cam_id, raw_id, capture * 0.025))
+
+    for start in range(0, len(wire_rows), 40):
+        batch = classify.process(_batch(wire_rows[start:start + 40]))
+        batch = repair.process(batch)
+        _stamp_bfi(batch)
+        side_average.process(batch)
+
+        corrections.extend(e for e in batch.events
+                           if type(e).__name__ == "FrameIdConsensusCorrection")
+        samples.extend(e.payload for e in batch.events
+                       if isinstance(e, LiveEmit) and e.channel == "live_side")
+        output_rows.extend(zip(
+            batch.cam_ids.tolist(), batch.frame_ids.tolist(),
+            batch.abs_frame_ids.tolist(), batch.frame_type.tolist(),
+            batch.quality.tolist(), batch.timestamp_s.tolist(),
+        ))
+
+    flush = _batch([])
+    side_average.on_scan_stop(flush)
+    samples.extend(e.payload for e in flush.events
+                   if isinstance(e, LiveEmit) and e.channel == "live_side")
+
+    assert len(corrections) == 1
+    assert corrections[0].observed_raw_frame_id == 6
+    assert corrections[0].consensus_raw_frame_id == 198
+    corrupt_row = next(
+        row for row in output_rows
+        if row[0] == 3 and row[1] == 6 and np.isclose(row[5], 198 * 0.025)
+    )
+    assert corrupt_row[2:5] == (198, "light", "ok")
+    assert not any(row[3] == "stale" for row in output_rows)
+    assert not any(row[4] in ("ts_corrected", "nan_filled")
+                   for row in output_rows)
+
+    assert len(samples) == 220
+    assert np.all(np.diff([sample.t for sample in samples]) > 0)
+    finite_bfi = [sample.bfi for sample in samples if np.isfinite(sample.bfi)]
+    assert finite_bfi and np.allclose(finite_bfi, 3.0)

--- a/tests/test_pipeline/test_sources.py
+++ b/tests/test_pipeline/test_sources.py
@@ -204,6 +204,72 @@ def test_live_usb_source_reader_loop_builds_batches_from_packet_queue(monkeypatc
         assert b.raw_histograms.shape[-1] == 1024
 
 
+def test_live_usb_source_never_splits_a_coalesced_histogram_packet(monkeypatch):
+    """Crossing the batch-size threshold mid-packet must wait for the next
+    timestamp boundary. Otherwise classification cannot compare all sibling
+    histograms before unwrapping their frame IDs."""
+    import numpy as np
+
+    def _fake_parse(q, stop_evt, buf, *, on_row_fn=None,
+                    expected_row_sum=None, t0_normalizer=None):
+        rows = [
+            *((cam, 10, 0.025) for cam in range(6)),
+            *((cam, 11, 0.050) for cam in range(2)),
+        ]
+        for cam, frame_id, timestamp_s in rows:
+            on_row_fn(
+                cam, frame_id, timestamp_s,
+                np.ones(1024, dtype=np.uint32), 1024, 27.0,
+            )
+        return len(rows)
+
+    monkeypatch.setattr(
+        "omotion.MotionProcessing.parse_histogram_stream", _fake_parse,
+    )
+    src = LiveUsbSource(
+        console=None, left=object(), right=None,
+        batch_size_frames=4, metadata=_meta(),
+    )
+
+    src._reader_loop("left")
+    batches = [src._batch_queue.get_nowait(), src._batch_queue.get_nowait()]
+
+    assert [len(batch.cam_ids) for batch in batches] == [6, 2]
+    assert [set(batch.timestamp_s) for batch in batches] == [{0.025}, {0.050}]
+
+
+def test_live_usb_source_separates_packets_when_timestamp_is_stuck(monkeypatch):
+    """A repeated camera identifies the next packet even if its timestamp
+    counter is frozen. Without this boundary, batching would merge captures
+    and manufacture duplicate-camera packet anomalies downstream."""
+    import numpy as np
+
+    def _fake_parse(q, stop_evt, buf, *, on_row_fn=None,
+                    expected_row_sum=None, t0_normalizer=None):
+        for frame_id in (10, 11):
+            for cam in range(4):
+                on_row_fn(
+                    cam, frame_id, 0.025,
+                    np.ones(1024, dtype=np.uint32), 1024, 27.0,
+                )
+        return 8
+
+    monkeypatch.setattr(
+        "omotion.MotionProcessing.parse_histogram_stream", _fake_parse,
+    )
+    src = LiveUsbSource(
+        console=None, left=object(), right=None,
+        batch_size_frames=100, metadata=_meta(),
+    )
+
+    src._reader_loop("left")
+    batches = [src._batch_queue.get_nowait(), src._batch_queue.get_nowait()]
+
+    assert [batch.frame_ids.tolist() for batch in batches] == [
+        [10] * 4, [11] * 4,
+    ]
+
+
 def _consume_bounded(src, *, want_batches: int, timeout_s: float):
     """Consume FrameBatches from `src` on a worker thread, bounded by
     timeout_s. Returns (batches_seen, error).

--- a/tests/test_pipeline/test_timestamp_repair_stage.py
+++ b/tests/test_pipeline/test_timestamp_repair_stage.py
@@ -118,6 +118,61 @@ def test_condition2_frame_id_disagreement_is_per_side():
     np.testing.assert_array_equal(result.quality, ["ok", "ok", "ok", "ok"])
 
 
+def test_condition2_uses_effective_absolute_ids_not_preserved_wire_ids():
+    """A classifier-consensus correction deliberately leaves the bad wire ID
+    intact. Timestamp repair must trust the aligned absolute IDs or it will
+    re-corrupt the packet that classification just recovered."""
+    stage = TimestampRepairStage()
+    batch = _make_batch(
+        cam_ids=[0, 1, 2, 0, 1, 2],
+        frame_ids=[1, 1, 1, 2, 130, 2],
+        side_ids=[0] * 6,
+        timestamps=[0.025] * 3 + [0.050] * 3,
+        abs_frame_ids=[1, 1, 1, 2, 2, 2],
+        frame_types=["light"] * 6,
+    )
+
+    result = stage.process(batch)
+
+    np.testing.assert_array_equal(result.quality, ["ok"] * 6)
+    np.testing.assert_allclose(result.timestamp_s, [0.025] * 3 + [0.050] * 3)
+
+
+def test_timestamp_deviation_emits_pre_mutation_evidence():
+    """Removing the anomaly event would again leave a production log unable
+    to distinguish a truthful timestamp from a bad ID or stale anchor."""
+    stage = TimestampRepairStage()
+    batch = _make_batch(
+        cam_ids=[0, 0, 0, 0],
+        frame_ids=[11, 12, 13, 14],
+        side_ids=[0] * 4,
+        timestamps=[0.025, 0.050, 0.130, 0.100],
+        abs_frame_ids=[11, 12, 13, 14],
+        frame_types=["light"] * 4,
+    )
+
+    stage.process(batch)
+
+    events = [e for e in batch.events
+              if type(e).__name__ == "TimestampRepairInputAnomaly"]
+    assert len(events) == 1
+    event = events[0]
+    assert event.detector == "timestamp_deviation"
+    assert event.side == 0 and event.cam_id == 0
+    assert event.raw_frame_id == 13 and event.abs_frame_id == 13
+    assert event.original_timestamp_s == pytest.approx(0.130)
+    assert event.previous_raw_frame_id == 12
+    assert event.previous_abs_frame_id == 12
+    assert event.previous_timestamp_s == pytest.approx(0.050)
+    assert event.nominal_period_s == pytest.approx(0.025)
+    assert event.frame_id_gap == 1
+    assert event.expected_timestamp_s == pytest.approx(0.075)
+    assert event.signed_residual_s == pytest.approx(0.055)
+    assert event.tolerance_s == pytest.approx(0.008)
+    assert event.packet == ((0, 13, 13),)
+    assert event.action == "timestamp_corrected"
+
+
 def test_nan_fill_for_missing_frames():
     """Missing abs_frame_ids get synthetic NaN-fill rows inserted."""
     stage = TimestampRepairStage()
@@ -148,6 +203,22 @@ def test_nan_fill_for_missing_frames():
     assert result.timestamp_s[2] > result.timestamp_s[1]
     assert result.timestamp_s[2] < 0.100
 
+    events = [e for e in result.events
+              if type(e).__name__ == "FrameGapFillAnomaly"]
+    assert len(events) == 1
+    event = events[0]
+    assert event.side == 0 and event.cam_id == 0
+    assert event.previous_raw_frame_id == 11
+    assert event.previous_abs_frame_id == 11
+    assert event.previous_timestamp_s == pytest.approx(0.025)
+    assert event.current_raw_frame_id == 14
+    assert event.current_abs_frame_id == 14
+    assert event.current_timestamp_s == pytest.approx(0.100)
+    assert event.missing_count == 2
+    assert (event.first_missing_abs_frame_id,
+            event.last_missing_abs_frame_id) == (12, 13)
+    assert event.action == "inserted_nan_fill_rows"
+
 
 def test_nan_fill_for_missing_frames_across_process_calls():
     """Missing abs_frame_ids are detected across source batch boundaries."""
@@ -177,6 +248,24 @@ def test_nan_fill_for_missing_frames_across_process_calls():
     np.testing.assert_array_equal(result.quality, ["nan_filled", "ok"])
     assert result.timestamp_s[0] == pytest.approx(0.050)
     assert result.timestamp_s[1] == pytest.approx(0.075)
+
+
+def test_gap_anomaly_keeps_original_timestamp_when_current_frame_is_repaired():
+    """Gap diagnostics describe inbound data, not the timestamp that repair
+    just fabricated for interpolation."""
+    stage = TimestampRepairStage()
+    batch = _make_batch(
+        cam_ids=[0, 0], frame_ids=[11, 14], side_ids=[0, 0],
+        timestamps=[0.025, 0.200], abs_frame_ids=[11, 14],
+        frame_types=["light", "light"],
+    )
+
+    result = stage.process(batch)
+
+    gap = next(e for e in result.events
+               if type(e).__name__ == "FrameGapFillAnomaly")
+    assert gap.current_timestamp_s == pytest.approx(0.200)
+    assert result.timestamp_s[-1] == pytest.approx(0.100)
 
 
 def test_default_tolerance_catches_ten_ms_timestamp_error():
@@ -363,6 +452,8 @@ def test_terminal_stop_frame_not_warned(caplog):
              and "Terminal stop frame" in r.message]
     assert len(infos) == 1
     assert not any(isinstance(e, TimestampMisalignmentWindow)
+                   for e in list(batch.events) + list(flush.events))
+    assert not any(type(e).__name__ == "TimestampRepairInputAnomaly"
                    for e in list(batch.events) + list(flush.events))
 
 

--- a/tests/test_pipeline/test_timestamp_repair_stage.py
+++ b/tests/test_pipeline/test_timestamp_repair_stage.py
@@ -215,16 +215,16 @@ def test_default_tolerance_allows_two_ms_device_jitter():
     np.testing.assert_allclose(result.timestamp_s, [0.250, 0.277, 0.300])
 
 
-def test_buffer_force_flush_at_max():
-    """When buffer fills without a re-anchor, force-flush using nominal period."""
-    stage = TimestampRepairStage(max_buffer_frames=4)
-    # 1 good frame, then 5 bad frames (buffer size 4, so force-flush at frame 4)
-    ts = [0.025]
-    fids = [11]
-    # Bad frames: all have timestamp 0.050 (way off from expected 50ms, 75ms, 100ms, 125ms, 150ms)
-    for i in range(5):
-        ts.append(0.050)
-        fids.append(12 + i)
+def test_stuck_timestamp_run_corrected_via_nominal_fallback():
+    """A run of frames sharing one stuck timestamp (condition 2) has no
+    valid right anchor in the batch — each is corrected by nominal-period
+    steps from the genuine left anchor."""
+    stage = TimestampRepairStage()
+    # 1 good frame, then 5 frames all stuck at t=0.050 (a frozen timestamp
+    # counter): same-side rows sharing a timestamp with differing frame_ids
+    # are all condition-2-flagged, and none can serve as a re-anchor.
+    ts = [0.025] + [0.050] * 5
+    fids = [11, 12, 13, 14, 15, 16]
     batch = _make_batch(
         cam_ids=[0] * 6,
         frame_ids=fids,
@@ -234,9 +234,12 @@ def test_buffer_force_flush_at_max():
         frame_types=["light"] * 6,
     )
     result = stage.process(batch)
-    # The first 4 bad frames should be force-flushed as ts_corrected
-    corrected_count = sum(1 for q in result.quality if q == "ts_corrected")
-    assert corrected_count >= 4
+    np.testing.assert_array_equal(
+        result.quality, ["ok"] + ["ts_corrected"] * 5)
+    # Nominal-period steps from the genuine anchor (11, 0.025)
+    np.testing.assert_allclose(
+        result.timestamp_s, [0.025, 0.050, 0.075, 0.100, 0.125, 0.150],
+        atol=1e-9)
 
 
 def test_logging_one_warning_per_window(caplog):
@@ -425,6 +428,117 @@ def test_real_window_emits_diagnostics_event():
     assert events[0].side == 0
     assert events[0].n_corrected == 1
     assert events[0].onset_fid == 13
+
+
+def test_burst_right_anchor_must_be_condition1_clean():
+    """During a multi-frame burst, the frame after a bad frame is itself
+    still corrupted — it must NOT serve as the re-anchor (spec §4.5: both
+    anchors are real device timestamps of good frames). Corrections land on
+    the true frame grid, the first genuine frame after the burst stays
+    untouched, and the repaired timeline is monotonic."""
+    stage = TimestampRepairStage()
+    # fid 100 good; 101-102 corrupted (+4.5 s EMI offset); 103-104 good.
+    batch = _make_batch(
+        cam_ids=[0] * 5,
+        frame_ids=[100, 101, 102, 103, 104],
+        side_ids=[0] * 5,
+        timestamps=[2.500, 7.000, 7.025, 2.575, 2.600],
+        abs_frame_ids=[100, 101, 102, 103, 104],
+        frame_types=["light"] * 5,
+    )
+    result = stage.process(batch)
+    np.testing.assert_array_equal(
+        result.quality, ["ok", "ts_corrected", "ts_corrected", "ok", "ok"])
+    # Interpolated between the GENUINE anchors (100, 2.500) and (103, 2.575)
+    np.testing.assert_allclose(
+        result.timestamp_s, [2.500, 2.525, 2.550, 2.575, 2.600], atol=1e-9)
+    assert np.all(np.diff(result.timestamp_s) > 0)
+
+
+def test_single_camera_divergence_one_window_despite_interleaving(caplog):
+    """A healthy camera interleaved with a diverging one must not close
+    (and re-open) the side's window per row: one divergent episode on one
+    camera = one coalesced WARNING + one diagnostics event (spec R3)."""
+    stage = TimestampRepairStage()
+    # Captures fid 11..15 on two cameras. cam0's timestamps are +0.5 s for
+    # fids 12-14 (corrupt); cam1 stays clean throughout.
+    rows = []  # (cam, fid, ts)
+    for fid in range(11, 16):
+        t = 0.025 * (fid - 10)
+        t_cam0 = t + 0.5 if fid in (12, 13, 14) else t
+        rows.append((0, fid, t_cam0))
+        rows.append((1, fid, t))
+    batch = _make_batch(
+        cam_ids=[r[0] for r in rows],
+        frame_ids=[r[1] for r in rows],
+        side_ids=[0] * len(rows),
+        timestamps=[r[2] for r in rows],
+        abs_frame_ids=[r[1] for r in rows],
+        frame_types=["light"] * len(rows),
+    )
+    with caplog.at_level(logging.WARNING,
+                         logger="openmotion.sdk.pipeline.stages.timestamp_repair"):
+        stage.process(batch)
+    warnings = [r for r in caplog.records if "Misalignment window" in r.message]
+    assert len(warnings) == 1, [w.message for w in warnings]
+    events = [e for e in batch.events if isinstance(e, TimestampMisalignmentWindow)]
+    assert len(events) == 1
+    assert events[0].n_corrected == 3
+
+
+def test_persistent_timeline_shift_resyncs(caplog):
+    """A permanent timestamp shift (e.g. recovery after a long dropout) is
+    adopted as the new timeline after enough mutually-consistent flagged
+    frames, instead of being 'corrected' against the stale anchor for the
+    rest of the scan."""
+    stage = TimestampRepairStage()
+    # fid 10 on the original timeline, then fids 11..25 all +3.0 s but
+    # internally on a clean 25 ms cadence.
+    fids = list(range(10, 26))
+    ts = [0.250] + [0.250 + 0.025 * (f - 10) + 3.0 for f in fids[1:]]
+    batch = _make_batch(
+        cam_ids=[0] * len(fids),
+        frame_ids=[f & 0xFF for f in fids],
+        side_ids=[0] * len(fids),
+        timestamps=ts,
+        abs_frame_ids=fids,
+        frame_types=["light"] * len(fids),
+    )
+    with caplog.at_level(logging.WARNING,
+                         logger="openmotion.sdk.pipeline.stages.timestamp_repair"):
+        result = stage.process(batch)
+    # Frames 11..17 (_RESYNC_CONSISTENT_FRAMES - 1 of them) were corrected
+    # against the stale anchor; the 8th consistent frame (fid 18) triggers
+    # re-sync and the shifted device timestamps are accepted untouched.
+    assert result.quality[0] == "ok"
+    assert all(q == "ts_corrected" for q in result.quality[1:8])
+    assert all(q == "ok" for q in result.quality[8:])
+    np.testing.assert_allclose(result.timestamp_s[8:], ts[8:], atol=1e-9)
+    assert any("re-anchored" in r.message for r in caplog.records)
+
+
+def test_nan_fill_preserves_telemetry_stamps():
+    """Rebuilding the batch for NaN-fills keeps the TelemetryIngestStage
+    stamps (spec §4.6): original rows keep their values, fill rows get the
+    no-sample sentinels (NaN pdc, 0 tcm/tcl)."""
+    stage = TimestampRepairStage()
+    batch = _make_batch(
+        cam_ids=[0, 0],
+        frame_ids=[11, 14],
+        side_ids=[0, 0],
+        timestamps=[0.025, 0.100],
+        abs_frame_ids=[11, 14],
+        frame_types=["light", "light"],
+    )
+    batch.pdc = np.array([1.5, 2.5], dtype=np.float32)
+    batch.tcm = np.array([40, 41], dtype=np.int64)
+    batch.tcl = np.array([30, 31], dtype=np.int64)
+    result = stage.process(batch)
+    assert len(result.cam_ids) == 4
+    np.testing.assert_allclose(result.pdc[[0, 3]], [1.5, 2.5])
+    assert np.isnan(result.pdc[1]) and np.isnan(result.pdc[2])
+    np.testing.assert_array_equal(result.tcm, [40, 0, 0, 41])
+    np.testing.assert_array_equal(result.tcl, [30, 0, 0, 31])
 
 
 def test_warmup_and_stale_frames_pass_through_untouched():


### PR DESCRIPTION
Refs #229
Refs #220

## What changed

- Validates timestamp-repair re-anchors against the last genuine device timestamp, never promotes a fabricated timestamp to an anchor, coalesces per-side repair windows, and preserves telemetry through NaN gap filling.
- Keeps every coalesced histogram packet atomic through frame classification, including packets whose device timestamp is frozen.
- Accepts exactly one raw frame-ID outlier when all sibling histograms in the packet agree on the expected absolute frame. The raw ID is preserved for diagnostics; downstream stages receive the consensus absolute frame at the packet timestamp.
- Leaves ambiguous packets untouched instead of guessing.
- Adds bounded, explicit `INBOUND DATA ANOMALY` logs before data is normalized: raw/absolute IDs, packet membership, timestamps, camera/side, consensus evidence, prior state, repair inputs, and gap-fill context. These diagnostics stay in logs and are intentionally not persisted to SQLite.
- Simplifies the timestamp-repair control flow and removes the dead `max_buffer_frames` constructor parameter.

## Root cause and impact

A single corrupted camera frame ID in an otherwise valid sensor packet could unwrap into a large forward jump. Timestamp repair then treated the jump as genuine, fabricated a large run of gaps, and could poison later anchors. The result was a scan-wide failure from one malformed histogram, while the existing logs omitted the packet evidence needed to prove what arrived.

The new consensus rule is deliberately narrow: it repairs only one disagreeing histogram when every sibling provides an unambiguous expected frame. Multiple outliers, split consensus, unexpected cadence, or insufficient packet evidence are not repaired; they are emitted as explicit anomalies for investigation.

## Behavior notes

- Clean scans retain the normal fast path and do not emit anomaly logs.
- Single-frame timestamp glitches still repair onto the genuine frame grid.
- Persistent timeline shifts resynchronize after eight mutually cadence-consistent frames.
- Terminal stop artifacts retain their existing classification without false anomaly noise.
- Diagnostic anomaly events are rate-limited per type (first eight plus a suppression notice), with totals retained in the scan summary.

## Verification

- `python -m pytest tests/test_pipeline/` — 271 passed, 30 skipped.
- Focused consensus and diagnostics suite — 8 passed.
- Exact #220 regression covers `0xC6 -> 0x06` corruption and verifies no stale rows, fabricated gaps, NaNs, or timestamp zigzag.
- `python -m compileall -q omotion/pipeline`
- `git diff --check`
