### PR TITLE
Remove fixed sleeps from send_packet async round-trip path

### DIFF
--- a/omotion/CommInterface.py
+++ b/omotion/CommInterface.py
@@ -161,7 +161,6 @@ class CommInterface(USBInterfaceBase):
             )
 
             self.write(tx_bytes)
-            time.sleep(0.0005)
 
             if not self.async_mode:
                 start = time.monotonic()
@@ -184,26 +183,36 @@ class CommInterface(USBInterfaceBase):
                             continue
                 last_error = TimeoutError("No response")
             else:
+                # Block on the queue instead of sleep-polling: get(timeout=)
+                # wakes the instant _process_responses enqueues the packet.
+                # The 50 ms chunks are only so a dead transport still cancels
+                # an in-flight send promptly (bloodflow-app#130); on the happy
+                # path they add no latency. The old poll loop paid a fixed
+                # ~2.5 ms of sleep per command — the dominant cost of bulk
+                # command streams like the NVCM burn (#233).
                 start_time = time.monotonic()
-                while time.monotonic() - start_time < timeout:
+                while True:
                     if self._transport_down_evt.is_set():
                         raise ConnectionError(
                             f"{self.desc}: transport down, packet id "
                             f"0x{id:04X} not deliverable"
                         )
-                    if self.response_queue.empty():
-                        time.sleep(0.0005)
-                    else:
-                        time.sleep(0.001)
-                        pkt = self.response_queue.get()
-                        if pkt.id != id:
-                            logger.warning(
-                                "%s: discarding stale response id=0x%04X (expected 0x%04X)",
-                                self.desc, pkt.id, id,
-                            )
-                            continue
-                        return pkt
-                raise TimeoutError(f"No response in async mode, packet id 0x{id:04X}")
+                    remaining = timeout - (time.monotonic() - start_time)
+                    if remaining <= 0:
+                        raise TimeoutError(
+                            f"No response in async mode, packet id 0x{id:04X}"
+                        )
+                    try:
+                        pkt = self.response_queue.get(timeout=min(0.05, remaining))
+                    except queue.Empty:
+                        continue
+                    if pkt.id != id:
+                        logger.warning(
+                            "%s: discarding stale response id=0x%04X (expected 0x%04X)",
+                            self.desc, pkt.id, id,
+                        )
+                        continue
+                    return pkt
 
     def clear_buffer(self):
         with self._buffer_lock:
@@ -324,7 +333,8 @@ class CommInterface(USBInterfaceBase):
                         self._read_buffer.extend(data_bytes)
                         self._buffer_condition.notify()
                     logger.debug(f"Read {len(data)} bytes.")
-                time.sleep(0.001)
+                # No pacing sleep: dev.read blocks (timeout=100 ms) when the
+                # endpoint is idle, so looping straight back cannot busy-spin.
             except usb.core.USBError as e:
                 # During an intentional shutdown the read loop will see USB
                 # errors as the transport is closed; suppress them silently.


### PR DESCRIPTION
Refs #233

## What

`send_packet`'s async path paid ~2.5 ms of hardcoded `time.sleep` per command — more than 25× the actual USB+firmware round-trip time. This PR:

- drops the 0.5 ms sleep after every bulk write (send/response are strictly sequential; it protected nothing),
- replaces the response-queue sleep-poll loop (0.5 ms quanta + a flat 1 ms sleep *after* the response had arrived) with a blocking `Queue.get(timeout=...)` in 50 ms chunks,
- drops the 1 ms pacing sleep in `_read_loop` (`dev.read` already blocks with a 100 ms timeout — no busy-spin without it).

Preserved semantics: transport-down cancellation within ≤50 ms (bloodflow-app#130 guarantee — was ~0.5 ms, test allows 1 s), stale-id discard with the same warning, same TimeoutError/ConnectionError contract, overall caller timeout.

## Numbers

| Measurement | Before | After |
|---|---|---|
| Host-side overhead per command (mock dev, n=2000) | 2.549 ms mean | **0.018 ms** mean |
| Hardware round-trip (left bench sensor, n=300 ping + 300 creset read) | 2.65 ms mean | not yet re-measured (bench access paused) |

The dominant beneficiary is the NVCM burn: 83,833 round-trips ≈ 3 min 9 s per camera measured 2026-06-10, of which ~13 s is device-mandated wait. If hardware tracks the mock delta, expect roughly 30–60 s per camera with full readback verification retained. Every other SDK command path (telemetry polls, register R/W, firmware update chunks) gets the same per-command reduction.

## Testing

- `tests/test_comm_transport_down.py`, `tests/test_comm_clear_halt.py`, `tests/test_comm_paths.py`, `tests/test_errors.py` — 23 passed, 7 skipped (right sensor absent).
- flake8 clean on the diff (the F841 on `last_error` is pre-existing on `next` — sync-mode timeout silently returns None; tracked separately).
- Hardware before/after benchmark of an actual burn is deferred until bench time is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)